### PR TITLE
Release readiness: debug, retry, dry-run, token expiry, WS warnings

### DIFF
--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -42,6 +42,10 @@ Examples:
 			return err
 		}
 
+		if isDryRun(cmd, "Would deploy %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
+			return nil
+		}
+
 		resp, err := c.BulkDeploy(ids)
 		if err != nil {
 			return err
@@ -73,6 +77,10 @@ Examples:
 		ids, err := resolveBulkIDs(c, cmd, args)
 		if err != nil {
 			return err
+		}
+
+		if isDryRun(cmd, "Would stop %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
+			return nil
 		}
 
 		resp, err := c.BulkStop(ids)
@@ -108,6 +116,10 @@ Examples:
 		ids, err := resolveBulkIDs(c, cmd, args)
 		if err != nil {
 			return err
+		}
+
+		if isDryRun(cmd, "Would clean %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
+			return nil
 		}
 
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will clean %d stack instances. Continue? (y/n): ", len(ids)))
@@ -154,6 +166,10 @@ Examples:
 			return err
 		}
 
+		if isDryRun(cmd, "Would delete %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
+			return nil
+		}
+
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will permanently delete %d stack instances. Continue? (y/n): ", len(ids)))
 		if err != nil {
 			return err
@@ -174,14 +190,18 @@ Examples:
 
 func init() {
 	bulkDeployCmd.Flags().String("ids", "", flagDescIDs)
+	bulkDeployCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	bulkStopCmd.Flags().String("ids", "", flagDescIDs)
+	bulkStopCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	bulkCleanCmd.Flags().String("ids", "", flagDescIDs)
 	bulkCleanCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	bulkCleanCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	bulkDeleteCmd.Flags().String("ids", "", flagDescIDs)
 	bulkDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	bulkDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	bulkCmd.AddCommand(bulkDeployCmd)
 	bulkCmd.AddCommand(bulkStopCmd)

--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -32,6 +32,10 @@ Examples:
   stackctl bulk deploy --ids 1,2,3 -o json`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if raw := rawBulkArgs(cmd, args); isDryRun(cmd, "Would deploy %d stacks: %s", len(raw), strings.Join(raw, ", ")) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -40,10 +44,6 @@ Examples:
 		ids, err := resolveBulkIDs(c, cmd, args)
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would deploy %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
-			return nil
 		}
 
 		resp, err := c.BulkDeploy(ids)
@@ -69,6 +69,10 @@ Examples:
   stackctl bulk stop --ids 1,2,3 -o json`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if raw := rawBulkArgs(cmd, args); isDryRun(cmd, "Would stop %d stacks: %s", len(raw), strings.Join(raw, ", ")) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -77,10 +81,6 @@ Examples:
 		ids, err := resolveBulkIDs(c, cmd, args)
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would stop %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
-			return nil
 		}
 
 		resp, err := c.BulkStop(ids)
@@ -108,6 +108,10 @@ Examples:
   stackctl bulk clean --ids 1,2,3 --yes`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if raw := rawBulkArgs(cmd, args); isDryRun(cmd, "Would clean %d stacks: %s", len(raw), strings.Join(raw, ", ")) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -116,10 +120,6 @@ Examples:
 		ids, err := resolveBulkIDs(c, cmd, args)
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would clean %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
-			return nil
 		}
 
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will clean %d stack instances. Continue? (y/n): ", len(ids)))
@@ -156,6 +156,10 @@ Examples:
   stackctl bulk delete --ids 1,2,3 --yes`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if raw := rawBulkArgs(cmd, args); isDryRun(cmd, "Would delete %d stacks: %s", len(raw), strings.Join(raw, ", ")) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -164,10 +168,6 @@ Examples:
 		ids, err := resolveBulkIDs(c, cmd, args)
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would delete %d stacks: %s", len(ids), strings.Join(ids, ", ")) {
-			return nil
 		}
 
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will permanently delete %d stack instances. Continue? (y/n): ", len(ids)))
@@ -208,6 +208,22 @@ func init() {
 	bulkCmd.AddCommand(bulkCleanCmd)
 	bulkCmd.AddCommand(bulkDeleteCmd)
 	rootCmd.AddCommand(bulkCmd)
+}
+
+func rawBulkArgs(cmd *cobra.Command, args []string) []string {
+	var parts []string
+	if idsStr, _ := cmd.Flags().GetString("ids"); idsStr != "" {
+		parts = append(parts, strings.Split(idsStr, ",")...)
+	}
+	parts = append(parts, args...)
+	var out []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func resolveBulkIDs(c *client.Client, cmd *cobra.Command, args []string) ([]string, error) {

--- a/cli/cmd/bulk_test.go
+++ b/cli/cmd/bulk_test.go
@@ -769,3 +769,46 @@ func TestBulkDeployCmd_Forbidden(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Permission denied")
 }
+
+// ---- Dry-run Tests ----
+
+func TestBulkDeleteCmd_DryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should NOT be called in dry-run mode")
+	}))
+	defer server.Close()
+
+	buf := setupBulkTestCmd(t, server.URL)
+
+	bulkDeleteCmd.Flags().Set("ids", "10,20,30")
+	bulkDeleteCmd.Flags().Set("dry-run", "true")
+	t.Cleanup(func() {
+		bulkDeleteCmd.Flags().Set("ids", "")
+		bulkDeleteCmd.Flags().Set("dry-run", "false")
+	})
+
+	err := bulkDeleteCmd.RunE(bulkDeleteCmd, []string{})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Would delete 3 stacks")
+	assert.Contains(t, buf.String(), "10, 20, 30")
+}
+
+func TestBulkCleanCmd_DryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should NOT be called in dry-run mode")
+	}))
+	defer server.Close()
+
+	buf := setupBulkTestCmd(t, server.URL)
+
+	bulkCleanCmd.Flags().Set("ids", "5,6")
+	bulkCleanCmd.Flags().Set("dry-run", "true")
+	t.Cleanup(func() {
+		bulkCleanCmd.Flags().Set("ids", "")
+		bulkCleanCmd.Flags().Set("dry-run", "false")
+	})
+
+	err := bulkCleanCmd.RunE(bulkCleanCmd, []string{})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Would clean 2 stacks")
+}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -358,6 +358,10 @@ Examples:
 			return err
 		}
 
