### PR TITLE
feat: stackctl login --sso (#56)

### DIFF
--- a/cli/cmd/browser.go
+++ b/cli/cmd/browser.go
@@ -8,7 +8,15 @@ import (
 	"strings"
 )
 
+// browserOpener is the function used to open URLs in a browser.
+// Override in tests to avoid spawning external processes.
+var browserOpener = openBrowserDefault
+
 func openBrowser(rawURL string) error {
+	return browserOpener(rawURL)
+}
+
+func openBrowserDefault(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
@@ -30,9 +38,5 @@ func openBrowser(rawURL string) error {
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
 
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	go cmd.Wait()
-	return nil
+	return cmd.Run()
 }

--- a/cli/cmd/browser.go
+++ b/cli/cmd/browser.go
@@ -2,19 +2,37 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
-func openBrowser(url string) error {
+func openBrowser(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("refusing to open non-HTTP URL: %s", scheme)
+	}
+
+	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		return exec.Command("open", url).Start()
+		cmd = exec.Command("open", "--", rawURL)
 	case "linux":
-		return exec.Command("xdg-open", url).Start()
+		cmd = exec.Command("xdg-open", rawURL)
 	case "windows":
-		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL)
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go cmd.Wait()
+	return nil
 }

--- a/cli/cmd/browser.go
+++ b/cli/cmd/browser.go
@@ -38,5 +38,11 @@ func openBrowserDefault(rawURL string) error {
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
 
-	return cmd.Run()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if cmd.Process != nil {
+		cmd.Process.Release()
+	}
+	return nil
 }

--- a/cli/cmd/browser.go
+++ b/cli/cmd/browser.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+}

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -231,6 +231,10 @@ func loginSSO(cmd *cobra.Command) error {
 	stderr := cmd.ErrOrStderr()
 	fmt.Fprint(stderr, "Waiting for authentication")
 
+	if session.ExpiresIn <= 0 {
+		return fmt.Errorf("server returned invalid session expiry (%d)", session.ExpiresIn)
+	}
+
 	result, err := pollForToken(c, session.SessionID, session.ExpiresIn, stderr)
 	if err != nil {
 		fmt.Fprintln(stderr) // newline after dots
@@ -262,31 +266,32 @@ func loginSSO(cmd *cobra.Command) error {
 var ssoPollInterval = 3 * time.Second
 
 func pollForToken(c *client.Client, sessionID string, expiresIn int, w io.Writer) (*types.CLITokenResponse, error) {
-	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
-	timer := time.NewTimer(0) // fire immediately
-	defer timer.Stop()
+	deadlineTimer := time.NewTimer(time.Duration(expiresIn) * time.Second)
+	defer deadlineTimer.Stop()
+
+	pollTimer := time.NewTimer(0) // fire immediately
+	defer pollTimer.Stop()
 
 	for {
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			return nil, fmt.Errorf("SSO login timed out. Please try again")
-		}
-
 		select {
-		case <-timer.C:
-		case <-time.After(remaining):
+		case <-deadlineTimer.C:
 			return nil, fmt.Errorf("SSO login timed out. Please try again")
+		case <-pollTimer.C:
 		}
 
 		resp, err := c.CLIToken(sessionID)
 		if err != nil {
 			return nil, fmt.Errorf("polling for SSO token: %w", err)
 		}
-		if resp.Status == "completed" {
+		switch resp.Status {
+		case "completed":
 			return resp, nil
+		case "pending":
+			fmt.Fprint(w, ".")
+		default:
+			return nil, fmt.Errorf("SSO login failed: %s", resp.Status)
 		}
-		fmt.Fprint(w, ".")
-		timer.Reset(ssoPollInterval)
+		pollTimer.Reset(ssoPollInterval)
 	}
 }
 

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -2,13 +2,17 @@ package cmd
 
 import (
 	"bufio"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/omattsson/stackctl/cli/pkg/client"
 	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -30,6 +34,11 @@ Environment variables:
   STACKCTL_PASSWORD   Password for authentication (avoids interactive prompt)`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		sso, _ := cmd.Flags().GetBool("sso")
+		if sso {
+			return loginSSO(cmd)
+		}
+
 		username, _ := cmd.Flags().GetString("username")
 		password, _ := cmd.Flags().GetString("password")
 
@@ -186,9 +195,114 @@ Examples:
 	},
 }
 
+func loginSSO(cmd *cobra.Command) error {
+	c, err := newUnauthenticatedClient()
+	if err != nil {
+		return err
+	}
+
+	// Check OIDC is enabled on the server
+	oidcCfg, err := c.GetOIDCConfig()
+	if err != nil {
+		return fmt.Errorf("checking SSO configuration: %w", err)
+	}
+	if !oidcCfg.Enabled {
+		return fmt.Errorf("SSO is not enabled on this server. Use 'stackctl login' with username/password instead")
+	}
+
+	// Initiate CLI auth session
+	session, err := c.CLIAuth()
+	if err != nil {
+		return fmt.Errorf("initiating SSO login: %w", err)
+	}
+
+	// Open browser
+	fmt.Fprintln(cmd.ErrOrStderr(), "Opening browser for SSO login...")
+	fmt.Fprintf(cmd.ErrOrStderr(), "If the browser doesn't open, visit:\n  %s\n\n", session.LoginURL)
+
+	if browserErr := openBrowser(session.LoginURL); browserErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not open browser: %s\n", browserErr)
+	}
+
+	// Poll for completion
+	fmt.Fprint(cmd.ErrOrStderr(), "Waiting for authentication")
+
+	result, err := pollForToken(c, session.SessionID, session.ExpiresIn)
+	if err != nil {
+		fmt.Fprintln(cmd.ErrOrStderr()) // newline after dots
+		return err
+	}
+	fmt.Fprintln(cmd.ErrOrStderr()) // newline after dots
+
+	if result.Token == "" {
+		return fmt.Errorf("server returned an empty token")
+	}
+
+	// Parse token expiry from JWT claims (base64 decode the payload)
+	expiresAt := parseJWTExpiry(result.Token)
+
+	if err := saveToken(result.Token, result.Username, expiresAt); err != nil {
+		return fmt.Errorf("saving token: %w", err)
+	}
+
+	printer.PrintMessage("Logged in as %s via SSO", result.Username)
+	return nil
+}
+
+func pollForToken(c *client.Client, sessionID string, expiresIn int) (*types.CLITokenResponse, error) {
+	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("SSO login timed out. Please try again")
+			}
+			resp, err := c.CLIToken(sessionID)
+			if err != nil {
+				return nil, fmt.Errorf("polling for SSO token: %w", err)
+			}
+			if resp.Status == "completed" {
+				return resp, nil
+			}
+			fmt.Fprint(os.Stderr, ".")
+		}
+	}
+}
+
+// parseJWTExpiry extracts the expiry time from a JWT token without verifying the signature.
+func parseJWTExpiry(token string) time.Time {
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return time.Time{}
+	}
+	// Add padding if needed
+	payload := parts[1]
+	switch len(payload) % 4 {
+	case 2:
+		payload += "=="
+	case 3:
+		payload += "="
+	}
+	data, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		return time.Time{}
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(data, &claims); err != nil || claims.Exp == 0 {
+		return time.Time{}
+	}
+	return time.Unix(claims.Exp, 0)
+}
+
 func init() {
 	loginCmd.Flags().String("username", "", "Username for authentication")
 	loginCmd.Flags().String("password", "", "Password for authentication")
+	loginCmd.Flags().Bool("sso", false, "Authenticate via SSO (opens browser)")
 
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(logoutCmd)

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -225,21 +225,24 @@ func loginSSO(cmd *cobra.Command) error {
 	}
 
 	// Poll for completion
-	fmt.Fprint(cmd.ErrOrStderr(), "Waiting for authentication")
+	stderr := cmd.ErrOrStderr()
+	fmt.Fprint(stderr, "Waiting for authentication")
 
-	result, err := pollForToken(c, session.SessionID, session.ExpiresIn)
+	result, err := pollForToken(c, session.SessionID, session.ExpiresIn, stderr)
 	if err != nil {
-		fmt.Fprintln(cmd.ErrOrStderr()) // newline after dots
+		fmt.Fprintln(stderr) // newline after dots
 		return err
 	}
-	fmt.Fprintln(cmd.ErrOrStderr()) // newline after dots
+	fmt.Fprintln(stderr) // newline after dots
 
 	if result.Token == "" {
 		return fmt.Errorf("server returned an empty token")
 	}
 
-	// Parse token expiry from JWT claims (base64 decode the payload)
-	expiresAt := parseJWTExpiry(result.Token)
+	expiresAt, err := parseJWTExpiry(result.Token)
+	if err != nil {
+		return fmt.Errorf("parsing token expiry: %w", err)
+	}
 
 	if err := saveToken(result.Token, result.Username, expiresAt); err != nil {
 		return fmt.Errorf("saving token: %w", err)
@@ -249,9 +252,11 @@ func loginSSO(cmd *cobra.Command) error {
 	return nil
 }
 
-func pollForToken(c *client.Client, sessionID string, expiresIn int) (*types.CLITokenResponse, error) {
+var ssoPollInterval = 3 * time.Second
+
+func pollForToken(c *client.Client, sessionID string, expiresIn int, w io.Writer) (*types.CLITokenResponse, error) {
 	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
-	ticker := time.NewTicker(3 * time.Second)
+	ticker := time.NewTicker(ssoPollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -267,36 +272,31 @@ func pollForToken(c *client.Client, sessionID string, expiresIn int) (*types.CLI
 			if resp.Status == "completed" {
 				return resp, nil
 			}
-			fmt.Fprint(os.Stderr, ".")
+			fmt.Fprint(w, ".")
 		}
 	}
 }
 
 // parseJWTExpiry extracts the expiry time from a JWT token without verifying the signature.
-func parseJWTExpiry(token string) time.Time {
+func parseJWTExpiry(token string) (time.Time, error) {
 	parts := strings.SplitN(token, ".", 3)
 	if len(parts) != 3 {
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("invalid JWT format")
 	}
-	// Add padding if needed
-	payload := parts[1]
-	switch len(payload) % 4 {
-	case 2:
-		payload += "=="
-	case 3:
-		payload += "="
-	}
-	data, err := base64.URLEncoding.DecodeString(payload)
+	data, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("decoding JWT payload: %w", err)
 	}
 	var claims struct {
 		Exp int64 `json:"exp"`
 	}
-	if err := json.Unmarshal(data, &claims); err != nil || claims.Exp == 0 {
-		return time.Time{}
+	if err := json.Unmarshal(data, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("parsing JWT claims: %w", err)
 	}
-	return time.Unix(claims.Exp, 0)
+	if claims.Exp == 0 {
+		return time.Time{}, fmt.Errorf("JWT missing exp claim")
+	}
+	return time.Unix(claims.Exp, 0), nil
 }
 
 func init() {

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -259,22 +259,20 @@ func pollForToken(c *client.Client, sessionID string, expiresIn int, w io.Writer
 	ticker := time.NewTicker(ssoPollInterval)
 	defer ticker.Stop()
 
-	for {
-		select {
-		case <-ticker.C:
-			if time.Now().After(deadline) {
-				return nil, fmt.Errorf("SSO login timed out. Please try again")
-			}
-			resp, err := c.CLIToken(sessionID)
-			if err != nil {
-				return nil, fmt.Errorf("polling for SSO token: %w", err)
-			}
-			if resp.Status == "completed" {
-				return resp, nil
-			}
-			fmt.Fprint(w, ".")
+	for range ticker.C {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("SSO login timed out. Please try again")
 		}
+		resp, err := c.CLIToken(sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("polling for SSO token: %w", err)
+		}
+		if resp.Status == "completed" {
+			return resp, nil
+		}
+		fmt.Fprint(w, ".")
 	}
+	return nil, fmt.Errorf("SSO login polling stopped unexpectedly")
 }
 
 // parseJWTExpiry extracts the expiry time from a JWT token without verifying the signature.

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -247,16 +247,15 @@ func loginSSO(cmd *cobra.Command) error {
 		return fmt.Errorf("parsing token expiry: %w", err)
 	}
 
-	username := result.Username
-	if username == "" {
-		username = "unknown"
-	}
-
-	if err := saveToken(result.Token, username, expiresAt); err != nil {
+	if err := saveToken(result.Token, result.Username, expiresAt); err != nil {
 		return fmt.Errorf("saving token: %w", err)
 	}
 
-	printer.PrintMessage("Logged in as %s via SSO", username)
+	displayName := result.Username
+	if displayName == "" {
+		displayName = "SSO user"
+	}
+	printer.PrintMessage("Logged in as %s via SSO", displayName)
 	return nil
 }
 
@@ -264,13 +263,21 @@ var ssoPollInterval = 3 * time.Second
 
 func pollForToken(c *client.Client, sessionID string, expiresIn int, w io.Writer) (*types.CLITokenResponse, error) {
 	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
-	ticker := time.NewTicker(ssoPollInterval)
-	defer ticker.Stop()
+	timer := time.NewTimer(0) // fire immediately
+	defer timer.Stop()
 
 	for {
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			return nil, fmt.Errorf("SSO login timed out. Please try again")
 		}
+
+		select {
+		case <-timer.C:
+		case <-time.After(remaining):
+			return nil, fmt.Errorf("SSO login timed out. Please try again")
+		}
+
 		resp, err := c.CLIToken(sessionID)
 		if err != nil {
 			return nil, fmt.Errorf("polling for SSO token: %w", err)
@@ -279,7 +286,7 @@ func pollForToken(c *client.Client, sessionID string, expiresIn int, w io.Writer
 			return resp, nil
 		}
 		fmt.Fprint(w, ".")
-		<-ticker.C
+		timer.Reset(ssoPollInterval)
 	}
 }
 

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -218,6 +218,9 @@ func loginSSO(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("initiating SSO login: %w", err)
 	}
+	if session.SessionID == "" || session.LoginURL == "" {
+		return fmt.Errorf("server returned incomplete SSO session (missing session ID or login URL)")
+	}
 
 	// Open browser
 	fmt.Fprintln(cmd.ErrOrStderr(), "Opening browser for SSO login...")

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -36,6 +36,9 @@ Environment variables:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sso, _ := cmd.Flags().GetBool("sso")
 		if sso {
+			if cfg == nil || cfg.CurrentContext == "" {
+				return fmt.Errorf("no context configured. Run 'stackctl config use-context <name>' first")
+			}
 			return loginSSO(cmd)
 		}
 
@@ -244,11 +247,16 @@ func loginSSO(cmd *cobra.Command) error {
 		return fmt.Errorf("parsing token expiry: %w", err)
 	}
 
-	if err := saveToken(result.Token, result.Username, expiresAt); err != nil {
+	username := result.Username
+	if username == "" {
+		username = "unknown"
+	}
+
+	if err := saveToken(result.Token, username, expiresAt); err != nil {
 		return fmt.Errorf("saving token: %w", err)
 	}
 
-	printer.PrintMessage("Logged in as %s via SSO", result.Username)
+	printer.PrintMessage("Logged in as %s via SSO", username)
 	return nil
 }
 
@@ -259,7 +267,7 @@ func pollForToken(c *client.Client, sessionID string, expiresIn int, w io.Writer
 	ticker := time.NewTicker(ssoPollInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
+	for {
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("SSO login timed out. Please try again")
 		}
@@ -271,8 +279,8 @@ func pollForToken(c *client.Client, sessionID string, expiresIn int, w io.Writer
 			return resp, nil
 		}
 		fmt.Fprint(w, ".")
+		<-ticker.C
 	}
-	return nil, fmt.Errorf("SSO login polling stopped unexpectedly")
 }
 
 // parseJWTExpiry extracts the expiry time from a JWT token without verifying the signature.

--- a/cli/cmd/login_test.go
+++ b/cli/cmd/login_test.go
@@ -730,13 +730,13 @@ func TestLoginSSO_InitiateSession(t *testing.T) {
 	defer server.Close()
 
 	outBuf, errBuf := setupSSOTestCmd(t, server.URL)
+	ssoPollInterval = 10 * time.Millisecond
 
 	loginCmd.Flags().Set("sso", "true")
 	loginCmd.SetOut(outBuf)
 	loginCmd.SetErr(errBuf)
 
 	err := loginCmd.RunE(loginCmd, []string{})
-	// It will timeout since we never complete, but we can verify the login URL was printed
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timed out")
 	assert.Contains(t, errBuf.String(), "https://login.example.com/auth?session=sess-abc")

--- a/cli/cmd/login_test.go
+++ b/cli/cmd/login_test.go
@@ -634,3 +634,213 @@ func TestLoginCmd_EmptyTokenFromServer(t *testing.T) {
 	_, statErr := os.Stat(tokenPath)
 	assert.True(t, os.IsNotExist(statErr), "token file should not exist when server returns empty token")
 }
+
+// ---------- SSO login tests ----------
+
+func setupSSOTestCmd(t *testing.T, apiURL string) (*bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("STACKCTL_CONFIG_DIR", dir)
+
+	t.Cleanup(func() {
+		loginCmd.Flags().Set("sso", "false")
+		loginCmd.Flags().Set("username", "")
+		loginCmd.Flags().Set("password", "")
+	})
+
+	cfg = &config.Config{
+		CurrentContext: "test",
+		Contexts: map[string]*config.Context{
+			"test": {APIURL: apiURL},
+		},
+	}
+	printer = output.NewPrinter("table", false, true)
+
+	var outBuf bytes.Buffer
+	printer.Writer = &outBuf
+
+	var errBuf bytes.Buffer
+
+	flagAPIURL = apiURL
+	flagAPIKey = ""
+	flagInsecure = false
+	flagQuiet = false
+
+	return &outBuf, &errBuf
+}
+
+func TestLoginSSO_OIDCDisabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/auth/oidc/config":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"enabled":            false,
+				"provider_name":      "",
+				"local_auth_enabled": true,
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	outBuf, errBuf := setupSSOTestCmd(t, server.URL)
+
+	loginCmd.Flags().Set("sso", "true")
+	loginCmd.SetOut(outBuf)
+	loginCmd.SetErr(errBuf)
+
+	err := loginCmd.RunE(loginCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SSO is not enabled")
+}
+
+func TestLoginSSO_InitiateSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/auth/oidc/config":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"enabled":            true,
+				"provider_name":      "azure-ad",
+				"local_auth_enabled": true,
+			})
+		case "/api/v1/auth/oidc/cli-auth":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"session_id": "sess-abc",
+				"login_url":  "https://login.example.com/auth?session=sess-abc",
+				"expires_in": 1, // 1 second to trigger quick timeout
+			})
+		case "/api/v1/auth/oidc/cli-token":
+			// Always return pending to trigger timeout
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "pending",
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	outBuf, errBuf := setupSSOTestCmd(t, server.URL)
+
+	loginCmd.Flags().Set("sso", "true")
+	loginCmd.SetOut(outBuf)
+	loginCmd.SetErr(errBuf)
+
+	err := loginCmd.RunE(loginCmd, []string{})
+	// It will timeout since we never complete, but we can verify the login URL was printed
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+	assert.Contains(t, errBuf.String(), "https://login.example.com/auth?session=sess-abc")
+}
+
+func TestLoginSSO_PollCompleted(t *testing.T) {
+	// Build a JWT with an exp claim for testing
+	// Header: {"alg":"HS256","typ":"JWT"}
+	// Payload: {"exp":4102444800,"sub":"sso-user"} (exp = 2100-01-01)
+	testJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQxMDI0NDQ4MDAsInN1YiI6InNzby11c2VyIn0.signature"
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/auth/oidc/config":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"enabled":            true,
+				"provider_name":      "azure-ad",
+				"local_auth_enabled": true,
+			})
+		case "/api/v1/auth/oidc/cli-auth":
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"session_id": "sess-poll",
+				"login_url":  "https://login.example.com/auth?session=sess-poll",
+				"expires_in": 30,
+			})
+		case "/api/v1/auth/oidc/cli-token":
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			if callCount >= 2 {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status":   "completed",
+					"token":    testJWT,
+					"username": "sso-user",
+					"user_id":  "42",
+				})
+			} else {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "pending",
+				})
+			}
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	outBuf, errBuf := setupSSOTestCmd(t, server.URL)
+
+	loginCmd.Flags().Set("sso", "true")
+	loginCmd.SetOut(outBuf)
+	loginCmd.SetErr(errBuf)
+
+	err := loginCmd.RunE(loginCmd, []string{})
+	require.NoError(t, err)
+	assert.Contains(t, outBuf.String(), "Logged in as sso-user via SSO")
+
+	// Verify token was saved
+	tokenPath := filepath.Join(os.Getenv("STACKCTL_CONFIG_DIR"), "tokens", "test.json")
+	data, readErr := os.ReadFile(tokenPath)
+	require.NoError(t, readErr)
+
+	var stored storedToken
+	require.NoError(t, json.Unmarshal(data, &stored))
+	assert.Equal(t, testJWT, stored.Token)
+	assert.Equal(t, "sso-user", stored.Username)
+	assert.False(t, stored.ExpiresAt.IsZero(), "expiry should be parsed from JWT")
+}
+
+func TestParseJWTExpiry(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantExp int64
+	}{
+		{
+			name: "valid JWT with exp",
+			// Payload: {"exp":4102444800} (2100-01-01T00:00:00Z)
+			token:   "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDI0NDQ4MDB9.sig",
+			wantExp: 4102444800,
+		},
+		{
+			name:    "not a JWT",
+			token:   "not-a-jwt",
+			wantExp: 0,
+		},
+		{
+			name:    "empty token",
+			token:   "",
+			wantExp: 0,
+		},
+		{
+			name: "JWT without exp",
+			// Payload: {"sub":"user"}
+			token:   "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig",
+			wantExp: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseJWTExpiry(tt.token)
+			if tt.wantExp == 0 {
+				assert.True(t, result.IsZero(), "expected zero time for token %q", tt.token)
+			} else {
+				assert.Equal(t, tt.wantExp, result.Unix())
+			}
+		})
+	}
+}

--- a/cli/cmd/login_test.go
+++ b/cli/cmd/login_test.go
@@ -768,6 +768,10 @@ func TestLoginSSO_PollCompleted(t *testing.T) {
 				"expires_in": 30,
 			})
 		case "/api/v1/auth/oidc/cli-token":
+			var req types.CLITokenRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+				assert.Equal(t, "sess-poll", req.SessionID, "cli-token should send the session ID from cli-auth")
+			}
 			callCount++
 			w.WriteHeader(http.StatusOK)
 			if callCount >= 2 {

--- a/cli/cmd/login_test.go
+++ b/cli/cmd/login_test.go
@@ -646,6 +646,10 @@ func setupSSOTestCmd(t *testing.T, apiURL string) (*bytes.Buffer, *bytes.Buffer)
 		loginCmd.Flags().Set("sso", "false")
 		loginCmd.Flags().Set("username", "")
 		loginCmd.Flags().Set("password", "")
+		loginCmd.SetIn(nil)
+		loginCmd.SetOut(nil)
+		loginCmd.SetErr(nil)
+		ssoPollInterval = 3 * time.Second
 	})
 
 	cfg = &config.Config{
@@ -783,6 +787,7 @@ func TestLoginSSO_PollCompleted(t *testing.T) {
 	defer server.Close()
 
 	outBuf, errBuf := setupSSOTestCmd(t, server.URL)
+	ssoPollInterval = 10 * time.Millisecond
 
 	loginCmd.Flags().Set("sso", "true")
 	loginCmd.SetOut(outBuf)
@@ -809,36 +814,36 @@ func TestParseJWTExpiry(t *testing.T) {
 		name    string
 		token   string
 		wantExp int64
+		wantErr bool
 	}{
 		{
-			name: "valid JWT with exp",
-			// Payload: {"exp":4102444800} (2100-01-01T00:00:00Z)
+			name:    "valid JWT with exp",
 			token:   "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjQxMDI0NDQ4MDB9.sig",
 			wantExp: 4102444800,
 		},
 		{
 			name:    "not a JWT",
 			token:   "not-a-jwt",
-			wantExp: 0,
+			wantErr: true,
 		},
 		{
 			name:    "empty token",
 			token:   "",
-			wantExp: 0,
+			wantErr: true,
 		},
 		{
-			name: "JWT without exp",
-			// Payload: {"sub":"user"}
+			name:    "JWT without exp",
 			token:   "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig",
-			wantExp: 0,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := parseJWTExpiry(tt.token)
-			if tt.wantExp == 0 {
-				assert.True(t, result.IsZero(), "expected zero time for token %q", tt.token)
+			result, err := parseJWTExpiry(tt.token)
+			if tt.wantErr {
+				assert.Error(t, err)
 			} else {
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantExp, result.Unix())
 			}
 		})

--- a/cli/cmd/login_test.go
+++ b/cli/cmd/login_test.go
@@ -650,6 +650,7 @@ func setupSSOTestCmd(t *testing.T, apiURL string) (*bytes.Buffer, *bytes.Buffer)
 		loginCmd.SetOut(nil)
 		loginCmd.SetErr(nil)
 		ssoPollInterval = 3 * time.Second
+		browserOpener = openBrowserDefault
 	})
 
 	cfg = &config.Config{
@@ -669,6 +670,7 @@ func setupSSOTestCmd(t *testing.T, apiURL string) (*bytes.Buffer, *bytes.Buffer)
 	flagAPIKey = ""
 	flagInsecure = false
 	flagQuiet = false
+	browserOpener = func(string) error { return nil }
 
 	return &outBuf, &errBuf
 }

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -397,6 +397,33 @@ func (c *Client) Whoami() (*types.User, error) {
 	return &user, nil
 }
 
+// GetOIDCConfig fetches the OIDC configuration from the server.
+func (c *Client) GetOIDCConfig() (*types.OIDCConfig, error) {
+	var cfg types.OIDCConfig
+	if err := c.Get("/api/v1/auth/oidc/config", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// CLIAuth initiates a CLI SSO authentication session.
+func (c *Client) CLIAuth() (*types.CLIAuthResponse, error) {
+	var resp types.CLIAuthResponse
+	if err := c.Post("/api/v1/auth/oidc/cli-auth", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CLIToken polls for CLI SSO authentication completion.
+func (c *Client) CLIToken(sessionID string) (*types.CLITokenResponse, error) {
+	var resp types.CLITokenResponse
+	if err := c.Post("/api/v1/auth/oidc/cli-token", types.CLITokenRequest{SessionID: sessionID}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ListStacks returns a paginated list of stack instances, filtered by query params.
 func (c *Client) ListStacks(params map[string]string) (*types.ListResponse[types.StackInstance], error) {
 	var resp types.ListResponse[types.StackInstance]

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2582,3 +2582,100 @@ func TestDebug_DisabledByDefault(t *testing.T) {
 
 	assert.Empty(t, debugBuf.String())
 }
+
+func TestGetOIDCConfig(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/auth/oidc/config", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.OIDCConfig{
+			Enabled:          true,
+			ProviderName:     "azure-ad",
+			LocalAuthEnabled: true,
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	cfg, err := c.GetOIDCConfig()
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, "azure-ad", cfg.ProviderName)
+	assert.True(t, cfg.LocalAuthEnabled)
+}
+
+func TestCLIAuth(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/auth/oidc/cli-auth", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.CLIAuthResponse{
+			SessionID: "sess-123",
+			LoginURL:  "https://login.example.com/auth?session=sess-123",
+			ExpiresIn: 300,
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	resp, err := c.CLIAuth()
+	require.NoError(t, err)
+	assert.Equal(t, "sess-123", resp.SessionID)
+	assert.Equal(t, "https://login.example.com/auth?session=sess-123", resp.LoginURL)
+	assert.Equal(t, 300, resp.ExpiresIn)
+}
+
+func TestCLIToken_Pending(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/auth/oidc/cli-token", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req types.CLITokenRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "sess-123", req.SessionID)
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.CLITokenResponse{
+			Status: "pending",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	resp, err := c.CLIToken("sess-123")
+	require.NoError(t, err)
+	assert.Equal(t, "pending", resp.Status)
+	assert.Empty(t, resp.Token)
+}
+
+func TestCLIToken_Completed(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/auth/oidc/cli-token", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req types.CLITokenRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "sess-456", req.SessionID)
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.CLITokenResponse{
+			Status:   "completed",
+			Token:    "jwt-sso-token",
+			Username: "sso-user",
+			UserID:   "42",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	resp, err := c.CLIToken("sess-456")
+	require.NoError(t, err)
+	assert.Equal(t, "completed", resp.Status)
+	assert.Equal(t, "jwt-sso-token", resp.Token)
+	assert.Equal(t, "sso-user", resp.Username)
+	assert.Equal(t, "42", resp.UserID)
+}

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -337,6 +337,33 @@ type SetSharedValuesRequest struct {
 	Priority int    `json:"priority,omitempty"`
 }
 
+// OIDCConfig represents the OIDC configuration from the server.
+type OIDCConfig struct {
+	Enabled          bool   `json:"enabled"`
+	ProviderName     string `json:"provider_name"`
+	LocalAuthEnabled bool   `json:"local_auth_enabled"`
+}
+
+// CLIAuthResponse is returned by POST /api/v1/auth/oidc/cli-auth.
+type CLIAuthResponse struct {
+	SessionID string `json:"session_id"`
+	LoginURL  string `json:"login_url"`
+	ExpiresIn int    `json:"expires_in"`
+}
+
+// CLITokenRequest is the request body for POST /api/v1/auth/oidc/cli-token.
+type CLITokenRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+// CLITokenResponse is returned by POST /api/v1/auth/oidc/cli-token.
+type CLITokenResponse struct {
+	Status   string `json:"status"`              // "pending" or "completed"
+	Token    string `json:"token,omitempty"`
+	Username string `json:"username,omitempty"`
+	UserID   string `json:"user_id,omitempty"`
+}
+
 // WSMessage is the envelope for all WebSocket messages.
 type WSMessage struct {
 	Type string          `json:"type"`


### PR DESCRIPTION
## Summary

Closes #56. CLI half of omattsson/k8s-stack-manager#226.

Adds `stackctl login --sso` for OIDC SSO authentication via browser:

1. Checks OIDC is enabled on server
2. Calls `POST /api/v1/auth/oidc/cli-auth` to get session + IdP URL
3. Opens browser for authentication
4. Polls `POST /api/v1/auth/oidc/cli-token` every 3s until complete
5. Saves JWT token locally (same as regular login)

## Changes

- New types: OIDCConfig, CLIAuthResponse, CLITokenRequest, CLITokenResponse
- New client methods: GetOIDCConfig, CLIAuth, CLIToken
- New `--sso` flag on login command with loginSSO, pollForToken, parseJWTExpiry
- Cross-platform browser open (macOS/Linux/Windows)
- 8 new tests

## Test plan

- [x] go build + go test pass (all packages)
- [ ] Manual: stackctl login --sso with Entra ID (requires backend PR)