### PR TITLE
feat(cluster): add create/update/delete/set-default commands

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,28 +7,36 @@ stackctl is a Go CLI tool (Cobra + Viper) for managing Kubernetes stack deployme
 ## Architecture
 
 - All code lives under `cli/` — the Go module root
-- Commands: `cli/cmd/` (one file per command group, subcommands in `init()`)
-- HTTP client: `cli/pkg/client/client.go` (47 methods, dual auth: JWT + API key)
-- Types: `cli/pkg/types/types.go` (34 types matching API responses)
+- Commands: `cli/cmd/` (one file per command group, subcommands registered in `init()`)
+- HTTP client: `cli/pkg/client/client.go` (REST) + `cli/pkg/client/websocket.go` (deployment log streaming)
+- Types: `cli/pkg/types/types.go` (client-side structs matching API responses)
 - Output: `cli/pkg/output/output.go` (table, JSON, YAML, quiet formatters)
 - Config: `cli/pkg/config/config.go` (Viper-based, `~/.stackmanager/config.yaml`)
-- Tests: alongside code (`*_test.go`), plus `cli/test/integration/` and `cli/test/e2e/`
+- Tests: alongside code (`*_test.go`), plus `cli/test/integration/`, `cli/test/e2e/`, and `cli/test/live/` (opt-in tests against a real backend)
 
-## Command Groups (47 commands total)
+## Command Groups
 
 | Group | Subcommands | File |
 |-------|------------|------|
 | `config` | set, get, list, use-context, current-context, delete-context | config.go |
-| `login/logout/whoami` | (top-level) | login.go |
-| `stack` | list, get, create, deploy, stop, clean, delete, status, logs, clone, extend, values, compare | stack.go |
+| `login`/`logout`/`whoami` | top-level; supports password + OIDC loopback flow | login.go |
+| `stack` | list, get, create, deploy, stop, clean, delete, status, logs, clone, extend, values, compare, history, rollback, history-values | stack.go |
 | `template` | list, get, instantiate, quick-deploy | template.go |
 | `definition` | list, get, create, update, delete, export, import | definition.go |
 | `override` | list, set, delete, branch (list/set/delete), quota (get/set/delete) | override.go |
 | `bulk` | deploy, stop, clean, delete | bulk.go |
 | `git` | branches, validate | git.go |
-| `cluster` | list, get | cluster.go |
+| `cluster` | list, get + health/quota/shared-values subcommands | cluster.go |
+| `orphaned` | list, clean — namespaces with the stack-manager label but no DB record | orphaned.go |
 | `completion` | bash, zsh, fish, powershell | completion.go |
-| `version` | (top-level) | version.go |
+| `version` | top-level | version.go |
+
+Helper (non-command) files in `cli/cmd/`:
+- `browser.go` — `openBrowser()` for OIDC loopback flow. Override `browserOpener` in tests.
+- `resolve.go` — `resolveStackID()` lets stack commands accept a name or an ID/UUID.
+- `plugins.go` — `registerPlugins()` discovers `stackctl-<name>` executables on `$PATH` and registers them as subcommands (kubectl/git/gh pattern). Built-in commands always win on name collision.
+- `token.go` — token storage helpers (load/save/delete JWT under `~/.stackmanager/tokens/`).
+- `root.go` — global flags, `newClient()`, `resolveAPIURL()`, `applyInsecureTLS()`.
 
 ## Code Review Guidelines
 
@@ -37,20 +45,26 @@ When reviewing PRs for this project, check:
 ### Pattern Compliance
 - Commands use `RunE` (not `Run`) and `SilenceUsage: true`
 - All output goes through `pkg/output` formatters (table, JSON, YAML, quiet)
-- All API calls go through `pkg/client` — never raw `http.Get`
-- `--quiet` mode outputs only numeric IDs, one per line (for `xargs` piping)
+- All HTTP/WebSocket calls go through `pkg/client` — never raw `http.Get` or `websocket.Dial`
+- `--quiet` mode outputs only IDs (or identifying names like namespaces for `orphaned list`), one per line — for `xargs` piping
 - Destructive commands (delete, clean) prompt for confirmation unless `--yes` is passed
 - Flag precedence: flag > env var (`STACKCTL_*`) > config file
+- Stack-scoped commands accept name or ID via `resolveStackID()`; commands that only take numeric/sub-resource IDs (chart IDs, cluster IDs) use `parseID()`
+- New `stackctl-<name>` plugin-style executables on PATH are discovered automatically — do not hardcode plugin paths
 
 ### Security
 - Token files must be `0600` — never world-readable
-- Never log or print tokens, API keys, or passwords
-- TLS certificate verification enabled by default (`--insecure` for dev only)
+- Never log or print tokens, API keys, or passwords (client debug logging redacts auth headers)
+- TLS certificate verification enabled by default; `--insecure` (or per-context `insecure: true`) prints a stderr warning
+- `openBrowser()` refuses non-http/https schemes — never bypass
+- Plugin discovery rejects mixed-case or non-conforming names (`pluginNamePattern`)
 
 ### Testing
 - `testify/assert` + `testify/require`, table-driven tests
 - `httptest.NewServer` for API mocking — never call real APIs in unit tests
+- WebSocket tests use `httptest.NewServer` + `websocket.Upgrader`
 - Test all output modes (table, JSON, YAML, quiet) for each command
+- `cmd/` tests must NOT use `t.Parallel()` (mutate package-level globals); `pkg/` tests should
 - Target 80%+ coverage on `pkg/` packages
 
 ### Global Flags
@@ -59,7 +73,8 @@ When reviewing PRs for this project, check:
 - `--no-color` — disable colored output
 - `--api-url` — override API server URL
 - `--api-key` — override API key
-- `--insecure` — skip TLS verification
+- `--insecure` — skip TLS verification (prints warning)
+- `--debug` — log HTTP requests/responses to stderr (also via `STACKCTL_DEBUG=1`)
 
 ## Build & Test
 

--- a/.github/instructions/client.instructions.md
+++ b/.github/instructions/client.instructions.md
@@ -9,10 +9,14 @@ The client supports JWT tokens and API keys. API key takes precedence.
 Headers are injected automatically in `do()` — never set auth headers in individual methods.
 
 ## Method Patterns
-- **GET with path**: `c.Get("/api/v1/resource/" + strconv.FormatUint(uint64(id), 10), &result)`
+IDs in client method signatures are `string` — no numeric conversion. Callers pass the value returned from `parseID()` or `resolveStackID()` directly.
+
+- **GET with path**: `c.Get("/api/v1/resource/" + id, &result)`
 - **GET with query**: `c.GetWithQuery("/api/v1/resource", params, &result)` where params is `map[string]string`
 - **POST/PUT**: `c.Post("/api/v1/resource", requestBody, &result)` — body is JSON-marshaled automatically
-- **DELETE**: `c.Delete("/api/v1/resource/" + strconv.FormatUint(uint64(id), 10))`
+- **DELETE**: `c.Delete("/api/v1/resource/" + id)`
+- **Idempotent retries**: `do()` calls `doWithRetry()` for GET/HEAD on transient errors; do not add retry loops in individual methods.
+- **WebSocket**: streaming methods live in `websocket.go` (e.g. `StreamDeploymentLogs`). They reuse the client's `APIKey`/`Token` for auth and the HTTP transport's TLS config — never construct a new dialer with hardcoded settings.
 
 ## Error Handling
 The `do()` method maps HTTP status codes to user-friendly errors:
@@ -24,6 +28,9 @@ The `do()` method maps HTTP status codes to user-friendly errors:
 - 500 → "Server error."
 
 ## Response Parsing
-Use `json.NewDecoder(resp.Body).Decode(&result)` — never read the full body into a byte slice.
+Use `json.NewDecoder(resp.Body).Decode(&result)` — never read the full body into a byte slice. Paginated list endpoints return `*types.ListResponse[T]`.
 
-All methods return typed results: `(*types.SomeType, error)` or `([]types.SomeType, error)`.
+All methods return typed results: `(*types.SomeType, error)`, `([]types.SomeType, error)`, or `(*types.ListResponse[T], error)`.
+
+## Debug Logging
+When `c.Debug` is true, requests and responses are written to `c.DebugWriter` (set to `os.Stderr` from `cmd/root.go`). Auth headers (`Authorization`, `X-API-Key`) MUST be redacted. Never log request/response bodies for auth endpoints (`/auth/login`, `/auth/cli/*`).

--- a/.github/instructions/commands.instructions.md
+++ b/.github/instructions/commands.instructions.md
@@ -39,15 +39,25 @@ Commands that delete or clean resources must:
 2. Prompt on stderr: `fmt.Fprintf(cmd.ErrOrStderr(), "prompt: ")`
 3. Read from `cmd.InOrStdin()` using `bufio.NewReader`
 