+		if isDryRun(cmd, "Would delete shared values %s from cluster %s", svID, clusterID) {
+			return nil
+		}
+
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will delete shared values %s from cluster %s. Continue? (y/n): ", svID, clusterID))
 		if err != nil {
 			return err
@@ -396,6 +400,7 @@ func init() {
 
 	// shared-values delete flags
 	clusterSharedValuesDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	clusterSharedValuesDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	// Wire up shared-values subcommands
 	clusterSharedValuesCmd.AddCommand(clusterSharedValuesListCmd)

--- a/cli/cmd/definition.go
+++ b/cli/cmd/definition.go
@@ -538,6 +538,7 @@ func init() {
 
 	// definition delete flags
 	definitionDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	definitionDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	// definition export flags
 	definitionExportCmd.Flags().String("output-file", "", "Write export to file instead of stdout")

--- a/cli/cmd/definition.go
+++ b/cli/cmd/definition.go
@@ -429,7 +429,6 @@ Examples:
 
 		req := types.UpdateChartConfigRequest{
 			ChartName:     current.ChartName,
-			ChartPath:     current.RepoURL,
 			ChartVersion:  current.ChartVersion,
 			SourceRepoURL: current.SourceRepoURL,
 			DefaultValues: current.DefaultValues,

--- a/cli/cmd/definition.go
+++ b/cli/cmd/definition.go
@@ -385,6 +385,7 @@ Examples:
   stackctl definition update-chart 1 5 --chart-version 0.3.0
   stackctl definition update-chart 1 5 --chart-path /charts/kvk-core
   stackctl definition update-chart 1 5 --deploy-order 6
+  stackctl definition update-chart 1 5 --source-repo-url https://dev.azure.com/org/project/_git/repo
   stackctl definition update-chart 1 5 --file values.yaml`,
 	Args:         cobra.ExactArgs(2),
 	SilenceUsage: true,
@@ -400,11 +401,12 @@ Examples:
 
 		chartPath, _ := cmd.Flags().GetString("chart-path")
 		chartVersion, _ := cmd.Flags().GetString("chart-version")
+		sourceRepoURL, _ := cmd.Flags().GetString("source-repo-url")
 		deployOrder, _ := cmd.Flags().GetInt("deploy-order")
 		valuesFile, _ := cmd.Flags().GetString("file")
 
-		if chartPath == "" && chartVersion == "" && deployOrder < 0 && valuesFile == "" {
-			return fmt.Errorf("at least one of --chart-path, --chart-version, --deploy-order, or --file must be specified")
+		if chartPath == "" && chartVersion == "" && sourceRepoURL == "" && deployOrder < 0 && valuesFile == "" {
+			return fmt.Errorf("at least one of --chart-path, --chart-version, --source-repo-url, --deploy-order, or --file must be specified")
 		}
 
 		if valuesFile != "" {
@@ -429,6 +431,7 @@ Examples:
 			ChartName:     current.ChartName,
 			ChartPath:     current.RepoURL,
 			ChartVersion:  current.ChartVersion,
+			SourceRepoURL: current.SourceRepoURL,
 			DefaultValues: current.DefaultValues,
 		}
 
@@ -437,6 +440,9 @@ Examples:
 		}
 		if chartVersion != "" {
 			req.ChartVersion = chartVersion
+		}
+		if sourceRepoURL != "" {
+			req.SourceRepoURL = sourceRepoURL
 		}
 		if deployOrder >= 0 {
 			req.DeployOrder = &deployOrder
@@ -533,6 +539,7 @@ func init() {
 	// definition update-chart flags
 	definitionUpdateChartCmd.Flags().String("chart-path", "", "Chart path (e.g. /charts/kvk-core)")
 	definitionUpdateChartCmd.Flags().String("chart-version", "", "Chart version")
+	definitionUpdateChartCmd.Flags().String("source-repo-url", "", "Git repository URL for branch listing")
 	definitionUpdateChartCmd.Flags().Int("deploy-order", -1, "Deploy order (0+)")
 	definitionUpdateChartCmd.Flags().String("file", "", "File containing default values")
 

--- a/cli/cmd/orphaned.go
+++ b/cli/cmd/orphaned.go
@@ -80,6 +80,10 @@ Examples:
 			return fmt.Errorf("namespace must not be empty")
 		}
 
+		if isDryRun(cmd, "Would delete orphaned namespace %q", namespace) {
+			return nil
+		}
+
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will delete orphaned namespace %q. Continue? (y/n): ", namespace))
 		if err != nil {
 			return err
@@ -110,6 +114,7 @@ Examples:
 
 func init() {
 	orphanedDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	orphanedDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	orphanedCmd.AddCommand(orphanedListCmd)
 	orphanedCmd.AddCommand(orphanedDeleteCmd)

--- a/cli/cmd/override.go
+++ b/cli/cmd/override.go
@@ -476,6 +476,10 @@ Examples:
 			return err
 		}
 
+		if isDryRun(cmd, "Would delete quota override for instance %s", instanceID) {
+			return nil
+		}
+
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will delete the quota override for instance %s. Continue? (y/n): ", instanceID))
 		if err != nil {
 			return err
@@ -513,6 +517,10 @@ func deleteChartOverride(cmd *cobra.Command, args []string, kind string, deleteF
 	instanceID, err := resolveStackID(c, args[0])
 	if err != nil {
 		return err
+	}
+
+	if isDryRun(cmd, "Would delete %s override for chart %s on instance %s", kind, chartID, instanceID) {
+		return nil
 	}
 
 	confirmed, err := confirmAction(cmd, fmt.Sprintf("This will delete the %s override for chart %s on instance %s. Continue? (y/n): ", kind, chartID, instanceID))
@@ -586,9 +594,11 @@ func init() {
 
 	// override delete flags
 	overrideDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	overrideDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	// branch delete flags
 	overrideBranchDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	overrideBranchDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	// quota set flags
 	overrideQuotaSetCmd.Flags().String("cpu-request", "", "CPU request (e.g. 100m)")
@@ -598,6 +608,7 @@ func init() {
 
 	// quota delete flags
 	overrideQuotaDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	overrideQuotaDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	// Wire up branch subcommands
 	overrideBranchCmd.AddCommand(overrideBranchListCmd)

--- a/cli/cmd/override.go
+++ b/cli/cmd/override.go
@@ -466,6 +466,10 @@ Examples:
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if isDryRun(cmd, "Would delete quota override for instance %s", args[0]) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -474,10 +478,6 @@ Examples:
 		instanceID, err := resolveStackID(c, args[0])
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would delete quota override for instance %s", instanceID) {
-			return nil
 		}
 
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will delete the quota override for instance %s. Continue? (y/n): ", instanceID))
@@ -504,6 +504,10 @@ Examples:
 }
 
 func deleteChartOverride(cmd *cobra.Command, args []string, kind string, deleteFn func(*client.Client, string, string) error) error {
+	if isDryRun(cmd, "Would delete %s override for chart %s on instance %s", kind, args[1], args[0]) {
+		return nil
+	}
+
 	chartID, err := parseID(args[1])
 	if err != nil {
 		return err
@@ -517,10 +521,6 @@ func deleteChartOverride(cmd *cobra.Command, args []string, kind string, deleteF
 	instanceID, err := resolveStackID(c, args[0])
 	if err != nil {
 		return err
-	}
-
-	if isDryRun(cmd, "Would delete %s override for chart %s on instance %s", kind, chartID, instanceID) {
-		return nil
 	}
 
 	confirmed, err := confirmAction(cmd, fmt.Sprintf("This will delete the %s override for chart %s on instance %s. Continue? (y/n): ", kind, chartID, instanceID))

--- a/cli/cmd/plugins.go
+++ b/cli/cmd/plugins.go
@@ -142,6 +142,11 @@ func pluginEnv(cmd *cobra.Command) []string {
 			env = setEnv(env, "STACKCTL_OUTPUT", strings.ToLower(strings.TrimSpace(output)))
 		}
 	}
+	if flags.Changed("debug") {
+		if debug, err := flags.GetBool("debug"); err == nil {
+			env = setEnv(env, "STACKCTL_DEBUG", boolEnvValue(debug))
+		}
+	}
 	return env
 }
 

--- a/cli/cmd/plugins_test.go
+++ b/cli/cmd/plugins_test.go
@@ -224,3 +224,41 @@ func TestRegisterPlugins_RunViaCobraRouting(t *testing.T) {
 	assert.Contains(t, string(contents), "--hello=world")
 	assert.Contains(t, string(contents), "posarg")
 }
+
+// ---------- pluginEnv ----------
+
+func TestPluginEnv_PassesDebugFlag(t *testing.T) {
+	t.Parallel()
+	root := &cobra.Command{Use: "stackctl"}
+	root.PersistentFlags().Bool("debug", false, "")
+	require.NoError(t, root.PersistentFlags().Set("debug", "true"))
+
+	env := pluginEnv(root)
+	found := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "STACKCTL_DEBUG=") {
+			assert.Equal(t, "STACKCTL_DEBUG=1", kv)
+			found = true
+		}
+	}
+	assert.True(t, found, "STACKCTL_DEBUG should be set when --debug flag is changed")
+}
+
+func TestPluginEnv_OmitsDebugWhenNotChanged(t *testing.T) {
+	t.Parallel()
+	root := &cobra.Command{Use: "stackctl"}
+	root.PersistentFlags().Bool("debug", false, "")
+
+	env := pluginEnv(root)
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "STACKCTL_DEBUG=") {
+			t.Fatal("STACKCTL_DEBUG should not be set when --debug flag is not changed")
+		}
+	}
+}
+
+func TestPluginEnv_NilCommand(t *testing.T) {
+	t.Parallel()
+	env := pluginEnv(nil)
+	assert.NotEmpty(t, env)
+}

--- a/cli/cmd/plugins_test.go
+++ b/cli/cmd/plugins_test.go
@@ -228,7 +228,7 @@ func TestRegisterPlugins_RunViaCobraRouting(t *testing.T) {
 // ---------- pluginEnv ----------
 
 func TestPluginEnv_PassesDebugFlag(t *testing.T) {
-	t.Parallel()
+
 	root := &cobra.Command{Use: "stackctl"}
 	root.PersistentFlags().Bool("debug", false, "")
 	require.NoError(t, root.PersistentFlags().Set("debug", "true"))
@@ -245,7 +245,7 @@ func TestPluginEnv_PassesDebugFlag(t *testing.T) {
 }
 
 func TestPluginEnv_OmitsDebugWhenNotChanged(t *testing.T) {
-	t.Parallel()
+
 	root := &cobra.Command{Use: "stackctl"}
 	root.PersistentFlags().Bool("debug", false, "")
 
@@ -258,7 +258,7 @@ func TestPluginEnv_OmitsDebugWhenNotChanged(t *testing.T) {
 }
 
 func TestPluginEnv_NilCommand(t *testing.T) {
-	t.Parallel()
+
 	env := pluginEnv(nil)
 	assert.NotEmpty(t, env)
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -23,6 +23,7 @@ var (
 	flagAPIURL   string
 	flagAPIKey   string
 	flagInsecure bool
+	flagDebug    bool
 
 	// Loaded at runtime
 	cfg     *config.Config
@@ -82,6 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "API server URL (overrides config)")
 	rootCmd.PersistentFlags().StringVar(&flagAPIKey, "api-key", "", "API key (overrides config)")
 	rootCmd.PersistentFlags().BoolVar(&flagInsecure, "insecure", false, "Skip TLS certificate verification (use with caution)")
+	rootCmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "Log HTTP requests and responses to stderr")
 }
 
 // Execute runs the root command.
@@ -103,6 +105,12 @@ func newClient() (*client.Client, error) {
 
 	c := client.New(apiURL)
 
+	// Debug: flag > env
+	if flagDebug || os.Getenv("STACKCTL_DEBUG") == "1" {
+		c.Debug = true
+		c.DebugWriter = os.Stderr
+	}
+
 	// API key: flag > env > config
 	apiKey := flagAPIKey
 	if apiKey == "" {
@@ -117,11 +125,14 @@ func newClient() (*client.Client, error) {
 
 	// JWT token from stored token file (only if no API key)
 	if c.APIKey == "" {
-		token, err := loadToken()
+		token, warning, err := loadToken()
 		if err != nil && !flagQuiet {
 			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
 		}
 		c.Token = token
+		if warning != "" && !flagQuiet {
+			fmt.Fprintln(os.Stderr, warning)
+		}
 	}
 
 	return c, nil
@@ -215,6 +226,10 @@ func deleteByID(cmd *cobra.Command, args []string, promptFmt string, resolveFn f
 		return err
 	}
 
+	if isDryRun(cmd, "Would delete %s", id) {
+		return nil
+	}
+
 	confirmed, err := confirmAction(cmd, fmt.Sprintf(promptFmt, id))
 	if err != nil {
 		return err
@@ -235,6 +250,15 @@ func deleteByID(cmd *cobra.Command, args []string, promptFmt string, resolveFn f
 
 	printer.PrintMessage(successFmt, id)
 	return nil
+}
+
+func isDryRun(cmd *cobra.Command, format string, args ...interface{}) bool {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if dryRun {
+		printer.PrintMessage(format, args...)
+		return true
+	}
+	return false
 }
 
 func passthroughID(_ *client.Client, id string) (string, error) {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -105,9 +105,13 @@ func newClient() (*client.Client, error) {
 
 	c := client.New(apiURL)
 
-	// Debug: flag > env
-	if flagDebug || os.Getenv("STACKCTL_DEBUG") == "1" {
+	// Debug: explicit flag overrides env var
+	if rootCmd.PersistentFlags().Changed("debug") {
+		c.Debug = flagDebug
+	} else if os.Getenv("STACKCTL_DEBUG") == "1" {
 		c.Debug = true
+	}
+	if c.Debug {
 		c.DebugWriter = os.Stderr
 	}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -216,6 +216,10 @@ func confirmAction(cmd *cobra.Command, message string) (bool, error) {
 }
 
 func deleteByID(cmd *cobra.Command, args []string, promptFmt string, resolveFn func(*client.Client, string) (string, error), deleteFn func(*client.Client, string) error, successFmt string) error {
+	if isDryRun(cmd, "Would delete %s", args[0]) {
+		return nil
+	}
+
 	c, err := newClient()
 	if err != nil {
 		return err
@@ -224,10 +228,6 @@ func deleteByID(cmd *cobra.Command, args []string, promptFmt string, resolveFn f
 	id, err := resolveFn(c, args[0])
 	if err != nil {
 		return err
-	}
-
-	if isDryRun(cmd, "Would delete %s", id) {
-		return nil
 	}
 
 	confirmed, err := confirmAction(cmd, fmt.Sprintf(promptFmt, id))

--- a/cli/cmd/stack.go
+++ b/cli/cmd/stack.go
@@ -22,7 +22,7 @@ func followLogs(c *client.Client, instanceID string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	result, err := c.StreamDeploymentLogs(ctx, instanceID, os.Stdout)
+	result, err := c.StreamDeploymentLogs(ctx, instanceID, os.Stdout, os.Stderr)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil
@@ -252,6 +252,10 @@ Examples:
 			return err
 		}
 
+		if isDryRun(cmd, "Would deploy stack %s", id) {
+			return nil
+		}
+
 		resp, err := c.DeployStack(id)
 		if err != nil {
 			return err
@@ -293,6 +297,10 @@ Examples:
 		id, err := resolveStackID(c, args[0])
 		if err != nil {
 			return err
+		}
+
+		if isDryRun(cmd, "Would stop stack %s", id) {
+			return nil
 		}
 
 		resp, err := c.StopStack(id)
@@ -338,6 +346,10 @@ Examples:
 		id, err := resolveStackID(c, args[0])
 		if err != nil {
 			return err
+		}
+
+		if isDryRun(cmd, "Would clean stack %s (undeploy + remove namespace)", id) {
+			return nil
 		}
 
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will undeploy and remove the namespace for stack %s. Continue? (y/n): ", id))
@@ -800,6 +812,10 @@ Examples:
 			return err
 		}
 
+		if isDryRun(cmd, "Would rollback stack %s", id) {
+			return nil
+		}
+
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will rollback stack %s. Continue? (y/n): ", id))
 		if err != nil {
 			return err
@@ -905,6 +921,13 @@ func init() {
 	stackCleanCmd.Flags().BoolP("follow", "f", false, "Stream logs until completion")
 	stackLogsCmd.Flags().BoolP("follow", "f", false, "Stream logs from active deployment")
 	stackRollbackCmd.Flags().BoolP("follow", "f", false, "Stream logs until completion")
+
+	// --dry-run flags
+	stackDeployCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+	stackStopCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+	stackCleanCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+	stackDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+	stackRollbackCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	// stack clean flags
 	stackCleanCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")

--- a/cli/cmd/stack.go
+++ b/cli/cmd/stack.go
@@ -242,6 +242,10 @@ Examples:
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if isDryRun(cmd, "Would deploy stack %s", args[0]) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -250,10 +254,6 @@ Examples:
 		id, err := resolveStackID(c, args[0])
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would deploy stack %s", id) {
-			return nil
 		}
 
 		resp, err := c.DeployStack(id)
@@ -289,6 +289,10 @@ Examples:
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if isDryRun(cmd, "Would stop stack %s", args[0]) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -297,10 +301,6 @@ Examples:
 		id, err := resolveStackID(c, args[0])
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would stop stack %s", id) {
-			return nil
 		}
 
 		resp, err := c.StopStack(id)
@@ -338,6 +338,10 @@ Examples:
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if isDryRun(cmd, "Would clean stack %s (undeploy + remove namespace)", args[0]) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -346,10 +350,6 @@ Examples:
 		id, err := resolveStackID(c, args[0])
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would clean stack %s (undeploy + remove namespace)", id) {
-			return nil
 		}
 
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will undeploy and remove the namespace for stack %s. Continue? (y/n): ", id))
@@ -802,6 +802,10 @@ Examples:
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if isDryRun(cmd, "Would rollback stack %s", args[0]) {
+			return nil
+		}
+
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -810,10 +814,6 @@ Examples:
 		id, err := resolveStackID(c, args[0])
 		if err != nil {
 			return err
-		}
-
-		if isDryRun(cmd, "Would rollback stack %s", id) {
-			return nil
 		}
 
 		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will rollback stack %s. Continue? (y/n): ", id))

--- a/cli/cmd/stack_test.go
+++ b/cli/cmd/stack_test.go
@@ -1807,3 +1807,41 @@ func TestStackHistoryValuesCmd_QuietOutput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "300\n", buf.String())
 }
+
+// ---- Dry-run Tests ----
+
+func TestStackDeleteCmd_DryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should NOT be called in dry-run mode")
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	stackDeleteCmd.Flags().Set("dry-run", "true")
+	t.Cleanup(func() {
+		stackDeleteCmd.Flags().Set("dry-run", "false")
+	})
+
+	err := stackDeleteCmd.RunE(stackDeleteCmd, []string{"42"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Would delete 42")
+}
+
+func TestStackDeployCmd_DryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should NOT be called in dry-run mode")
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	stackDeployCmd.Flags().Set("dry-run", "true")
+	t.Cleanup(func() {
+		stackDeployCmd.Flags().Set("dry-run", "false")
+	})
+
+	err := stackDeployCmd.RunE(stackDeployCmd, []string{"42"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Would deploy")
+}

--- a/cli/cmd/template.go
+++ b/cli/cmd/template.go
@@ -273,6 +273,7 @@ func init() {
 
 	// template delete flags
 	templateDeleteCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	templateDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
 	// Wire up subcommands
 	templateCmd.AddCommand(templateListCmd)

--- a/cli/cmd/token.go
+++ b/cli/cmd/token.go
@@ -60,36 +60,47 @@ func saveToken(token, username string, expiresAt time.Time) error {
 }
 
 // loadToken reads the JWT token for the current context.
-// Returns empty string and nil error if no token exists.
-// Returns an error if the token is expired or the file cannot be read.
-func loadToken() (string, error) {
+// Returns the token, an optional expiry warning, and any error.
+// Returns empty strings and nil error if no token exists.
+func loadToken() (token string, warning string, err error) {
 	if cfg.CurrentContext == "" {
-		return "", nil
+		return "", "", nil
 	}
 
 	path, err := config.TokenPath(cfg.CurrentContext)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", nil
+			return "", "", nil
 		}
-		return "", fmt.Errorf("reading token file: %w", err)
+		return "", "", fmt.Errorf("reading token file: %w", err)
 	}
 
 	var t storedToken
 	if err := json.Unmarshal(data, &t); err != nil {
-		return "", fmt.Errorf("parsing token file: %w", err)
+		return "", "", fmt.Errorf("parsing token file: %w", err)
 	}
 
-	if !t.ExpiresAt.IsZero() && time.Now().After(t.ExpiresAt) {
-		return "", fmt.Errorf("token expired. Run 'stackctl login' to re-authenticate")
+	if !t.ExpiresAt.IsZero() {
+		if time.Now().After(t.ExpiresAt) {
+			return "", "", fmt.Errorf("token expired. Run 'stackctl login' to re-authenticate")
+		}
+		remaining := time.Until(t.ExpiresAt)
+		if remaining < 5*time.Minute {
+			mins := int(remaining.Minutes()) + 1
+			unit := "minutes"
+			if mins == 1 {
+				unit = "minute"
+			}
+			warning = fmt.Sprintf("Warning: token expires in %d %s. Run 'stackctl login' to refresh.", mins, unit)
+		}
 	}
 
-	return t.Token, nil
+	return t.Token, warning, nil
 }
 
 // deleteToken removes the token file for the current context.

--- a/cli/cmd/token.go
+++ b/cli/cmd/token.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -91,7 +92,10 @@ func loadToken() (token string, warning string, err error) {
 			return "", "", fmt.Errorf("token expired. Run 'stackctl login' to re-authenticate")
 		}
 		if remaining < 5*time.Minute {
-			mins := int(remaining.Minutes()) + 1
+			mins := int(math.Ceil(remaining.Minutes()))
+			if mins < 1 {
+				mins = 1
+			}
 			unit := "minutes"
 			if mins == 1 {
 				unit = "minute"

--- a/cli/cmd/token.go
+++ b/cli/cmd/token.go
@@ -86,10 +86,10 @@ func loadToken() (token string, warning string, err error) {
 	}
 
 	if !t.ExpiresAt.IsZero() {
-		if time.Now().After(t.ExpiresAt) {
+		remaining := time.Until(t.ExpiresAt)
+		if remaining <= 0 {
 			return "", "", fmt.Errorf("token expired. Run 'stackctl login' to re-authenticate")
 		}
-		remaining := time.Until(t.ExpiresAt)
 		if remaining < 5*time.Minute {
 			mins := int(remaining.Minutes()) + 1
 			unit := "minutes"

--- a/cli/cmd/token_test.go
+++ b/cli/cmd/token_test.go
@@ -64,9 +64,10 @@ func TestLoadToken_Valid(t *testing.T) {
 	data, _ := json.Marshal(stored)
 	require.NoError(t, os.WriteFile(filepath.Join(tokenDir, "test.json"), data, 0600))
 
-	token, err := loadToken()
+	token, warning, err := loadToken()
 	require.NoError(t, err)
 	assert.Equal(t, "valid-jwt", token)
+	assert.Empty(t, warning)
 }
 
 func TestLoadToken_Expired(t *testing.T) {
@@ -84,7 +85,7 @@ func TestLoadToken_Expired(t *testing.T) {
 	data, _ := json.Marshal(stored)
 	require.NoError(t, os.WriteFile(filepath.Join(tokenDir, "test.json"), data, 0600))
 
-	_, err := loadToken()
+	_, _, err := loadToken()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "token expired")
 }
@@ -95,7 +96,7 @@ func TestLoadToken_NoFile(t *testing.T) {
 
 	cfg = &config.Config{CurrentContext: "test", Contexts: map[string]*config.Context{"test": {}}}
 
-	token, err := loadToken()
+	token, _, err := loadToken()
 	require.NoError(t, err)
 	assert.Empty(t, token)
 }
@@ -103,7 +104,7 @@ func TestLoadToken_NoFile(t *testing.T) {
 func TestLoadToken_NoCurrentContext(t *testing.T) {
 	cfg = &config.Config{Contexts: map[string]*config.Context{}}
 
-	token, err := loadToken()
+	token, _, err := loadToken()
 	require.NoError(t, err)
 	assert.Empty(t, token)
 }
@@ -118,7 +119,7 @@ func TestLoadToken_InvalidJSON(t *testing.T) {
 	require.NoError(t, os.MkdirAll(tokenDir, 0700))
 	require.NoError(t, os.WriteFile(filepath.Join(tokenDir, "test.json"), []byte("not json"), 0600))
 
-	_, err := loadToken()
+	_, _, err := loadToken()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing token file")
 }
@@ -138,9 +139,10 @@ func TestLoadToken_ZeroExpiry(t *testing.T) {
 	data, _ := json.Marshal(stored)
 	require.NoError(t, os.WriteFile(filepath.Join(tokenDir, "test.json"), data, 0600))
 
-	token, err := loadToken()
+	token, warning, err := loadToken()
 	require.NoError(t, err)
 	assert.Equal(t, "no-expiry-jwt", token)
+	assert.Empty(t, warning)
 }
 
 func TestDeleteToken(t *testing.T) {
@@ -180,6 +182,49 @@ func TestDeleteToken_NoCurrentContext(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestLoadToken_NearExpiryWarning(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STACKCTL_CONFIG_DIR", dir)
+
+	cfg = &config.Config{CurrentContext: "test", Contexts: map[string]*config.Context{"test": {}}}
+
+	tokenDir := filepath.Join(dir, "tokens")
+	require.NoError(t, os.MkdirAll(tokenDir, 0700))
+	stored := storedToken{
+		Token:     "expiring-soon-jwt",
+		ExpiresAt: time.Now().Add(3 * time.Minute),
+	}
+	data, _ := json.Marshal(stored)
+	require.NoError(t, os.WriteFile(filepath.Join(tokenDir, "test.json"), data, 0600))
+
+	token, warning, err := loadToken()
+	require.NoError(t, err)
+	assert.Equal(t, "expiring-soon-jwt", token)
+	assert.Contains(t, warning, "Warning: token expires in")
+	assert.Contains(t, warning, "stackctl login")
+}
+
+func TestLoadToken_NoWarningWhenFarFromExpiry(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STACKCTL_CONFIG_DIR", dir)
+
+	cfg = &config.Config{CurrentContext: "test", Contexts: map[string]*config.Context{"test": {}}}
+
+	tokenDir := filepath.Join(dir, "tokens")
+	require.NoError(t, os.MkdirAll(tokenDir, 0700))
+	stored := storedToken{
+		Token:     "valid-jwt",
+		ExpiresAt: time.Now().Add(2 * time.Hour),
+	}
+	data, _ := json.Marshal(stored)
+	require.NoError(t, os.WriteFile(filepath.Join(tokenDir, "test.json"), data, 0600))
+
+	token, warning, err := loadToken()
+	require.NoError(t, err)
+	assert.Equal(t, "valid-jwt", token)
+	assert.Empty(t, warning)
+}
+
 func TestSaveAndLoadToken_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("STACKCTL_CONFIG_DIR", dir)
@@ -189,7 +234,7 @@ func TestSaveAndLoadToken_RoundTrip(t *testing.T) {
 	expires := time.Now().Add(2 * time.Hour)
 	require.NoError(t, saveToken("my-jwt-token", "testuser", expires))
 
-	token, err := loadToken()
+	token, _, err := loadToken()
 	require.NoError(t, err)
 	assert.Equal(t, "my-jwt-token", token)
 }

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,8 +1,9 @@
 module github.com/omattsson/stackctl/cli
 
-go 1.26.2
+go 1.26.3
 
 require (
+	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,10 +32,13 @@ const (
 // TLS configuration (insecure mode) is handled by the caller setting
 // HTTPClient.Transport before making requests.
 type Client struct {
-	BaseURL    string
-	Token      string
-	APIKey     string
-	HTTPClient *http.Client
+	BaseURL      string
+	Token        string
+	APIKey       string
+	HTTPClient   *http.Client
+	Debug        bool
+	DebugWriter  io.Writer
+	RetryBackoff []time.Duration
 }
 
 // New creates a new API client.
@@ -51,6 +55,7 @@ func New(baseURL string) *Client {
 type APIError struct {
 	StatusCode int
 	Message    string
+	retryAfter time.Duration
 }
 
 func (e *APIError) Error() string {
@@ -163,26 +168,107 @@ func (c *Client) do(method, path string, body interface{}) (*http.Response, erro
 		req.Header.Set("Authorization", "Bearer "+c.Token)
 	}
 
+	if c.Debug && c.DebugWriter != nil {
+		fmt.Fprintf(c.DebugWriter, "→ %s %s\n", method, u)
+	}
+
+	start := time.Now()
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
+		if c.Debug && c.DebugWriter != nil {
+			fmt.Fprintf(c.DebugWriter, "✗ %s (%s)\n", err, time.Since(start).Truncate(time.Millisecond))
+		}
 		return nil, fmt.Errorf("making request: %w", err)
+	}
+
+	if c.Debug && c.DebugWriter != nil {
+		fmt.Fprintf(c.DebugWriter, "← %d %s (%s)\n", resp.StatusCode, http.StatusText(resp.StatusCode), time.Since(start).Truncate(time.Millisecond))
 	}
 
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
+		apiErr := &APIError{StatusCode: resp.StatusCode}
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
+				apiErr.retryAfter = time.Duration(secs) * time.Second
+			}
+		}
 		var errResp types.ErrorResponse
 		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
-			return nil, &APIError{StatusCode: resp.StatusCode, Message: http.StatusText(resp.StatusCode)}
+			apiErr.Message = http.StatusText(resp.StatusCode)
+			return nil, apiErr
 		}
-		return nil, &APIError{StatusCode: resp.StatusCode, Message: errResp.Error}
+		apiErr.Message = errResp.Error
+		return nil, apiErr
 	}
 
 	return resp, nil
 }
 
+var retryableStatuses = map[int]bool{
+	http.StatusTooManyRequests:     true,
+	http.StatusBadGateway:          true,
+	http.StatusServiceUnavailable:  true,
+	http.StatusGatewayTimeout:      true,
+}
+
+var idempotentMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPut:    true,
+	http.MethodDelete: true,
+	http.MethodHead:   true,
+}
+
+const maxRetryAfter = 30 * time.Second
+
+var defaultRetryBackoff = []time.Duration{time.Second, 3 * time.Second}
+
+// doWithRetry wraps do with retry logic for transient failures on idempotent methods.
+func (c *Client) doWithRetry(method, path string, body interface{}) (*http.Response, error) {
+	if !idempotentMethods[method] {
+		return c.do(method, path, body)
+	}
+
+	backoff := c.RetryBackoff
+	if backoff == nil {
+		backoff = defaultRetryBackoff
+	}
+	var lastErr error
+
+	for attempt := 0; attempt <= len(backoff); attempt++ {
+		resp, err := c.do(method, path, body)
+		if err == nil {
+			return resp, nil
+		}
+
+		apiErr, ok := err.(*APIError)
+		if !ok || !retryableStatuses[apiErr.StatusCode] {
+			return nil, err
+		}
+		lastErr = err
+
+		if attempt < len(backoff) {
+			wait := backoff[attempt]
+			if apiErr.StatusCode == http.StatusTooManyRequests {
+				if ra := apiErr.retryAfter; ra > 0 {
+					if ra > maxRetryAfter {
+						ra = maxRetryAfter
+					}
+					wait = ra
+				}
+			}
+			if c.Debug && c.DebugWriter != nil {
+				fmt.Fprintf(c.DebugWriter, "↻ retrying in %s (attempt %d/%d)\n", wait, attempt+1, len(backoff))
+			}
+			time.Sleep(wait)
+		}
+	}
+	return nil, lastErr
+}
+
 // doJSON executes a request and decodes the JSON response into v.
 func (c *Client) doJSON(method, path string, body interface{}, v interface{}) error {
-	resp, err := c.do(method, path, body)
+	resp, err := c.doWithRetry(method, path, body)
 	if err != nil {
 		return err
 	}
@@ -220,7 +306,7 @@ func (c *Client) Put(path string, body interface{}, v interface{}) error {
 
 // Delete performs a DELETE request.
 func (c *Client) Delete(path string) error {
-	resp, err := c.do(http.MethodDelete, path, nil)
+	resp, err := c.doWithRetry(http.MethodDelete, path, nil)
 	if err != nil {
 		return err
 	}
@@ -535,7 +621,7 @@ func (c *Client) DeleteDefinition(id string) error {
 
 // ExportDefinition exports a stack definition as raw JSON bytes.
 func (c *Client) ExportDefinition(id string) ([]byte, error) {
-	resp, err := c.do(http.MethodGet, fmt.Sprintf("/api/v1/stack-definitions/%s/export", id), nil)
+	resp, err := c.doWithRetry(http.MethodGet, fmt.Sprintf("/api/v1/stack-definitions/%s/export", id), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	Debug        bool
 	DebugWriter  io.Writer
 	RetryBackoff []time.Duration
+	Sleeper      func(time.Duration) // injectable for tests; defaults to time.Sleep
 }
 
 // New creates a new API client.
@@ -170,6 +171,11 @@ func (c *Client) do(method, path string, body interface{}) (*http.Response, erro
 
 	if c.Debug && c.DebugWriter != nil {
 		fmt.Fprintf(c.DebugWriter, "→ %s %s\n", method, u)
+		for _, h := range []string{"Authorization", "X-API-Key", "Content-Type"} {
+			if v := req.Header.Get(h); v != "" {
+				fmt.Fprintf(c.DebugWriter, "  %s: %s\n", h, maskCredential(h, v))
+			}
+		}
 	}
 
 	start := time.Now()
@@ -260,7 +266,7 @@ func (c *Client) doWithRetry(method, path string, body interface{}) (*http.Respo
 			if c.Debug && c.DebugWriter != nil {
 				fmt.Fprintf(c.DebugWriter, "↻ retrying in %s (attempt %d/%d)\n", wait, attempt+1, len(backoff))
 			}
-			time.Sleep(wait)
+			c.sleep(wait)
 		}
 	}
 	return nil, lastErr
@@ -302,6 +308,26 @@ func (c *Client) Post(path string, body interface{}, v interface{}) error {
 // Put performs a PUT request and decodes the response.
 func (c *Client) Put(path string, body interface{}, v interface{}) error {
 	return c.doJSON(http.MethodPut, path, body, v)
+}
+
+func (c *Client) sleep(d time.Duration) {
+	if c.Sleeper != nil {
+		c.Sleeper(d)
+		return
+	}
+	time.Sleep(d)
+}
+
+func maskCredential(header, value string) string {
+	switch strings.ToLower(header) {
+	case "authorization", "x-api-key":
+		if len(value) <= 8 {
+			return "***"
+		}
+		return value[:8] + "***"
+	default:
+		return value
+	}
 }
 
 // Delete performs a DELETE request.

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -320,11 +320,16 @@ func (c *Client) sleep(d time.Duration) {
 
 func maskCredential(header, value string) string {
 	switch strings.ToLower(header) {
-	case "authorization", "x-api-key":
-		if len(value) <= 8 {
-			return "***"
+	case "authorization":
+		if i := strings.IndexByte(value, ' '); i > 0 {
+			return value[:i] + " ***"
 		}
-		return value[:8] + "***"
+		return "***"
+	case "x-api-key":
+		if len(value) > 4 {
+			return "***" + value[len(value)-4:]
+		}
+		return "***"
 	default:
 		return value
 	}

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -317,6 +317,7 @@ func (c *Client) sleep(d time.Duration) {
 }
 
 func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
 	if secs, err := strconv.Atoi(value); err == nil && secs > 0 {
 		return time.Duration(secs) * time.Second
 	}

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -195,9 +195,7 @@ func (c *Client) do(method, path string, body interface{}) (*http.Response, erro
 		defer resp.Body.Close()
 		apiErr := &APIError{StatusCode: resp.StatusCode}
 		if ra := resp.Header.Get("Retry-After"); ra != "" {
-			if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
-				apiErr.retryAfter = time.Duration(secs) * time.Second
-			}
+			apiErr.retryAfter = parseRetryAfter(ra)
 		}
 		var errResp types.ErrorResponse
 		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
@@ -316,6 +314,18 @@ func (c *Client) sleep(d time.Duration) {
 		return
 	}
 	time.Sleep(d)
+}
+
+func parseRetryAfter(value string) time.Duration {
+	if secs, err := strconv.Atoi(value); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 func maskCredential(header, value string) string {

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/omattsson/stackctl/cli/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -2406,4 +2407,177 @@ func TestGetDeployLogValues_NotFound(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
 	assert.Equal(t, "log entry not found", apiErr.Message)
+}
+
+// ---------- Debug logging ----------
+
+func TestDebug_LogsRequestAndResponse(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{})
+	}))
+	defer server.Close()
+
+	var debugBuf strings.Builder
+	c := New(server.URL)
+	c.Debug = true
+	c.DebugWriter = &debugBuf
+
+	var result map[string]string
+	err := c.Get("/test", &result)
+	require.NoError(t, err)
+
+	output := debugBuf.String()
+	assert.Contains(t, output, "→ GET")
+	assert.Contains(t, output, "/test")
+	assert.Contains(t, output, "← 200 OK")
+}
+
+func TestDebug_LogsConnectionError(t *testing.T) {
+	t.Parallel()
+	var debugBuf strings.Builder
+	c := New("http://127.0.0.1:1")
+	c.Debug = true
+	c.DebugWriter = &debugBuf
+
+	var result map[string]string
+	_ = c.Get("/test", &result)
+
+	output := debugBuf.String()
+	assert.Contains(t, output, "→ GET")
+	assert.Contains(t, output, "✗")
+}
+
+// ---------- Retry logic ----------
+
+func TestRetry_RetriesOnTransientError(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "temporarily down"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	c.RetryBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	var result map[string]string
+	err := c.Get("/test", &result)
+	require.NoError(t, err)
+	assert.Equal(t, 3, attempts)
+	assert.Equal(t, "true", result["ok"])
+}
+
+func TestRetry_NoRetryOnPost(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "down"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	c.RetryBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	var result map[string]string
+	err := c.Post("/test", nil, &result)
+	require.Error(t, err)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestRetry_NoRetryOnNonRetryableStatus(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	c.RetryBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	var result map[string]string
+	err := c.Get("/test", &result)
+	require.Error(t, err)
+	assert.Equal(t, 1, attempts)
+}
+
+func TestRetry_RespectsRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "rate limited"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	c.RetryBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	start := time.Now()
+	var result map[string]string
+	err := c.Get("/test", &result)
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+	assert.GreaterOrEqual(t, time.Since(start), 900*time.Millisecond)
+}
+
+func TestRetry_CapsRetryAfterAt30s(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "3600")
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "rate limited"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	c.RetryBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	start := time.Now()
+	var result map[string]string
+	err := c.Get("/test", &result)
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempts)
+	// Capped at 30s, not 3600s — but should complete within ~31s (we test < 35s)
+	assert.Less(t, time.Since(start), 35*time.Second)
+}
+
+func TestDebug_DisabledByDefault(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{})
+	}))
+	defer server.Close()
+
+	var debugBuf strings.Builder
+	c := New(server.URL)
+	c.DebugWriter = &debugBuf
+
+	var result map[string]string
+	_ = c.Get("/test", &result)
+
+	assert.Empty(t, debugBuf.String())
 }

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2555,13 +2555,13 @@ func TestRetry_CapsRetryAfterAt30s(t *testing.T) {
 
 	c := New(server.URL)
 	c.RetryBackoff = []time.Duration{time.Millisecond, time.Millisecond}
-	start := time.Now()
+	var sleptFor time.Duration
+	c.Sleeper = func(d time.Duration) { sleptFor = d }
 	var result map[string]string
 	err := c.Get("/test", &result)
 	require.NoError(t, err)
 	assert.Equal(t, 2, attempts)
-	// Capped at 30s, not 3600s — but should complete within ~31s (we test < 35s)
-	assert.Less(t, time.Since(start), 35*time.Second)
+	assert.Equal(t, 30*time.Second, sleptFor, "Retry-After: 3600 should be capped to 30s")
 }
 
 func TestDebug_DisabledByDefault(t *testing.T) {

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2529,12 +2529,13 @@ func TestRetry_RespectsRetryAfterHeader(t *testing.T) {
 
 	c := New(server.URL)
 	c.RetryBackoff = []time.Duration{time.Millisecond, time.Millisecond}
-	start := time.Now()
+	var sleptFor time.Duration
+	c.Sleeper = func(d time.Duration) { sleptFor = d }
 	var result map[string]string
 	err := c.Get("/test", &result)
 	require.NoError(t, err)
 	assert.Equal(t, 2, attempts)
-	assert.GreaterOrEqual(t, time.Since(start), 900*time.Millisecond)
+	assert.Equal(t, time.Second, sleptFor, "should respect Retry-After: 1")
 }
 
 func TestRetry_CapsRetryAfterAt30s(t *testing.T) {

--- a/cli/pkg/client/websocket.go
+++ b/cli/pkg/client/websocket.go
@@ -22,7 +22,7 @@ var terminalStatuses = map[string]bool{
 // StreamDeploymentLogs connects to the backend WebSocket and streams deployment
 // log lines for the given instance to w. It blocks until a terminal status is
 // received, the context is cancelled, or the connection drops.
-func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w io.Writer) (*types.StreamResult, error) {
+func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w io.Writer, warnWriter io.Writer) (*types.StreamResult, error) {
 	wsURL, err := c.websocketURL("/ws")
 	if err != nil {
 		return nil, err
@@ -41,6 +41,8 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 			dialer = &websocket.Dialer{
 				TLSClientConfig: t.TLSClientConfig,
 			}
+		} else if warnWriter != nil {
+			fmt.Fprintln(warnWriter, "Warning: custom HTTP transport detected; WebSocket TLS config may not be applied")
 		}
 	}
 
@@ -85,6 +87,9 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 
 		var msg types.WSMessage
 		if err := json.Unmarshal(message, &msg); err != nil {
+			if warnWriter != nil {
+				fmt.Fprintf(warnWriter, "Warning: skipping malformed WebSocket message: %v\n", err)
+			}
 			continue
 		}
 
@@ -92,6 +97,9 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 		case "deployment.log":
 			var logLine types.WSDeploymentLog
 			if err := json.Unmarshal(msg.Data, &logLine); err != nil {
+				if warnWriter != nil {
+					fmt.Fprintf(warnWriter, "Warning: skipping malformed log payload: %v\n", err)
+				}
 				continue
 			}
 			if logLine.InstanceID != instanceID {
@@ -102,6 +110,9 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 		case "deployment.status":
 			var status types.WSDeploymentStatus
 			if err := json.Unmarshal(msg.Data, &status); err != nil {
+				if warnWriter != nil {
+					fmt.Fprintf(warnWriter, "Warning: skipping malformed status payload: %v\n", err)
+				}
 				continue
 			}
 			if status.InstanceID != instanceID {

--- a/cli/pkg/client/websocket.go
+++ b/cli/pkg/client/websocket.go
@@ -38,9 +38,9 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 	dialer := websocket.DefaultDialer
 	if c.HTTPClient != nil && c.HTTPClient.Transport != nil {
 		if t, ok := c.HTTPClient.Transport.(*http.Transport); ok {
-			dialer = &websocket.Dialer{
-				TLSClientConfig: t.TLSClientConfig,
-			}
+			d := *websocket.DefaultDialer
+			d.TLSClientConfig = t.TLSClientConfig
+			dialer = &d
 		} else if warnWriter != nil {
 			fmt.Fprintln(warnWriter, "Warning: custom HTTP transport detected; WebSocket TLS config may not be applied")
 		}

--- a/cli/pkg/client/websocket_test.go
+++ b/cli/pkg/client/websocket_test.go
@@ -75,7 +75,7 @@ func TestStreamDeploymentLogs_Success(t *testing.T) {
 
 	c := New(server.URL)
 	var buf bytes.Buffer
-	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "running", result.Status)
@@ -98,7 +98,7 @@ func TestStreamDeploymentLogs_ErrorStatus(t *testing.T) {
 
 	c := New(server.URL)
 	var buf bytes.Buffer
-	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "error", result.Status)
@@ -127,7 +127,7 @@ func TestStreamDeploymentLogs_FiltersOtherInstances(t *testing.T) {
 
 	c := New(server.URL)
 	var buf bytes.Buffer
-	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "stopped", result.Status)
@@ -156,7 +156,7 @@ func TestStreamDeploymentLogs_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	_, err := c.StreamDeploymentLogs(ctx, "42", &buf)
+	_, err := c.StreamDeploymentLogs(ctx, "42", &buf, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
@@ -179,7 +179,7 @@ func TestStreamDeploymentLogs_AuthHeaders(t *testing.T) {
 	c := New(server.URL)
 	c.Token = "my-jwt-token"
 	var buf bytes.Buffer
-	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer my-jwt-token", capturedHeader.Get("Authorization"))
 }
@@ -203,7 +203,7 @@ func TestStreamDeploymentLogs_APIKeyAuth(t *testing.T) {
 	c.APIKey = "sk_test_123"
 	c.Token = "should-be-ignored"
 	var buf bytes.Buffer
-	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "sk_test_123", capturedHeader.Get("X-API-Key"))
 	assert.Empty(t, capturedHeader.Get("Authorization"))
@@ -226,7 +226,7 @@ func TestStreamDeploymentLogs_SkipsMalformedMessages(t *testing.T) {
 
 	c := New(server.URL)
 	var buf bytes.Buffer
-	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "running", result.Status)
 	assert.Equal(t, "Valid line\n", buf.String())
@@ -244,7 +244,7 @@ func TestStreamDeploymentLogs_DraftTerminal(t *testing.T) {
 
 	c := New(server.URL)
 	var buf bytes.Buffer
-	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "draft", result.Status)
 }
@@ -267,7 +267,7 @@ func TestStreamDeploymentLogs_NonTerminalStatusIgnored(t *testing.T) {
 
 	c := New(server.URL)
 	var buf bytes.Buffer
-	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "running", result.Status)
 	assert.Contains(t, buf.String(), "Still going...")
@@ -277,7 +277,7 @@ func TestStreamDeploymentLogs_ConnectionError(t *testing.T) {
 	t.Parallel()
 	c := New("http://localhost:1")
 	var buf bytes.Buffer
-	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connecting to WebSocket")
 }
@@ -286,7 +286,7 @@ func TestStreamDeploymentLogs_BadScheme(t *testing.T) {
 	t.Parallel()
 	c := &Client{BaseURL: "ftp://example.com"}
 	var buf bytes.Buffer
-	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf)
+	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported URL scheme")
 }
@@ -326,4 +326,50 @@ func TestWebsocketURL_StripTrailingSlash(t *testing.T) {
 	got, err := c.websocketURL("/ws")
 	require.NoError(t, err)
 	assert.False(t, strings.Contains(got, "//ws"))
+}
+
+func TestStreamDeploymentLogs_MalformedMessageWarning(t *testing.T) {
+	t.Parallel()
+	server := wsServer(t, func(conn *websocket.Conn) {
+		readSubscribe(t, conn, "42")
+		conn.WriteMessage(websocket.TextMessage, []byte(`not json`))
+		conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"deployment.log","payload":"bad"}`))
+		writeWSMessage(t, conn, "deployment.status", types.WSDeploymentStatus{
+			InstanceID: "42", Status: "running", LogID: "log-1",
+		})
+	})
+	defer server.Close()
+
+	c := New(server.URL)
+	var buf, warnBuf bytes.Buffer
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, &warnBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "running", result.Status)
+	assert.Contains(t, warnBuf.String(), "Warning: skipping malformed WebSocket message")
+	assert.Contains(t, warnBuf.String(), "Warning: skipping malformed log payload")
+}
+
+type customTransport struct{}
+
+func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestStreamDeploymentLogs_CustomTransportWarning(t *testing.T) {
+	t.Parallel()
+	server := wsServer(t, func(conn *websocket.Conn) {
+		readSubscribe(t, conn, "42")
+		writeWSMessage(t, conn, "deployment.status", types.WSDeploymentStatus{
+			InstanceID: "42", Status: "running", LogID: "log-1",
+		})
+	})
+	defer server.Close()
+
+	c := New(server.URL)
+	c.HTTPClient.Transport = &customTransport{}
+	var buf, warnBuf bytes.Buffer
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, &warnBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "running", result.Status)
+	assert.Contains(t, warnBuf.String(), "Warning: custom HTTP transport detected")
 }

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -57,6 +57,7 @@ type ChartConfig struct {
 	Base
 	Name          string `json:"name" yaml:"name"`
 	RepoURL       string `json:"repository_url" yaml:"repository_url"`
+	SourceRepoURL string `json:"source_repo_url,omitempty" yaml:"source_repo_url,omitempty"`
 	ChartName     string `json:"chart_name" yaml:"chart_name"`
 	ChartVersion  string `json:"chart_version,omitempty" yaml:"chart_version,omitempty"`
 	ReleaseName   string `json:"release_name,omitempty" yaml:"release_name,omitempty"`
@@ -225,6 +226,7 @@ type UpdateChartConfigRequest struct {
 	ChartName     string `json:"chart_name,omitempty" yaml:"chart_name,omitempty"`
 	ChartPath     string `json:"chart_path,omitempty" yaml:"chart_path,omitempty"`
 	ChartVersion  string `json:"chart_version,omitempty" yaml:"chart_version,omitempty"`
+	SourceRepoURL string `json:"source_repo_url,omitempty" yaml:"source_repo_url,omitempty"`
 	DeployOrder   *int   `json:"deploy_order,omitempty" yaml:"deploy_order,omitempty"`
 	DefaultValues string `json:"default_values,omitempty" yaml:"default_values,omitempty"`
 }

--- a/cli/pkg/types/types_test.go
+++ b/cli/pkg/types/types_test.go
@@ -1,0 +1,168 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackInstance_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	now := time.Now().Truncate(time.Second)
+	clusterID := "cluster-1"
+	orig := StackInstance{
+		Base:              Base{ID: "abc-123", CreatedAt: now, UpdatedAt: now, Version: "1"},
+		Name:              "my-stack",
+		StackDefinitionID: "def-1",
+		Owner:             "admin",
+		Branch:            "main",
+		Namespace:         "ns-my-stack",
+		Status:            "running",
+		ClusterID:         &clusterID,
+		TTLMinutes:        60,
+		DeployedAt:        &now,
+	}
+
+	data, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	var decoded StackInstance
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, orig.ID, decoded.ID)
+	assert.Equal(t, orig.Name, decoded.Name)
+	assert.Equal(t, orig.Status, decoded.Status)
+	assert.Equal(t, orig.ClusterID, decoded.ClusterID)
+	assert.Equal(t, orig.TTLMinutes, decoded.TTLMinutes)
+	assert.WithinDuration(t, *orig.DeployedAt, *decoded.DeployedAt, time.Second)
+}
+
+func TestStackInstance_OmitsNilOptionalFields(t *testing.T) {
+	t.Parallel()
+	inst := StackInstance{
+		Base:   Base{ID: "1"},
+		Name:   "test",
+		Status: "draft",
+	}
+
+	data, err := json.Marshal(inst)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	_, hasClusterID := raw["cluster_id"]
+	_, hasDeployedAt := raw["last_deployed_at"]
+	_, hasExpiresAt := raw["expires_at"]
+	assert.False(t, hasClusterID, "nil ClusterID should be omitted")
+	assert.False(t, hasDeployedAt, "nil DeployedAt should be omitted")
+	assert.False(t, hasExpiresAt, "nil ExpiresAt should be omitted")
+}
+
+func TestListResponse_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := ListResponse[StackInstance]{
+		Data: []StackInstance{
+			{Base: Base{ID: "1"}, Name: "stack-1"},
+			{Base: Base{ID: "2"}, Name: "stack-2"},
+		},
+		Total:      2,
+		Page:       1,
+		PageSize:   20,
+		TotalPages: 1,
+	}
+
+	data, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	var decoded ListResponse[StackInstance]
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, 2, decoded.Total)
+	assert.Len(t, decoded.Data, 2)
+	assert.Equal(t, "stack-1", decoded.Data[0].Name)
+}
+
+func TestWSMessage_RawPayload(t *testing.T) {
+	t.Parallel()
+	logPayload := WSDeploymentLog{
+		InstanceID: "42",
+		LogID:      "log-1",
+		Line:       "Installing chart...",
+	}
+	payloadBytes, err := json.Marshal(logPayload)
+	require.NoError(t, err)
+
+	msg := WSMessage{
+		Type: "deployment.log",
+		Data: json.RawMessage(payloadBytes),
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded WSMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "deployment.log", decoded.Type)
+
+	var decodedLog WSDeploymentLog
+	require.NoError(t, json.Unmarshal(decoded.Data, &decodedLog))
+	assert.Equal(t, "42", decodedLog.InstanceID)
+	assert.Equal(t, "Installing chart...", decodedLog.Line)
+}
+
+func TestQuotaOverride_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := QuotaOverride{
+		InstanceID: "42",
+		CPURequest: "100m",
+		CPULimit:   "500m",
+		MemRequest: "128Mi",
+		MemLimit:   "512Mi",
+	}
+
+	data, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	var decoded QuotaOverride
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, orig.InstanceID, decoded.InstanceID)
+	assert.Equal(t, orig.CPURequest, decoded.CPURequest)
+	assert.Equal(t, orig.MemLimit, decoded.MemLimit)
+}
+
+func TestStackDefinition_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := StackDefinition{
+		Base:          Base{ID: "def-1", Version: "2"},
+		Name:          "api-service",
+		Description:   "API stack definition",
+		DefaultBranch: "main",
+		Owner:         "admin",
+		Charts: []ChartConfig{
+			{
+				Base:         Base{ID: "chart-1"},
+				Name:         "api",
+				RepoURL:      "https://charts.example.com",
+				ChartName:    "api-chart",
+				ChartVersion: "1.0.0",
+			},
+		},
+	}
+
+	data, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	var decoded StackDefinition
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, orig.Name, decoded.Name)
+	assert.Equal(t, orig.DefaultBranch, decoded.DefaultBranch)
+	assert.Len(t, decoded.Charts, 1)
+	assert.Equal(t, "api", decoded.Charts[0].Name)
+	assert.Equal(t, "1.0.0", decoded.Charts[0].ChartVersion)
+}


### PR DESCRIPTION
## Summary
- **`--debug` flag** with HTTP request/response logging to stderr and credential masking (`X-API-Key`, `Authorization` headers). Also passed as `STACKCTL_DEBUG` env var to plugins.
- **Retry with backoff** for transient failures (429/502/503/504) on idempotent methods (GET/PUT/DELETE). Respects `Retry-After` header, capped at 30s. Configurable backoff via `Client.RetryBackoff`.
- **`--dry-run` flag** on all destructive operations: stack deploy/stop/clean/delete/rollback, all bulk ops, definition delete, template delete, cluster shared-values delete, orphaned delete, override value/branch/quota delete.
- **Token near-expiry warning** when JWT expires within 5 minutes. Refactored from package-level var to clean return value.
- **WebSocket warnings** on stderr for malformed JSON messages and custom HTTP transport TLS fallback.
- **Types package tests** — JSON round-trip coverage for `StackInstance`, `StackDefinition`, `ListResponse`, `WSMessage`, `QuotaOverride`, plus `omitempty` verification.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages pass (cmd, client, config, output, types, e2e, integration)
- [x] Retry-After cap test confirms 3600s server value is capped to 30s
- [ ] Manual: `stackctl --debug stack list` shows request/response on stderr
- [ ] Manual: `stackctl stack delete <id> --dry-run` prints message without calling API
- [ ] Manual: expired/near-expiry token triggers warning on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)