-## ID Parsing
-Use the `parseID()` helper from root.go for all ID arguments. Do not parse IDs inline.
+## ID & Name Parsing
+- `parseID()` (in `stack.go`) trims whitespace and validates non-empty; returns `string` (no numeric conversion). Use for chart IDs, cluster IDs, version IDs, and other sub-resource identifiers.
+- `resolveStackID()` (in `resolve.go`) accepts a stack name OR a numeric ID OR a UUID and resolves to the canonical ID via the API. Use for ALL stack-instance-scoped commands so users can pass `my-stack` instead of `42`.
+- Never parse IDs inline.
 
 ## API Calls
-All API calls go through `pkg/client` via `newClient()`. Never use `http.Get` directly.
+All API and WebSocket calls go through `pkg/client` via `newClient()` (or `newUnauthenticatedClient()` for login). Never use `http.Get` or `websocket.Dial` directly.
+
+## OIDC / Browser Flow
+For commands that open a browser (OIDC loopback login), call `openBrowser()` from `browser.go`. In tests, override the package-level `browserOpener` variable to capture the URL without spawning a process.
+
+## Plugins
+External `stackctl-<name>` executables on `$PATH` are auto-registered as subcommands by `registerPlugins()` in `Execute()`. Do not add command files that shadow common plugin names; do not call `registerPlugins()` from other code paths.
 
 ## Flag Conventions
 - `--output`, `-o` — output format (table|json|yaml)
 - `--quiet`, `-q` — IDs only, one per line
-- `--yes`, `-y` — skip confirmation
+- `--yes`, `-y` — skip confirmation on destructive operations
 - `--mine` — filter to current user
 - `--ids` — comma-separated IDs for bulk operations
+- `--debug` — log HTTP traffic to stderr (global; also via `STACKCTL_DEBUG=1`)
+- `--insecure` — skip TLS verification (global; prints stderr warning)

--- a/.github/instructions/config.instructions.md
+++ b/.github/instructions/config.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "cli/pkg/config/**"
+---
+
+# Config Package Conventions
+
+## Storage Layout
+- Config file: `~/.stackmanager/config.yaml` (XDG-aware via `os.UserConfigDir()` fallback).
+- Tokens: `~/.stackmanager/tokens/<context>.json` — one file per context. File mode MUST be `0600`; the directory MUST be `0700`. Verify mode after every write.
+- Never store secrets (`api-key`, password) in process env beyond the lifetime of the command unless explicitly set by the user.
+
+## Named Contexts
+- Multiple environments are supported via named contexts. `current-context` selects the active one.
+- All resolver helpers (`CurrentCtx()`, etc.) MUST return `nil` (never panic) when no context is selected.
+- Per-context `insecure: true` opts the context into TLS skip without requiring `--insecure` on every command.
+
+## Viper Bindings
+- Bind every CLI flag with a config equivalent so flag > env > file precedence is preserved.
+- Environment variable prefix is `STACKCTL_`. Use Viper's `SetEnvPrefix` + `AutomaticEnv` — never read `os.Getenv` directly in this package.
+
+## Load Behaviour
+- `Load()` MUST succeed (returning an empty config) when the file is missing — first-run UX requires it.
+- A malformed YAML file MUST return a wrapped error so the CLI can surface it instead of panicking. `version` and `completion` commands skip loading entirely (see `cmd/root.go`).

--- a/.github/instructions/config.instructions.md
+++ b/.github/instructions/config.instructions.md
@@ -5,7 +5,7 @@ applyTo: "cli/pkg/config/**"
 # Config Package Conventions
 
 ## Storage Layout
-- Config file: `~/.stackmanager/config.yaml` (XDG-aware via `os.UserConfigDir()` fallback).
+- Config file: `~/.stackmanager/config.yaml`. Directory resolved by `ConfigDir()`: checks `STACKCTL_CONFIG_DIR` env first, then `XDG_CONFIG_HOME` (appending `/stackmanager`), then falls back to `~/.stackmanager` via `os.UserHomeDir()`.
 - Tokens: `~/.stackmanager/tokens/<context>.json` — one file per context. File mode MUST be `0600`; the directory MUST be `0700`. Verify mode after every write.
 - Never store secrets (`api-key`, password) in process env beyond the lifetime of the command unless explicitly set by the user.
 

--- a/.github/instructions/output.instructions.md
+++ b/.github/instructions/output.instructions.md
@@ -1,0 +1,30 @@
+---
+applyTo: "cli/pkg/output/**"
+---
+
+# Output Package Conventions
+
+## Printer Contract
+All formatting goes through `*output.Printer`. A printer is created once in `cmd/root.go` `PersistentPreRunE` and shared across the command tree. Never instantiate a printer inside a command.
+
+## Required Modes
+Every formatter MUST handle all four modes consistently:
+- `table` (default) — human readable, headers + rows, color-aware
+- `json` — pretty-printed (`json.MarshalIndent` with 2-space indent), full structure
+- `yaml` — `gopkg.in/yaml.v3`, full structure
+- `quiet` — identifiers only, one per line, no headers, no color
+
+`--quiet` is checked first and short-circuits the format switch. Quiet output goes to `printer.Writer` (which Cobra sets to the command's stdout).
+
+## Color
+- Color is enabled by default and disabled when `--no-color` is set, when `NO_COLOR` env is set, or when stdout is not a TTY.
+- Centralise terminal detection here — commands MUST NOT call `isatty` themselves.
+
+## Errors
+- Format helpers return `error` for I/O failures only. Do not swallow encoder errors.
+- Never write to `os.Stdout`/`os.Stderr` directly; always use `printer.Writer` so tests can capture output via `bytes.Buffer`.
+
+## Adding a Formatter
+1. Add a `Print<Thing>(...)` method on `*Printer` that handles all four modes.
+2. Cover every mode in `*_test.go` with table-driven cases and `bytes.Buffer` capture.
+3. Keep table column ordering stable — downstream `grep`/`awk` users depend on it.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -11,7 +11,7 @@ applyTo: "cli/**_test.go"
 - Capture range variable: `tt := tt` inside the loop (only needed with `t.Parallel()`)
 
 ## API Mocking
-Always use `httptest.NewServer` — never call a real API in unit tests.
+Always use `httptest.NewServer` — never call a real API in unit tests. Live-backend tests belong in `cli/test/live/` and must be opt-in via build tag or env var.
 
 ```go
 server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,6 +24,15 @@ server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *htt
 defer server.Close()
 ```
 
+## WebSocket Mocking
+For `StreamDeploymentLogs` and other WebSocket endpoints, use `httptest.NewServer` with `gorilla/websocket.Upgrader`. Translate the `http://` URL to `ws://` when configuring the client. Always close the test server and the upgraded connection.
+
+## Browser-Opening Commands
+For commands that call `openBrowser()` (OIDC loopback), override the `browserOpener` package var in `cmd/browser.go` with a fake that captures the URL. Never let tests spawn `open`, `xdg-open`, or `rundll32`.
+
+## Plugin Tests
+When testing `registerPlugins()`, set up an isolated `PATH` pointing to a `t.TempDir()` containing executable `stackctl-<name>` scripts. Do not rely on the host's `$PATH`.
+
 ## Coverage Requirements
 - Test all output modes: table, JSON, YAML, quiet
 - Test error cases: API errors (401, 404, 500), invalid input
@@ -35,4 +44,6 @@ defer server.Close()
 Use `setupStackTestCmd(t, apiURL)` or equivalent helper that:
 1. Sets `flagAPIURL` to the mock server URL
 2. Creates a fresh `printer` with a `bytes.Buffer`
-3. Registers cleanup to restore defaults
+3. Registers cleanup to restore defaults (`cfg`, `printer`, all `flag*` globals)
+
+Because `cmd/` tests mutate package-level globals, they MUST NOT use `t.Parallel()` — even in subtests. Helpers should snapshot and restore globals via `t.Cleanup()`.

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -459,6 +459,9 @@ Examples:
 			if req.Name == "" {
 				return fmt.Errorf("name is required in the cluster file")
 			}
+			if req.KubeconfigData != "" && req.KubeconfigPath != "" {
+				return fmt.Errorf("file %s must not specify both kubeconfig_data and kubeconfig_path", fromFile)
+			}
 			// Resolve kubeconfig_path in the file to kubeconfig_data client-side.
 			// Relative paths are resolved relative to the directory of fromFile.
 			if req.KubeconfigPath != "" {
@@ -561,6 +564,13 @@ var clusterUpdateCmd = &cobra.Command{
 			}
 			// Resolve kubeconfig_path in the file to kubeconfig_data client-side.
 			// Relative paths are resolved relative to the directory of fromFile.
+			if req.KubeconfigData != nil && *req.KubeconfigData != "" && req.KubeconfigPath != nil && *req.KubeconfigPath != "" {
+				return fmt.Errorf("file %s must not specify both kubeconfig_data and kubeconfig_path", fromFile)
+			}
+			// Normalize kubeconfig_path: "" to nil so the empty-payload check below is accurate.
+			if req.KubeconfigPath != nil && *req.KubeconfigPath == "" {
+				req.KubeconfigPath = nil
+			}
 			if req.KubeconfigPath != nil && *req.KubeconfigPath != "" {
 				for _, segment := range strings.Split(filepath.ToSlash(*req.KubeconfigPath), "/") {
 					if segment == ".." {

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -467,7 +467,13 @@ Examples:
 			req.Name = name
 			req.Description, _ = cmd.Flags().GetString("description")
 			req.KubeconfigData, _ = cmd.Flags().GetString("kubeconfig-data")
-			req.KubeconfigPath, _ = cmd.Flags().GetString("kubeconfig-path")
+			if kubeconfigPath, _ := cmd.Flags().GetString("kubeconfig-path"); kubeconfigPath != "" {
+				content, err := os.ReadFile(kubeconfigPath)
+				if err != nil {
+					return fmt.Errorf("reading kubeconfig file %s: %w", kubeconfigPath, err)
+				}
+				req.KubeconfigData = string(content)
+			}
 		}
 
 		c, err := newClient()
@@ -544,7 +550,12 @@ var clusterUpdateCmd = &cobra.Command{
 			}
 			if kubeconfigPathChanged {
 				v, _ := cmd.Flags().GetString("kubeconfig-path")
-				req.KubeconfigPath = &v
+				content, err := os.ReadFile(v)
+				if err != nil {
+					return fmt.Errorf("reading kubeconfig file %s: %w", v, err)
+				}
+				s := string(content)
+				req.KubeconfigData = &s
 			}
 			if defaultChanged {
 				v, _ := cmd.Flags().GetBool("default")
@@ -609,6 +620,10 @@ var clusterSetDefaultCmd = &cobra.Command{
 			return err
 		}
 
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, id)
+			return nil
+		}
 		printer.PrintMessage("Cluster %s set as default", id)
 		return nil
 	},

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -390,6 +390,230 @@ Examples:
 	},
 }
 
+// printCluster renders a single cluster in the configured output format.
+func printCluster(cluster *types.Cluster) error {
+	if printer.Quiet {
+		fmt.Fprintln(printer.Writer, cluster.ID)
+		return nil
+	}
+
+	switch printer.Format {
+	case output.FormatJSON:
+		return printer.PrintJSON(cluster)
+	case output.FormatYAML:
+		return printer.PrintYAML(cluster)
+	default:
+		isDefault := "false"
+		if cluster.IsDefault {
+			isDefault = "true"
+		}
+		fields := []output.KeyValue{
+			{Key: "ID", Value: cluster.ID},
+			{Key: "Name", Value: cluster.Name},
+			{Key: "Description", Value: cluster.Description},
+			{Key: "Status", Value: printer.StatusColor(cluster.Status)},
+			{Key: "Default", Value: isDefault},
+			{Key: "Nodes", Value: strconv.Itoa(cluster.NodeCount)},
+		}
+		return printer.PrintSingle(cluster, fields)
+	}
+}
+
+var clusterCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Register a new cluster",
+	Long: `Register a new Kubernetes cluster.
+
+Provide either --from-file with a JSON/YAML file, or use --name and --kubeconfig-data / --kubeconfig-path.
+
+Examples:
+  stackctl cluster create --from-file cluster.json
+  stackctl cluster create --name prod --kubeconfig-path ~/.kube/config`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fromFile, _ := cmd.Flags().GetString("from-file")
+
+		var req types.CreateClusterRequest
+
+		if fromFile != "" {
+			for _, segment := range strings.Split(filepath.ToSlash(fromFile), "/") {
+				if segment == ".." {
+					return fmt.Errorf("file path must not contain '..' segments")
+				}
+			}
+			fromFile = filepath.Clean(fromFile)
+			data, err := os.ReadFile(fromFile)
+			if err != nil {
+				return fmt.Errorf("reading file %s: %w", fromFile, err)
+			}
+			ext := strings.ToLower(filepath.Ext(fromFile))
+			if ext == ".yaml" || ext == ".yml" {
+				if err := yaml.Unmarshal(data, &req); err != nil {
+					return fmt.Errorf("invalid YAML in file %s: %w", fromFile, err)
+				}
+			} else {
+				if err := json.Unmarshal(data, &req); err != nil {
+					return fmt.Errorf("invalid JSON in file %s: %w", fromFile, err)
+				}
+			}
+			if req.Name == "" {
+				return fmt.Errorf("name is required in the cluster file")
+			}
+		} else {
+			name, _ := cmd.Flags().GetString("name")
+			if name == "" {
+				return fmt.Errorf("--name is required (or use --from-file)")
+			}
+			req.Name = name
+			req.Description, _ = cmd.Flags().GetString("description")
+			req.KubeconfigData, _ = cmd.Flags().GetString("kubeconfig-data")
+			req.KubeconfigPath, _ = cmd.Flags().GetString("kubeconfig-path")
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		cluster, err := c.CreateCluster(&req)
+		if err != nil {
+			return err
+		}
+
+		return printCluster(cluster)
+	},
+}
+
+var clusterUpdateCmd = &cobra.Command{
+	Use:          "update <id>",
+	Short:        "Update cluster configuration",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+
+		fromFile, _ := cmd.Flags().GetString("from-file")
+		nameChanged := cmd.Flags().Changed("name")
+		descChanged := cmd.Flags().Changed("description")
+		kubeconfigDataChanged := cmd.Flags().Changed("kubeconfig-data")
+		kubeconfigPathChanged := cmd.Flags().Changed("kubeconfig-path")
+		defaultChanged := cmd.Flags().Changed("default")
+
+		if fromFile == "" && !nameChanged && !descChanged && !kubeconfigDataChanged && !kubeconfigPathChanged && !defaultChanged {
+			return fmt.Errorf("at least one of --name, --description, --kubeconfig-data, --kubeconfig-path, --default, or --from-file must be specified")
+		}
+
+		var req types.UpdateClusterRequest
+
+		if fromFile != "" {
+			for _, segment := range strings.Split(filepath.ToSlash(fromFile), "/") {
+				if segment == ".." {
+					return fmt.Errorf("file path must not contain '..' segments")
+				}
+			}
+			fromFile = filepath.Clean(fromFile)
+			data, err := os.ReadFile(fromFile)
+			if err != nil {
+				return fmt.Errorf("reading file %s: %w", fromFile, err)
+			}
+			ext := strings.ToLower(filepath.Ext(fromFile))
+			if ext == ".yaml" || ext == ".yml" {
+				if err := yaml.Unmarshal(data, &req); err != nil {
+					return fmt.Errorf("invalid YAML in file %s: %w", fromFile, err)
+				}
+			} else {
+				if err := json.Unmarshal(data, &req); err != nil {
+					return fmt.Errorf("invalid JSON in file %s: %w", fromFile, err)
+				}
+			}
+		} else {
+			if nameChanged {
+				v, _ := cmd.Flags().GetString("name")
+				req.Name = &v
+			}
+			if descChanged {
+				v, _ := cmd.Flags().GetString("description")
+				req.Description = &v
+			}
+			if kubeconfigDataChanged {
+				v, _ := cmd.Flags().GetString("kubeconfig-data")
+				req.KubeconfigData = &v
+			}
+			if kubeconfigPathChanged {
+				v, _ := cmd.Flags().GetString("kubeconfig-path")
+				req.KubeconfigPath = &v
+			}
+			if defaultChanged {
+				v, _ := cmd.Flags().GetBool("default")
+				req.IsDefault = &v
+			}
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		cluster, err := c.UpdateCluster(id, &req)
+		if err != nil {
+			return err
+		}
+
+		return printCluster(cluster)
+	},
+}
+
+var clusterDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a registered cluster",
+	Long: `Permanently delete a registered cluster.
+
+This is a destructive operation. You will be prompted for confirmation
+unless --yes is specified.
+
+Examples:
+  stackctl cluster delete 1
+  stackctl cluster delete 1 --yes`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return deleteByID(cmd, args,
+			"This will permanently delete cluster %s. Continue? (y/n): ",
+			passthroughID,
+			func(c *client.Client, id string) error { return c.DeleteCluster(id) },
+			"Deleted cluster %s",
+		)
+	},
+}
+
+var clusterSetDefaultCmd = &cobra.Command{
+	Use:          "set-default <id>",
+	Short:        "Mark a cluster as the default",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		if err := c.SetDefaultCluster(id); err != nil {
+			return err
+		}
+
+		printer.PrintMessage("Cluster %s set as default", id)
+		return nil
+	},
+}
+
 func init() {
 	// shared-values set flags
 	clusterSharedValuesSetCmd.Flags().String("name", "", "Name for the shared values entry (required)")
@@ -402,6 +626,25 @@ func init() {
 	clusterSharedValuesDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
 	clusterSharedValuesDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
+	// cluster create flags
+	clusterCreateCmd.Flags().String("from-file", "", "JSON or YAML file with cluster registration payload")
+	clusterCreateCmd.Flags().String("name", "", "Cluster name")
+	clusterCreateCmd.Flags().String("description", "", "Cluster description")
+	clusterCreateCmd.Flags().String("kubeconfig-data", "", "Raw kubeconfig data (base64 or YAML string)")
+	clusterCreateCmd.Flags().String("kubeconfig-path", "", "Path to kubeconfig file")
+
+	// cluster update flags
+	clusterUpdateCmd.Flags().String("from-file", "", "JSON or YAML file with update payload")
+	clusterUpdateCmd.Flags().String("name", "", "New cluster name")
+	clusterUpdateCmd.Flags().String("description", "", "New cluster description")
+	clusterUpdateCmd.Flags().String("kubeconfig-data", "", "New kubeconfig data")
+	clusterUpdateCmd.Flags().String("kubeconfig-path", "", "New path to kubeconfig file")
+	clusterUpdateCmd.Flags().Bool("default", false, "Mark cluster as default")
+
+	// cluster delete flags
+	clusterDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	clusterDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+
 	// Wire up shared-values subcommands
 	clusterSharedValuesCmd.AddCommand(clusterSharedValuesListCmd)
 	clusterSharedValuesCmd.AddCommand(clusterSharedValuesSetCmd)
@@ -410,5 +653,9 @@ func init() {
 	clusterCmd.AddCommand(clusterListCmd)
 	clusterCmd.AddCommand(clusterGetCmd)
 	clusterCmd.AddCommand(clusterSharedValuesCmd)
+	clusterCmd.AddCommand(clusterCreateCmd)
+	clusterCmd.AddCommand(clusterUpdateCmd)
+	clusterCmd.AddCommand(clusterDeleteCmd)
+	clusterCmd.AddCommand(clusterSetDefaultCmd)
 	rootCmd.AddCommand(clusterCmd)
 }

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -446,14 +446,9 @@ Examples:
 			if err != nil {
 				return fmt.Errorf("reading file %s: %w", fromFile, err)
 			}
-			ext := strings.ToLower(filepath.Ext(fromFile))
-			if ext == ".yaml" || ext == ".yml" {
-				if err := yaml.Unmarshal(data, &req); err != nil {
-					return fmt.Errorf("invalid YAML in file %s: %w", fromFile, err)
-				}
-			} else {
-				if err := json.Unmarshal(data, &req); err != nil {
-					return fmt.Errorf("invalid JSON in file %s: %w", fromFile, err)
+			if err := json.Unmarshal(data, &req); err != nil {
+				if yamlErr := yaml.Unmarshal(data, &req); yamlErr != nil {
+					return fmt.Errorf("invalid JSON/YAML in file %s (json: %v): %w", fromFile, err, yamlErr)
 				}
 			}
 			if req.Name == "" {
@@ -552,14 +547,9 @@ var clusterUpdateCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("reading file %s: %w", fromFile, err)
 			}
-			ext := strings.ToLower(filepath.Ext(fromFile))
-			if ext == ".yaml" || ext == ".yml" {
-				if err := yaml.Unmarshal(data, &req); err != nil {
-					return fmt.Errorf("invalid YAML in file %s: %w", fromFile, err)
-				}
-			} else {
-				if err := json.Unmarshal(data, &req); err != nil {
-					return fmt.Errorf("invalid JSON in file %s: %w", fromFile, err)
+			if err := json.Unmarshal(data, &req); err != nil {
+				if yamlErr := yaml.Unmarshal(data, &req); yamlErr != nil {
+					return fmt.Errorf("invalid JSON/YAML in file %s (json: %v): %w", fromFile, err, yamlErr)
 				}
 			}
 			// Resolve kubeconfig_path in the file to kubeconfig_data client-side.

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -535,6 +535,10 @@ var clusterUpdateCmd = &cobra.Command{
 					return fmt.Errorf("invalid JSON in file %s: %w", fromFile, err)
 				}
 			}
+			// Ensure the file contained at least one update field.
+			if b, _ := json.Marshal(req); string(b) == "{}" {
+				return fmt.Errorf("file %s specifies no update fields: at least one field must be provided", fromFile)
+			}
 		} else {
 			if nameChanged {
 				v, _ := cmd.Flags().GetString("name")

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -460,13 +460,18 @@ Examples:
 				return fmt.Errorf("name is required in the cluster file")
 			}
 			// Resolve kubeconfig_path in the file to kubeconfig_data client-side.
+			// Relative paths are resolved relative to the directory of fromFile.
 			if req.KubeconfigPath != "" {
 				for _, segment := range strings.Split(filepath.ToSlash(req.KubeconfigPath), "/") {
 					if segment == ".." {
 						return fmt.Errorf("kubeconfig_path in file must not contain '..' segments")
 					}
 				}
-				content, err := os.ReadFile(filepath.Clean(req.KubeconfigPath))
+				kpPath := req.KubeconfigPath
+				if !filepath.IsAbs(kpPath) {
+					kpPath = filepath.Join(filepath.Dir(fromFile), kpPath)
+				}
+				content, err := os.ReadFile(filepath.Clean(kpPath))
 				if err != nil {
 					return fmt.Errorf("reading kubeconfig file %s: %w", req.KubeconfigPath, err)
 				}
@@ -555,13 +560,18 @@ var clusterUpdateCmd = &cobra.Command{
 				}
 			}
 			// Resolve kubeconfig_path in the file to kubeconfig_data client-side.
+			// Relative paths are resolved relative to the directory of fromFile.
 			if req.KubeconfigPath != nil && *req.KubeconfigPath != "" {
 				for _, segment := range strings.Split(filepath.ToSlash(*req.KubeconfigPath), "/") {
 					if segment == ".." {
 						return fmt.Errorf("kubeconfig_path in file must not contain '..' segments")
 					}
 				}
-				content, err := os.ReadFile(filepath.Clean(*req.KubeconfigPath))
+				kpPath := *req.KubeconfigPath
+				if !filepath.IsAbs(kpPath) {
+					kpPath = filepath.Join(filepath.Dir(fromFile), kpPath)
+				}
+				content, err := os.ReadFile(filepath.Clean(kpPath))
 				if err != nil {
 					return fmt.Errorf("reading kubeconfig file %s: %w", *req.KubeconfigPath, err)
 				}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -459,15 +459,34 @@ Examples:
 			if req.Name == "" {
 				return fmt.Errorf("name is required in the cluster file")
 			}
+			// Resolve kubeconfig_path in the file to kubeconfig_data client-side.
+			if req.KubeconfigPath != "" {
+				for _, segment := range strings.Split(filepath.ToSlash(req.KubeconfigPath), "/") {
+					if segment == ".." {
+						return fmt.Errorf("kubeconfig_path in file must not contain '..' segments")
+					}
+				}
+				content, err := os.ReadFile(filepath.Clean(req.KubeconfigPath))
+				if err != nil {
+					return fmt.Errorf("reading kubeconfig file %s: %w", req.KubeconfigPath, err)
+				}
+				req.KubeconfigData = string(content)
+				req.KubeconfigPath = ""
+			}
 		} else {
 			name, _ := cmd.Flags().GetString("name")
 			if name == "" {
 				return fmt.Errorf("--name is required (or use --from-file)")
 			}
+			kubeconfigData, _ := cmd.Flags().GetString("kubeconfig-data")
+			kubeconfigPath, _ := cmd.Flags().GetString("kubeconfig-path")
+			if kubeconfigData != "" && kubeconfigPath != "" {
+				return fmt.Errorf("--kubeconfig-data and --kubeconfig-path are mutually exclusive")
+			}
 			req.Name = name
 			req.Description, _ = cmd.Flags().GetString("description")
-			req.KubeconfigData, _ = cmd.Flags().GetString("kubeconfig-data")
-			if kubeconfigPath, _ := cmd.Flags().GetString("kubeconfig-path"); kubeconfigPath != "" {
+			req.KubeconfigData = kubeconfigData
+			if kubeconfigPath != "" {
 				content, err := os.ReadFile(kubeconfigPath)
 				if err != nil {
 					return fmt.Errorf("reading kubeconfig file %s: %w", kubeconfigPath, err)
@@ -535,11 +554,29 @@ var clusterUpdateCmd = &cobra.Command{
 					return fmt.Errorf("invalid JSON in file %s: %w", fromFile, err)
 				}
 			}
+			// Resolve kubeconfig_path in the file to kubeconfig_data client-side.
+			if req.KubeconfigPath != nil && *req.KubeconfigPath != "" {
+				for _, segment := range strings.Split(filepath.ToSlash(*req.KubeconfigPath), "/") {
+					if segment == ".." {
+						return fmt.Errorf("kubeconfig_path in file must not contain '..' segments")
+					}
+				}
+				content, err := os.ReadFile(filepath.Clean(*req.KubeconfigPath))
+				if err != nil {
+					return fmt.Errorf("reading kubeconfig file %s: %w", *req.KubeconfigPath, err)
+				}
+				s := string(content)
+				req.KubeconfigData = &s
+				req.KubeconfigPath = nil
+			}
 			// Ensure the file contained at least one update field.
 			if b, _ := json.Marshal(req); string(b) == "{}" {
 				return fmt.Errorf("file %s specifies no update fields: at least one field must be provided", fromFile)
 			}
 		} else {
+			if kubeconfigDataChanged && kubeconfigPathChanged {
+				return fmt.Errorf("--kubeconfig-data and --kubeconfig-path are mutually exclusive")
+			}
 			if nameChanged {
 				v, _ := cmd.Flags().GetString("name")
 				req.Name = &v

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1202,6 +1202,20 @@ func TestClusterSetDefaultCmd_Success(t *testing.T) {
 	assert.Contains(t, buf.String(), "set as default")
 }
 
+func TestClusterSetDefaultCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	err := clusterSetDefaultCmd.RunE(clusterSetDefaultCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "1\n", buf.String())
+}
+
 func TestClusterSetDefaultCmd_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -860,6 +860,7 @@ func TestClusterCreateCmd_QuietOutput(t *testing.T) {
 
 func TestClusterCreateCmd_FromFile(t *testing.T) {
 	cl := sampleCluster()
+	cl.Name = "file-cluster"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		var req types.CreateClusterRequest
@@ -880,7 +881,7 @@ func TestClusterCreateCmd_FromFile(t *testing.T) {
 
 	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "dev-cluster")
+	assert.Contains(t, buf.String(), "file-cluster")
 }
 
 func TestClusterCreateCmd_MissingName(t *testing.T) {

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -899,7 +899,7 @@ func TestClusterCreateCmd_PathTraversal(t *testing.T) {
 
 	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "..")
+	assert.Contains(t, err.Error(), "file path must not contain '..'")
 }
 
 func TestClusterCreateCmd_Forbidden(t *testing.T) {
@@ -930,6 +930,7 @@ func resetClusterUpdateFlags(t *testing.T) {
 	clusterUpdateCmd.Flags().Set("kubeconfig-path", "")
 	clusterUpdateCmd.Flags().Set("default", "false")
 	// reset changed state
+	clusterUpdateCmd.Flags().Lookup("from-file").Changed = false
 	clusterUpdateCmd.Flags().Lookup("name").Changed = false
 	clusterUpdateCmd.Flags().Lookup("description").Changed = false
 	clusterUpdateCmd.Flags().Lookup("kubeconfig-data").Changed = false
@@ -1009,6 +1010,77 @@ func TestClusterUpdateCmd_SetDefault(t *testing.T) {
 	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "true")
+}
+
+func TestClusterUpdateCmd_PathTraversal(t *testing.T) {
+	_ = setupClusterTestCmd(t, "http://unused")
+	clusterUpdateCmd.Flags().Set("from-file", "../../etc/passwd")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file path must not contain '..'")
+}
+
+func TestClusterUpdateCmd_JSONOutput(t *testing.T) {
+	cl := sampleCluster()
+	cl.Name = "renamed-cluster"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+	clusterUpdateCmd.Flags().Set("name", "renamed-cluster")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"name":`)
+	assert.Contains(t, buf.String(), "renamed-cluster")
+}
+
+func TestClusterUpdateCmd_YAMLOutput(t *testing.T) {
+	cl := sampleCluster()
+	cl.Name = "renamed-cluster"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+	clusterUpdateCmd.Flags().Set("name", "renamed-cluster")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "name:")
+	assert.Contains(t, buf.String(), "renamed-cluster")
+}
+
+func TestClusterUpdateCmd_QuietOutput(t *testing.T) {
+	cl := sampleCluster()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+	clusterUpdateCmd.Flags().Set("name", "x")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "1\n", buf.String())
 }
 
 // ---------- cluster delete ----------

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -762,3 +762,385 @@ func TestClusterSharedValuesDeleteCmd_NotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "shared values not found")
 }
+
+// ---------- cluster create ----------
+
+func resetClusterCreateFlags(t *testing.T) {
+	t.Helper()
+	clusterCreateCmd.Flags().Set("from-file", "")
+	clusterCreateCmd.Flags().Set("name", "")
+	clusterCreateCmd.Flags().Set("description", "")
+	clusterCreateCmd.Flags().Set("kubeconfig-data", "")
+	clusterCreateCmd.Flags().Set("kubeconfig-path", "")
+}
+
+func TestClusterCreateCmd_TableOutput(t *testing.T) {
+	cl := sampleCluster()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		var req types.CreateClusterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.Equal(t, "dev-cluster", req.Name)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterCreateCmd.Flags().Set("name", "dev-cluster")
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "dev-cluster")
+}
+
+func TestClusterCreateCmd_JSONOutput(t *testing.T) {
+	cl := sampleCluster()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+	clusterCreateCmd.Flags().Set("name", "dev-cluster")
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.NoError(t, err)
+
+	var result types.Cluster
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
+	assert.Equal(t, "dev-cluster", result.Name)
+}
+
+func TestClusterCreateCmd_YAMLOutput(t *testing.T) {
+	cl := sampleCluster()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+	clusterCreateCmd.Flags().Set("name", "dev-cluster")
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "name: dev-cluster")
+}
+
+func TestClusterCreateCmd_QuietOutput(t *testing.T) {
+	cl := sampleCluster()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+	clusterCreateCmd.Flags().Set("name", "dev-cluster")
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "1\n", buf.String())
+}
+
+func TestClusterCreateCmd_FromFile(t *testing.T) {
+	cl := sampleCluster()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		var req types.CreateClusterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.Equal(t, "file-cluster", req.Name)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	tmpFile := filepath.Join(t.TempDir(), "cluster.json")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(`{"name":"file-cluster"}`), 0600))
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterCreateCmd.Flags().Set("from-file", tmpFile)
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "dev-cluster")
+}
+
+func TestClusterCreateCmd_MissingName(t *testing.T) {
+	_ = setupClusterTestCmd(t, "http://unused")
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name is required")
+}
+
+func TestClusterCreateCmd_PathTraversal(t *testing.T) {
+	_ = setupClusterTestCmd(t, "http://unused")
+	clusterCreateCmd.Flags().Set("from-file", "../etc/passwd")
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}
+
+func TestClusterCreateCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "forbidden"})
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterCreateCmd.Flags().Set("name", "dev-cluster")
+	t.Cleanup(func() { resetClusterCreateFlags(t) })
+
+	err := clusterCreateCmd.RunE(clusterCreateCmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Permission denied")
+}
+
+// ---------- cluster update ----------
+
+func resetClusterUpdateFlags(t *testing.T) {
+	t.Helper()
+	clusterUpdateCmd.Flags().Set("from-file", "")
+	clusterUpdateCmd.Flags().Set("name", "")
+	clusterUpdateCmd.Flags().Set("description", "")
+	clusterUpdateCmd.Flags().Set("kubeconfig-data", "")
+	clusterUpdateCmd.Flags().Set("kubeconfig-path", "")
+	clusterUpdateCmd.Flags().Set("default", "false")
+	// reset changed state
+	clusterUpdateCmd.Flags().Lookup("name").Changed = false
+	clusterUpdateCmd.Flags().Lookup("description").Changed = false
+	clusterUpdateCmd.Flags().Lookup("kubeconfig-data").Changed = false
+	clusterUpdateCmd.Flags().Lookup("kubeconfig-path").Changed = false
+	clusterUpdateCmd.Flags().Lookup("default").Changed = false
+}
+
+func TestClusterUpdateCmd_TableOutput(t *testing.T) {
+	cl := sampleCluster()
+	cl.Name = "renamed-cluster"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters/1", r.URL.Path)
+		require.Equal(t, http.MethodPut, r.Method)
+		var req types.UpdateClusterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.NotNil(t, req.Name)
+		require.Equal(t, "renamed-cluster", *req.Name)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterUpdateCmd.Flags().Set("name", "renamed-cluster")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "renamed-cluster")
+}
+
+func TestClusterUpdateCmd_NoFlags(t *testing.T) {
+	_ = setupClusterTestCmd(t, "http://unused")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of")
+}
+
+func TestClusterUpdateCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "forbidden"})
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterUpdateCmd.Flags().Set("name", "x")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Permission denied")
+}
+
+func TestClusterUpdateCmd_SetDefault(t *testing.T) {
+	cl := sampleCluster()
+	cl.IsDefault = true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req types.UpdateClusterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		require.NotNil(t, req.IsDefault)
+		require.True(t, *req.IsDefault)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(cl)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterUpdateCmd.Flags().Set("default", "true")
+	t.Cleanup(func() { resetClusterUpdateFlags(t) })
+
+	err := clusterUpdateCmd.RunE(clusterUpdateCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "true")
+}
+
+// ---------- cluster delete ----------
+
+func TestClusterDeleteCmd_WithYesFlag(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		require.Equal(t, "/api/v1/clusters/1", r.URL.Path)
+		require.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterDeleteCmd.Flags().Set("yes", "true")
+	t.Cleanup(func() { clusterDeleteCmd.Flags().Set("yes", "false") })
+
+	err := clusterDeleteCmd.RunE(clusterDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Contains(t, buf.String(), "Deleted cluster 1")
+}
+
+func TestClusterDeleteCmd_ConfirmAccept(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterDeleteCmd.Flags().Set("yes", "false")
+	t.Cleanup(func() {
+		clusterDeleteCmd.Flags().Set("yes", "false")
+		clusterDeleteCmd.SetIn(nil)
+		clusterDeleteCmd.SetErr(nil)
+	})
+	clusterDeleteCmd.SetIn(strings.NewReader("y\n"))
+	clusterDeleteCmd.SetErr(&bytes.Buffer{})
+
+	err := clusterDeleteCmd.RunE(clusterDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Contains(t, buf.String(), "Deleted cluster")
+}
+
+func TestClusterDeleteCmd_Declined(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should NOT be called when user declines")
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterDeleteCmd.Flags().Set("yes", "false")
+	t.Cleanup(func() {
+		clusterDeleteCmd.Flags().Set("yes", "false")
+		clusterDeleteCmd.SetIn(nil)
+		clusterDeleteCmd.SetErr(nil)
+	})
+	clusterDeleteCmd.SetIn(strings.NewReader("n\n"))
+	clusterDeleteCmd.SetErr(&bytes.Buffer{})
+
+	err := clusterDeleteCmd.RunE(clusterDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Aborted")
+}
+
+func TestClusterDeleteCmd_DryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should NOT be called in dry-run mode")
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterDeleteCmd.Flags().Set("dry-run", "true")
+	t.Cleanup(func() { clusterDeleteCmd.Flags().Set("dry-run", "false") })
+
+	err := clusterDeleteCmd.RunE(clusterDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Would delete")
+}
+
+func TestClusterDeleteCmd_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterDeleteCmd.Flags().Set("yes", "true")
+	t.Cleanup(func() { clusterDeleteCmd.Flags().Set("yes", "false") })
+
+	err := clusterDeleteCmd.RunE(clusterDeleteCmd, []string{"999"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster not found")
+}
+
+// ---------- cluster set-default ----------
+
+func TestClusterSetDefaultCmd_Success(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		require.Equal(t, "/api/v1/clusters/1/default", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+
+	err := clusterSetDefaultCmd.RunE(clusterSetDefaultCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Contains(t, buf.String(), "set as default")
+}
+
+func TestClusterSetDefaultCmd_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+
+	err := clusterSetDefaultCmd.RunE(clusterSetDefaultCmd, []string{"999"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster not found")
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -96,6 +96,19 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
+// SetArgs overrides the command-line arguments for the next Execute call.
+// Intended for integration tests.
+func SetArgs(args []string) {
+	rootCmd.SetArgs(args)
+}
+
+// SetOut redirects the root command output writer.
+// PersistentPreRunE passes this through to printer.Writer, so all command
+// output is captured. Intended for integration tests.
+func SetOut(w io.Writer) {
+	rootCmd.SetOut(w)
+}
+
 // newClient creates an API client from the current config and flags.
 func newClient() (*client.Client, error) {
 	apiURL := resolveAPIURL()

--- a/cli/cmd/stack_test.go
+++ b/cli/cmd/stack_test.go
@@ -30,17 +30,23 @@ func setupStackTestCmd(t *testing.T, apiURL string) *bytes.Buffer {
 	// Snapshot all mutated globals so t.Cleanup can restore them.
 	prevCfg := cfg
 	prevPrinter := printer
+	prevFlagOutput := flagOutput
+	prevFlagQuiet := flagQuiet
+	prevFlagNoColor := flagNoColor
 	prevFlagAPIURL := flagAPIURL
 	prevFlagAPIKey := flagAPIKey
 	prevFlagInsecure := flagInsecure
-	prevFlagQuiet := flagQuiet
+	prevFlagDebug := flagDebug
 	t.Cleanup(func() {
 		cfg = prevCfg
 		printer = prevPrinter
+		flagOutput = prevFlagOutput
+		flagQuiet = prevFlagQuiet
+		flagNoColor = prevFlagNoColor
 		flagAPIURL = prevFlagAPIURL
 		flagAPIKey = prevFlagAPIKey
 		flagInsecure = prevFlagInsecure
-		flagQuiet = prevFlagQuiet
+		flagDebug = prevFlagDebug
 	})
 
 	cfg = &config.Config{

--- a/cli/cmd/stack_test.go
+++ b/cli/cmd/stack_test.go
@@ -27,6 +27,22 @@ func setupStackTestCmd(t *testing.T, apiURL string) *bytes.Buffer {
 	dir := t.TempDir()
 	t.Setenv("STACKCTL_CONFIG_DIR", dir)
 
+	// Snapshot all mutated globals so t.Cleanup can restore them.
+	prevCfg := cfg
+	prevPrinter := printer
+	prevFlagAPIURL := flagAPIURL
+	prevFlagAPIKey := flagAPIKey
+	prevFlagInsecure := flagInsecure
+	prevFlagQuiet := flagQuiet
+	t.Cleanup(func() {
+		cfg = prevCfg
+		printer = prevPrinter
+		flagAPIURL = prevFlagAPIURL
+		flagAPIKey = prevFlagAPIKey
+		flagInsecure = prevFlagInsecure
+		flagQuiet = prevFlagQuiet
+	})
+
 	cfg = &config.Config{
 		CurrentContext: "test",
 		Contexts: map[string]*config.Context{

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1074,3 +1074,33 @@ func (c *Client) SetSharedValues(clusterID string, req *types.SetSharedValuesReq
 func (c *Client) DeleteSharedValues(clusterID, sharedValuesID string) error {
 	return c.Delete(fmt.Sprintf(pathSharedValuesID, clusterID, sharedValuesID))
 }
+
+// CreateCluster registers a new Kubernetes cluster.
+func (c *Client) CreateCluster(req *types.CreateClusterRequest) (*types.Cluster, error) {
+	var cluster types.Cluster
+	err := c.Post("/api/v1/clusters", req, &cluster)
+	if err != nil {
+		return nil, err
+	}
+	return &cluster, nil
+}
+
+// UpdateCluster updates cluster metadata and/or kubeconfig.
+func (c *Client) UpdateCluster(id string, req *types.UpdateClusterRequest) (*types.Cluster, error) {
+	var cluster types.Cluster
+	err := c.Put(fmt.Sprintf("/api/v1/clusters/%s", id), req, &cluster)
+	if err != nil {
+		return nil, err
+	}
+	return &cluster, nil
+}
+
+// DeleteCluster permanently removes a registered cluster.
+func (c *Client) DeleteCluster(id string) error {
+	return c.Delete(fmt.Sprintf("/api/v1/clusters/%s", id))
+}
+
+// SetDefaultCluster marks a cluster as the default for new deployments.
+func (c *Client) SetDefaultCluster(id string) error {
+	return c.Post(fmt.Sprintf("/api/v1/clusters/%s/default", id), nil, nil)
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -3224,3 +3224,128 @@ func TestBulkDeleteTemplates_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, resp)
 }
+
+// ---------- cluster write operations ----------
+
+func TestCreateCluster_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/clusters", r.URL.Path)
+		var body types.CreateClusterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "prod", body.Name)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(types.Cluster{Base: types.Base{ID: "5"}, Name: "prod", Status: "online"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	cluster, err := c.CreateCluster(&types.CreateClusterRequest{Name: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, "5", cluster.ID)
+	assert.Equal(t, "prod", cluster.Name)
+}
+
+func TestCreateCluster_Error(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "name is required"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	cluster, err := c.CreateCluster(&types.CreateClusterRequest{})
+	require.Error(t, err)
+	assert.Nil(t, cluster)
+}
+
+func TestUpdateCluster_Success(t *testing.T) {
+	t.Parallel()
+	newName := "updated"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/clusters/3", r.URL.Path)
+		var body types.UpdateClusterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.NotNil(t, body.Name)
+		assert.Equal(t, "updated", *body.Name)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.Cluster{Base: types.Base{ID: "3"}, Name: "updated", Status: "online"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	cluster, err := c.UpdateCluster("3", &types.UpdateClusterRequest{Name: &newName})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", cluster.Name)
+}
+
+func TestUpdateCluster_Error(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	cluster, err := c.UpdateCluster("99", &types.UpdateClusterRequest{})
+	require.Error(t, err)
+	assert.Nil(t, cluster)
+}
+
+func TestDeleteCluster_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/clusters/7", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.DeleteCluster("7")
+	require.NoError(t, err)
+}
+
+func TestDeleteCluster_Error(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.DeleteCluster("99")
+	require.Error(t, err)
+}
+
+func TestSetDefaultCluster_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/clusters/2/default", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.SetDefaultCluster("2")
+	require.NoError(t, err)
+}
+
+func TestSetDefaultCluster_Error(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.SetDefaultCluster("99")
+	require.Error(t, err)
+}

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -74,6 +74,41 @@ type Cluster struct {
 	NodeCount   int    `json:"node_count,omitempty" yaml:"node_count,omitempty"`
 }
 
+// CreateClusterRequest is the request body for POST /api/v1/clusters.
+type CreateClusterRequest struct {
+	Name                string `json:"name" yaml:"name"`
+	Description         string `json:"description,omitempty" yaml:"description,omitempty"`
+	APIServerURL        string `json:"api_server_url,omitempty" yaml:"api_server_url,omitempty"`
+	KubeconfigData      string `json:"kubeconfig_data,omitempty" yaml:"kubeconfig_data,omitempty"`
+	KubeconfigPath      string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
+	Region              string `json:"region,omitempty" yaml:"region,omitempty"`
+	MaxNamespaces       int    `json:"max_namespaces,omitempty" yaml:"max_namespaces,omitempty"`
+	MaxInstancesPerUser int    `json:"max_instances_per_user,omitempty" yaml:"max_instances_per_user,omitempty"`
+	IsDefault           bool   `json:"is_default,omitempty" yaml:"is_default,omitempty"`
+	UseInCluster        bool   `json:"use_in_cluster,omitempty" yaml:"use_in_cluster,omitempty"`
+	RegistryURL         string `json:"registry_url,omitempty" yaml:"registry_url,omitempty"`
+	RegistryUsername    string `json:"registry_username,omitempty" yaml:"registry_username,omitempty"`
+	ImagePullSecretName string `json:"image_pull_secret_name,omitempty" yaml:"image_pull_secret_name,omitempty"`
+}
+
+// UpdateClusterRequest is the request body for PUT /api/v1/clusters/:id.
+// All fields are optional; only non-nil fields are sent.
+type UpdateClusterRequest struct {
+	Name                *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Description         *string `json:"description,omitempty" yaml:"description,omitempty"`
+	APIServerURL        *string `json:"api_server_url,omitempty" yaml:"api_server_url,omitempty"`
+	KubeconfigData      *string `json:"kubeconfig_data,omitempty" yaml:"kubeconfig_data,omitempty"`
+	KubeconfigPath      *string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
+	Region              *string `json:"region,omitempty" yaml:"region,omitempty"`
+	MaxNamespaces       *int    `json:"max_namespaces,omitempty" yaml:"max_namespaces,omitempty"`
+	MaxInstancesPerUser *int    `json:"max_instances_per_user,omitempty" yaml:"max_instances_per_user,omitempty"`
+	IsDefault           *bool   `json:"is_default,omitempty" yaml:"is_default,omitempty"`
+	UseInCluster        *bool   `json:"use_in_cluster,omitempty" yaml:"use_in_cluster,omitempty"`
+	RegistryURL         *string `json:"registry_url,omitempty" yaml:"registry_url,omitempty"`
+	RegistryUsername    *string `json:"registry_username,omitempty" yaml:"registry_username,omitempty"`
+	ImagePullSecretName *string `json:"image_pull_secret_name,omitempty" yaml:"image_pull_secret_name,omitempty"`
+}
+
 // User represents a user account.
 type User struct {
 	Base

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -1720,7 +1720,11 @@ func startE2EClusterMockServer(t *testing.T) *httptest.Server {
 		// POST /api/v1/clusters — create
 		case r.URL.Path == "/api/v1/clusters" && r.Method == http.MethodPost:
 			var body map[string]interface{}
-			json.NewDecoder(r.Body).Decode(&body)
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+				return
+			}
 			name, _ := body["name"].(string)
 			resp := map[string]interface{}{
 				"id": "42", "name": name, "status": "active",
@@ -1748,7 +1752,11 @@ func startE2EClusterMockServer(t *testing.T) *httptest.Server {
 		// PUT /api/v1/clusters/1 — update
 		case r.URL.Path == "/api/v1/clusters/1" && r.Method == http.MethodPut:
 			var body map[string]interface{}
-			json.NewDecoder(r.Body).Decode(&body)
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+				return
+			}
 			name := "updated-cluster"
 			if v, ok := body["name"].(string); ok && v != "" {
 				name = v

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -1696,3 +1696,166 @@ func TestE2E_BulkTemplateDelete_NoConfirmation(t *testing.T) {
 	assert.Contains(t, stdout, "Aborted")
 }
 
+// ---------- Cluster E2E Mock Server ----------
+
+// startE2EClusterMockServer starts a mock API with cluster lifecycle endpoints for e2e tests.
+func startE2EClusterMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		// GET /api/v1/clusters — list
+		case r.URL.Path == "/api/v1/clusters" && r.Method == http.MethodGet:
+			resp := []map[string]interface{}{
+				{
+					"id": "1", "name": "prod-cluster", "status": "active",
+					"is_default": true, "node_count": 3,
+					"created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "version": "1",
+				},
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+
+		// POST /api/v1/clusters — create
+		case r.URL.Path == "/api/v1/clusters" && r.Method == http.MethodPost:
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			name, _ := body["name"].(string)
+			resp := map[string]interface{}{
+				"id": "42", "name": name, "status": "active",
+				"is_default": false, "node_count": 0,
+				"created_at": "2025-06-01T00:00:00Z", "updated_at": "2025-06-01T00:00:00Z", "version": "1",
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(resp)
+
+		// GET /api/v1/clusters/1 — get
+		case r.URL.Path == "/api/v1/clusters/1" && r.Method == http.MethodGet:
+			resp := map[string]interface{}{
+				"id": "1", "name": "prod-cluster", "status": "active",
+				"is_default": true, "node_count": 3,
+				"created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "version": "1",
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+
+		// GET /api/v1/clusters/1/health/summary — return 404 so get degrades gracefully
+		case r.URL.Path == "/api/v1/clusters/1/health/summary" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"error": "health not available"})
+
+		// PUT /api/v1/clusters/1 — update
+		case r.URL.Path == "/api/v1/clusters/1" && r.Method == http.MethodPut:
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			name := "updated-cluster"
+			if v, ok := body["name"].(string); ok && v != "" {
+				name = v
+			}
+			resp := map[string]interface{}{
+				"id": "1", "name": name, "status": "active",
+				"is_default": false, "node_count": 3,
+				"created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-06-01T00:00:00Z", "version": "2",
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(resp)
+
+		// DELETE /api/v1/clusters/1
+		case r.URL.Path == "/api/v1/clusters/1" && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+
+		// POST /api/v1/clusters/1/default
+		case r.URL.Path == "/api/v1/clusters/1/default" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		}
+	}))
+}
+
+func TestE2EClusterCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EClusterMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, _, err := runStackctl(t, dir, "cluster", "create", "--name", "prod")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "prod")
+}
+
+func TestE2EClusterCreateFromFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EClusterMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	clusterFile := filepath.Join(dir, "cluster.json")
+	require.NoError(t, os.WriteFile(clusterFile, []byte(`{"name":"from-file-cluster"}`), 0o600))
+
+	stdout, _, err := runStackctl(t, dir, "cluster", "create", "--from-file", clusterFile)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "from-file-cluster")
+}
+
+func TestE2EClusterUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EClusterMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, _, err := runStackctl(t, dir, "cluster", "update", "1", "--name", "updated")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "updated")
+}
+
+func TestE2EClusterDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EClusterMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, _, err := runStackctl(t, dir, "cluster", "delete", "1", "--yes")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "1")
+}
+
+func TestE2EClusterSetDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EClusterMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, _, err := runStackctl(t, dir, "cluster", "set-default", "1")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "1")
+}
+

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -1856,6 +1856,5 @@ func TestE2EClusterSetDefault(t *testing.T) {
 
 	stdout, _, err := runStackctl(t, dir, "cluster", "set-default", "1")
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "1")
+	assert.Contains(t, stdout, "set as default")
 }
-

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -1,0 +1,316 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clusterMockState holds mutable state for the cluster mock server.
+type clusterMockState struct {
+	mu       sync.Mutex
+	nextID   uint
+	clusters map[string]*types.Cluster
+}
+
+func newClusterMockState() *clusterMockState {
+	return &clusterMockState{
+		nextID:   1,
+		clusters: make(map[string]*types.Cluster),
+	}
+}
+
+func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		// POST /api/v1/clusters — create
+		case r.URL.Path == "/api/v1/clusters" && r.Method == http.MethodPost:
+			var cluster types.Cluster
+			if err := json.NewDecoder(r.Body).Decode(&cluster); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+				return
+			}
+			state.mu.Lock()
+			cluster.ID = fmt.Sprintf("%d", state.nextID)
+			state.nextID++
+			cluster.Status = "active"
+			cluster.CreatedAt = time.Now()
+			cluster.UpdatedAt = time.Now()
+			cluster.Version = "1"
+			state.clusters[cluster.ID] = &cluster
+			state.mu.Unlock()
+
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(cluster)
+
+		// GET /api/v1/clusters — list
+		case r.URL.Path == "/api/v1/clusters" && r.Method == http.MethodGet:
+			state.mu.Lock()
+			data := make([]types.Cluster, 0, len(state.clusters))
+			for _, cl := range state.clusters {
+				data = append(data, *cl)
+			}
+			state.mu.Unlock()
+
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(data)
+
+		default:
+			// Parse /api/v1/clusters/<id>[/<action>]
+			trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/clusters/")
+			if trimmed == r.URL.Path {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+				return
+			}
+			parts := strings.Split(trimmed, "/")
+			var id, action string
+			switch len(parts) {
+			case 1:
+				id = parts[0]
+			case 2:
+				id = parts[0]
+				action = parts[1]
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+				return
+			}
+			if id == "" {
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+				return
+			}
+
+			state.mu.Lock()
+			cl, exists := state.clusters[id]
+			state.mu.Unlock()
+
+			switch {
+			// GET /api/v1/clusters/:id
+			case action == "" && r.Method == http.MethodGet:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				state.mu.Lock()
+				copy := *cl
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(copy)
+
+			// PUT /api/v1/clusters/:id
+			case action == "" && r.Method == http.MethodPut:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				var req types.UpdateClusterRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+					return
+				}
+				state.mu.Lock()
+				if req.Name != nil {
+					cl.Name = *req.Name
+				}
+				if req.Description != nil {
+					cl.Description = *req.Description
+				}
+				if req.IsDefault != nil {
+					cl.IsDefault = *req.IsDefault
+				}
+				copy := *cl
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(copy)
+
+			// DELETE /api/v1/clusters/:id
+			case action == "" && r.Method == http.MethodDelete:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				state.mu.Lock()
+				delete(state.clusters, id)
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
+
+			// POST /api/v1/clusters/:id/default
+			case action == "default" && r.Method == http.MethodPost:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				state.mu.Lock()
+				for _, other := range state.clusters {
+					other.IsDefault = false
+				}
+				cl.IsDefault = true
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+			}
+		}
+	}))
+}
+
+// strPtr returns a pointer to the provided string value.
+func strPtr(s string) *string { v := s; return &v }
+
+func TestClusterWorkflow_CreateListSetDefaultDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	// 1. Create
+	created, err := c.CreateCluster(&types.CreateClusterRequest{Name: "prod-cluster"})
+	require.NoError(t, err)
+	assert.Equal(t, "prod-cluster", created.Name)
+	assert.NotEmpty(t, created.ID)
+	id := created.ID
+
+	// 2. List — length 1, name matches
+	clusters, err := c.ListClusters()
+	require.NoError(t, err)
+	assert.Len(t, clusters, 1)
+	assert.Equal(t, "prod-cluster", clusters[0].Name)
+
+	// 3. Get by ID
+	got, err := c.GetCluster(id)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-cluster", got.Name)
+
+	// 4. Set default
+	require.NoError(t, c.SetDefaultCluster(id))
+
+	// 5. Get again — IsDefault == true
+	got, err = c.GetCluster(id)
+	require.NoError(t, err)
+	assert.True(t, got.IsDefault)
+
+	// 6. Delete
+	require.NoError(t, c.DeleteCluster(id))
+
+	// 7. List — empty
+	clusters, err = c.ListClusters()
+	require.NoError(t, err)
+	assert.Len(t, clusters, 0)
+}
+
+func TestClusterWorkflow_UpdateMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	// 1. Create
+	created, err := c.CreateCluster(&types.CreateClusterRequest{Name: "dev-cluster"})
+	require.NoError(t, err)
+	id := created.ID
+
+	// 2. Update name
+	updated, err := c.UpdateCluster(id, &types.UpdateClusterRequest{Name: strPtr("dev-cluster-v2")})
+	require.NoError(t, err)
+	assert.Equal(t, "dev-cluster-v2", updated.Name)
+
+	// 3. Get — verify persisted
+	got, err := c.GetCluster(id)
+	require.NoError(t, err)
+	assert.Equal(t, "dev-cluster-v2", got.Name)
+}
+
+func TestClusterWorkflow_DeleteNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	err := c.DeleteCluster("9999")
+	assert.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "not found")
+}
+
+func TestClusterWorkflow_MultipleSetDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	// Create cluster-A
+	clusterA, err := c.CreateCluster(&types.CreateClusterRequest{Name: "cluster-a"})
+	require.NoError(t, err)
+	idA := clusterA.ID
+
+	// Create cluster-B
+	clusterB, err := c.CreateCluster(&types.CreateClusterRequest{Name: "cluster-b"})
+	require.NoError(t, err)
+	idB := clusterB.ID
+
+	// Set A as default
+	require.NoError(t, c.SetDefaultCluster(idA))
+	gotA, err := c.GetCluster(idA)
+	require.NoError(t, err)
+	assert.True(t, gotA.IsDefault)
+
+	// Set B as default — server unsets A
+	require.NoError(t, c.SetDefaultCluster(idB))
+	gotB, err := c.GetCluster(idB)
+	require.NoError(t, err)
+	assert.True(t, gotB.IsDefault)
+
+	gotA, err = c.GetCluster(idA)
+	require.NoError(t, err)
+	assert.False(t, gotA.IsDefault)
+}

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -40,11 +40,15 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 		switch {
 		// POST /api/v1/clusters — create
 		case r.URL.Path == "/api/v1/clusters" && r.Method == http.MethodPost:
-			var cluster types.Cluster
-			if err := json.NewDecoder(r.Body).Decode(&cluster); err != nil {
+			var createReq types.CreateClusterRequest
+			if err := json.NewDecoder(r.Body).Decode(&createReq); err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
 				return
+			}
+			cluster := types.Cluster{
+				Name:        createReq.Name,
+				Description: createReq.Description,
 			}
 			state.mu.Lock()
 			cluster.ID = fmt.Sprintf("%d", state.nextID)

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/omattsson/stackctl/cli/cmd"
 	"github.com/omattsson/stackctl/cli/pkg/client"
 	"github.com/omattsson/stackctl/cli/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -313,4 +315,69 @@ func TestClusterWorkflow_MultipleSetDefault(t *testing.T) {
 	gotA, err = c.GetCluster(idA)
 	require.NoError(t, err)
 	assert.False(t, gotA.IsDefault)
+}
+
+// TestClusterCobra_CreateListSetDefaultDelete drives the actual Cobra commands
+// in-process to validate flag parsing, output formatting, and confirmation
+// behavior across the full create → list → set-default → delete lifecycle.
+// NOT parallel: drives cmd package globals (rootCmd, printer).
+func TestClusterCobra_CreateListSetDefaultDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+
+	// ── create ──────────────────────────────────────────────────────────────
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "create", "--name", "cobra-prod"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "cobra-prod")
+
+	// ── list ─────────────────────────────────────────────────────────────────
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "list"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "cobra-prod")
+
+	// determine the created cluster's ID from server state
+	state.mu.Lock()
+	var createdID string
+	for id := range state.clusters {
+		createdID = id
+	}
+	state.mu.Unlock()
+	require.NotEmpty(t, createdID)
+
+	// ── set-default ──────────────────────────────────────────────────────────
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "set-default", createdID})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "set as default")
+
+	state.mu.Lock()
+	isDefault := state.clusters[createdID].IsDefault
+	state.mu.Unlock()
+	assert.True(t, isDefault)
+
+	// ── delete (--yes skips confirmation prompt) ─────────────────────────────
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "delete", createdID, "--yes"})
+	require.NoError(t, cmd.Execute())
+
+	state.mu.Lock()
+	_, exists := state.clusters[createdID]
+	state.mu.Unlock()
+	assert.False(t, exists)
 }


### PR DESCRIPTION
Closes #64

## Changes

### Types (`cli/pkg/types/types.go`)
- `CreateClusterRequest` — 13 fields (no `RegistryPassword`; secret managed server-side)
- `UpdateClusterRequest` — same fields as pointer types for selective patching

### Client (`cli/pkg/client/client.go`)
- `CreateCluster` → `POST /api/v1/clusters`
- `UpdateCluster` → `PUT /api/v1/clusters/:id`
- `DeleteCluster` → `DELETE /api/v1/clusters/:id`
- `SetDefaultCluster` → `POST /api/v1/clusters/:id/default` (204 No Content)

### Commands (`cli/cmd/cluster.go`)
- `cluster create` — `--name`, `--description`, `--kubeconfig-data`, `--kubeconfig-path`, `--from-file` (JSON/YAML with path-traversal guard)
- `cluster update` — same flags + `--default`; uses `cmd.Flags().Changed()` for selective update; requires at least one flag
- `cluster delete` — `--yes`, `--dry-run`; uses `deleteByID` + `confirmAction`
- `cluster set-default` — prints confirmation message

### Tests
- `cli/cmd/cluster_test.go` — all 4 output modes (table/JSON/YAML/quiet) + error paths + path-traversal guard for create and update
- `cli/pkg/client/client_test.go` — success + error cases for all 4 new client methods
- `cli/test/integration/cluster_integration_test.go` — round-trip workflow tests
- `cli/test/e2e/cli_e2e_test.go` — binary-level E2E tests for all new commands