### PR TITLE
feat(cluster): health/test-connection/utilization commands

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,80 @@
+# CodeRabbit configuration for stackctl
+# Docs: https://docs.coderabbit.ai/reference/yaml-config
+
+language: en-US
+
+reviews:
+  # Require review on every push (not just the first commit)
+  request_changes_workflow: false
+
+  # Pull in the project instruction files so CodeRabbit understands
+  # project-specific conventions before commenting.
+  path_instructions:
+    - path: "cli/cmd/**"
+      instructions: |
+        Follow the rules in .github/instructions/commands.instructions.md.
+        Key points:
+        - All commands use RunE + SilenceUsage: true
+        - --quiet outputs identifiers one per line via printer.PrintIDs or fmt.Fprintln(printer.Writer, ...)
+          before the format switch. Documented quiet-mode exceptions (not numeric IDs):
+            orphaned list → namespace names
+            cluster nodes → node names
+            cluster namespaces → namespace names
+            cluster utilization → namespace names
+            cluster health → derived status label (healthy/degraded/unknown)
+            cluster test-connection → connection status string (success/error)
+        - Destructive commands require --yes flag and stderr confirmation prompt
+        - All API calls go through pkg/client via newClient()
+        - parseID() for sub-resource IDs; resolveStackID() for stack-instance commands
+
+    - path: "cli/pkg/client/**"
+      instructions: |
+        Follow the rules in .github/instructions/client.instructions.md.
+        Key points:
+        - Every public method has a TSDoc-style Go doc comment with @see HTTP verb + route
+        - Non-2xx responses are returned as *APIError (decoded from {"error":"..."} body)
+        - The do() method handles all non-2xx uniformly; endpoint-specific structs are
+          only populated on 200 responses
+
+    - path: "cli/pkg/output/**"
+      instructions: |
+        Follow the rules in .github/instructions/output.instructions.md.
+        Key points:
+        - printer.Quiet is a package-level var reset by ResetFlagsForTest() in tests
+        - PrintIDs outputs identifiers one per line with no headers
+        - Table output uses tabwriter; JSON/YAML use encoding/json and gopkg.in/yaml.v3
+
+    - path: "cli/pkg/config/**"
+      instructions: |
+        Follow the rules in .github/instructions/config.instructions.md.
+
+    - path: "cli/**_test.go"
+      instructions: |
+        Follow the rules in .github/instructions/tests.instructions.md.
+        Key points:
+        - cmd/ tests must NOT use t.Parallel() (mutate package-level globals like printer.Quiet)
+        - pkg/ tests should use t.Parallel() on both parent and subtests
+        - Use httptest.NewServer for API mocking — never call real APIs in unit tests
+        - Quiet-mode tests must assert names/identifiers only and assert.NotContains for
+          table headers (NAME, STATUS, etc.)
+        - Table-output tests assert header presence; JSON/YAML tests unmarshal and check fields
+
+  # Enable all severity levels
+  high_level_summary: true
+  poem: false
+  review_status: true
+
+  # Auto-summarise what changed
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  # Instruct CodeRabbit to check against the project's coding conventions
+  finishing_touches:
+    docstrings:
+      enabled: true
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,6 +48,18 @@ reviews:
       instructions: |
         Follow the rules in .github/instructions/config.instructions.md.
 
+    - path: "cli/pkg/types/**"
+      instructions: |
+        Follow the rules in .github/instructions/types.instructions.md.
+        Key points:
+        - Every field must have both json: and yaml: struct tags
+        - All ID fields are string, not int/uint
+        - Resource structs embed Base; request/response-only structs do not
+        - Update request structs use pointer fields for optional fields
+        - Every exported type must have a godoc comment stating the endpoint it corresponds to
+          and when fields are populated vs zero-valued (especially status/error fields)
+        - Structs only populated on HTTP 200 must state that explicitly in the docstring
+
     - path: "cli/**_test.go"
       instructions: |
         Follow the rules in .github/instructions/tests.instructions.md.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,8 @@
 language: en-US
 
 reviews:
-  # Require review on every push (not just the first commit)
+  # Controls auto-approval behavior after requested changes or failing checks are
+  # resolved (true enables the auto-approval workflow).
   request_changes_workflow: false
 
   # Pull in the project instruction files so CodeRabbit understands

--- a/.github/instructions/commands.instructions.md
+++ b/.github/instructions/commands.instructions.md
@@ -32,6 +32,13 @@ default:
 
 - `--quiet` must output only numeric IDs, one per line
 - Commands without numeric IDs (like `git branches`) should skip quiet mode handling
+- **Documented exceptions** (print stable identifiers other than numeric IDs):
+  - `orphaned list` → prints namespace names
+  - `cluster nodes <id>` → prints node names via `printer.PrintIDs`
+  - `cluster namespaces <id>` → prints namespace names via `printer.PrintIDs`
+  - `cluster utilization <id>` → prints namespace names via `printer.PrintIDs`
+  - `cluster health <id>` → prints the derived status label (`healthy`/`degraded`/`unknown`) via `fmt.Fprintln(printer.Writer, deriveHealthStatus(health))`
+  - `cluster test-connection <id>` → prints the connection status string (`success`/`error`) via `fmt.Fprintln(printer.Writer, result.Status)`
 
 ## Destructive Operations
 Commands that delete or clean resources must:

--- a/.github/instructions/commands.instructions.md
+++ b/.github/instructions/commands.instructions.md
@@ -38,7 +38,7 @@ default:
   - `cluster namespaces <id>` → prints namespace names via `printer.PrintIDs`
   - `cluster utilization <id>` → prints namespace names via `printer.PrintIDs`
   - `cluster health <id>` → prints the derived status label (`healthy`/`degraded`/`unknown`) via `fmt.Fprintln(printer.Writer, deriveHealthStatus(health))`
-  - `cluster test-connection <id>` → prints the connection status string (`success`/`error`) via `fmt.Fprintln(printer.Writer, result.Status)`
+  - `cluster test-connection <id>` → prints `result.Status` (only on 2xx responses; non-2xx surfaces as an `APIError` command error, nothing is printed to stdout) via `fmt.Fprintln(printer.Writer, result.Status)`
 
 ## Destructive Operations
 Commands that delete or clean resources must:

--- a/.github/instructions/output.instructions.md
+++ b/.github/instructions/output.instructions.md
@@ -14,6 +14,13 @@ Every formatter MUST handle all four modes consistently:
 - `yaml` — `gopkg.in/yaml.v3`, full structure
 - `quiet` — identifiers only, one per line, no headers, no color
 
+  Most commands print numeric IDs. Documented exceptions that print other stable identifiers:
+  - `orphaned list`, `cluster namespaces` → namespace names
+  - `cluster nodes` → node names
+  - `cluster utilization` → namespace names from the utilization payload
+  - `cluster health` → derived status label (`healthy`/`degraded`/`unknown`)
+  - `cluster test-connection` → connection status string (`success`/`error`)
+
 `--quiet` is checked first and short-circuits the format switch. Quiet output goes to `printer.Writer` (which Cobra sets to the command's stdout).
 
 ## Color

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -35,6 +35,11 @@ When testing `registerPlugins()`, set up an isolated `PATH` pointing to a `t.Tem
 
 ## Coverage Requirements
 - Test all output modes: table, JSON, YAML, quiet
+  - **Quiet tests**: set `printer.Quiet = true`, assert the expected identifiers/labels are
+    present (one per line), and use `assert.NotContains` to verify table headers (`NAME`,
+    `STATUS`, `NAMESPACE`, etc.) are absent
+  - **Table tests**: assert header presence and key column values
+  - **JSON/YAML tests**: unmarshal the buffer and assert on struct fields
 - Test error cases: API errors (401, 404, 500), invalid input
 - Test flag parsing and validation
 - Test confirmation prompt behavior (yes/no/--yes flag)
@@ -47,3 +52,22 @@ Use `setupStackTestCmd(t, apiURL)` or equivalent helper that:
 3. Registers cleanup to restore defaults (`cfg`, `printer`, all `flag*` globals)
 
 Because `cmd/` tests mutate package-level globals, they MUST NOT use `t.Parallel()` — even in subtests. Helpers should snapshot and restore globals via `t.Cleanup()`.
+
+## E2E Tests (`cli/test/e2e/`)
+E2E tests build and invoke the actual `stackctl` binary. Rules:
+- `TestMain` builds the binary into a temp dir before running any test, and removes it after.
+- Every test calls `t.Skip()` when `testing.Short()` is true — they are excluded from `go test ./... -short`.
+- Use `runStackctl(t, configDir, args...)` / `runStackctlWithStdin(...)` helpers — never call `exec.Command` directly in individual tests.
+- Inject an isolated config dir via `STACKCTL_CONFIG_DIR` env var so tests don't touch `~/.stackmanager`.
+- Use `httptest.NewServer` for the mock API server; the server URL is passed via `--api-url`.
+- Assert on stdout/stderr strings and `err` (nil means exit 0; non-nil means non-zero exit).
+- Do NOT use `t.Parallel()` — binary builds and package-global `binaryPath` are not concurrency-safe.
+
+## Live Tests (`cli/test/live/`)
+Live tests call a real running backend. Rules:
+- File-level build tag: `//go:build live` — they are never compiled in normal `go test ./...` runs.
+- Run with: `go test -tags live ./test/live/ -v`
+- Require env vars `STACKCTL_LIVE_USER` and `STACKCTL_LIVE_PASS`; skip (not fail) if unset.
+- Optional `STACKCTL_LIVE_URL`; defaults to `http://localhost:8081`.
+- The `newLiveClient(t)` helper does a connectivity check and calls `t.Skip()` if the backend is unreachable — never let live tests fail due to infrastructure absence.
+- Do not add live tests to CI pipelines — they are developer opt-in only.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -66,7 +66,7 @@ E2E tests build and invoke the actual `stackctl` binary. Rules:
 ## Live Tests (`cli/test/live/`)
 Live tests call a real running backend. Rules:
 - File-level build tag: `//go:build live` — they are never compiled in normal `go test ./...` runs.
-- Run with: `go test -tags live ./test/live/ -v`
+- Run with: `cd cli && go test -tags live ./test/live/ -v`
 - Require env vars `STACKCTL_LIVE_USER` and `STACKCTL_LIVE_PASS`; skip (not fail) if unset.
 - Optional `STACKCTL_LIVE_URL`; defaults to `http://localhost:8081`.
 - The `newLiveClient(t)` helper does a connectivity check and calls `t.Skip()` if the backend is unreachable — never let live tests fail due to infrastructure absence.

--- a/.github/instructions/types.instructions.md
+++ b/.github/instructions/types.instructions.md
@@ -1,0 +1,59 @@
+---
+applyTo: "cli/pkg/types/**"
+---
+
+# Types Package Conventions
+
+## Purpose
+`cli/pkg/types` is the client-side contract layer — structs that mirror the backend API's JSON response shapes. No business logic belongs here.
+
+## Struct Rules
+
+### Tags
+Every field MUST have both `json:` and `yaml:` struct tags. Omit-empty where the field is optional in the API response:
+```go
+Name   string `json:"name" yaml:"name"`             // required in response
+Region string `json:"region,omitempty" yaml:"region,omitempty"` // optional
+```
+
+### IDs
+All ID fields are `string`, not `int` or `uint`. The backend uses string IDs in JSON responses. Never convert to a numeric type in this package.
+
+### Embedded Base
+Resource structs that correspond to backend entities embed `Base`:
+```go
+type Cluster struct {
+    Base
+    Name string `json:"name" yaml:"name"`
+    // ...
+}
+```
+Request/response-only structs (e.g. `CreateClusterRequest`, `LoginResponse`) do NOT embed `Base`.
+
+### Update Requests
+Update request structs use pointer fields for all optional fields so that only non-nil fields are marshaled:
+```go
+type UpdateFooRequest struct {
+    Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+```
+
+### Docstrings
+Every exported type MUST have a godoc comment that states:
+1. What API endpoint(s) it corresponds to
+2. For response types: when a field is populated vs. zero-valued (especially for status/error fields)
+3. For types that are only populated on a specific HTTP status code (e.g. 200 only), state that explicitly
+
+```go
+// ClusterTestConnectionResult is the response shape of
+// POST /api/v1/clusters/:id/test. On success Status == "success". On an
+// unreachable cluster the backend returns a non-2xx response that the client
+// surfaces as an APIError; this struct is only populated on 200 responses.
+type ClusterTestConnectionResult struct { ... }
+```
+
+## What Does NOT Belong Here
+- No constants for status strings (they live in `cmd/` where they are used for comparison or output)
+- No constructor functions
+- No methods that call `pkg/client`
+- No formatting or display logic

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -719,6 +719,11 @@ var clusterTestConnectionCmd = &cobra.Command{
 			return err
 		}
 
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, result.Status)
+			return nil
+		}
+
 		switch printer.Format {
 		case output.FormatJSON:
 			return printer.PrintJSON(result)
@@ -752,6 +757,11 @@ var clusterHealthCmd = &cobra.Command{
 		health, err := c.GetClusterHealth(id)
 		if err != nil {
 			return err
+		}
+
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, deriveHealthStatus(health))
+			return nil
 		}
 
 		switch printer.Format {

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -803,6 +803,15 @@ var clusterNodesCmd = &cobra.Command{
 			return err
 		}
 
+		if printer.Quiet {
+			names := make([]string, len(nodes))
+			for i, n := range nodes {
+				names[i] = n.Name
+			}
+			printer.PrintIDs(names)
+			return nil
+		}
+
 		switch printer.Format {
 		case output.FormatJSON:
 			return printer.PrintJSON(nodes)
@@ -845,6 +854,15 @@ var clusterNamespacesCmd = &cobra.Command{
 			return err
 		}
 
+		if printer.Quiet {
+			names := make([]string, len(namespaces))
+			for i, n := range namespaces {
+				names[i] = n.Name
+			}
+			printer.PrintIDs(names)
+			return nil
+		}
+
 		switch printer.Format {
 		case output.FormatJSON:
 			return printer.PrintJSON(namespaces)
@@ -883,6 +901,15 @@ var clusterUtilizationCmd = &cobra.Command{
 		util, err := c.GetClusterUtilization(id)
 		if err != nil {
 			return err
+		}
+
+		if printer.Quiet {
+			names := make([]string, len(util.Namespaces))
+			for i, ns := range util.Namespaces {
+				names[i] = ns.Namespace
+			}
+			printer.PrintIDs(names)
+			return nil
 		}
 
 		switch printer.Format {

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -873,7 +873,7 @@ var clusterNamespacesCmd = &cobra.Command{
 			rows := make([][]string, len(namespaces))
 			for i, n := range namespaces {
 				created := ""
-				if !n.CreatedAt.IsZero() {
+				if n.CreatedAt != nil {
 					created = n.CreatedAt.UTC().Format("2006-01-02 15:04:05")
 				}
 				rows[i] = []string{n.Name, printer.StatusColor(n.Phase), created}

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -719,11 +719,6 @@ var clusterTestConnectionCmd = &cobra.Command{
 			return err
 		}
 
-		if printer.Quiet {
-			fmt.Fprintln(printer.Writer, result.Status)
-			return nil
-		}
-
 		switch printer.Format {
 		case output.FormatJSON:
 			return printer.PrintJSON(result)
@@ -757,11 +752,6 @@ var clusterHealthCmd = &cobra.Command{
 		health, err := c.GetClusterHealth(id)
 		if err != nil {
 			return err
-		}
-
-		if printer.Quiet {
-			fmt.Fprintln(printer.Writer, deriveHealthStatus(health))
-			return nil
 		}
 
 		switch printer.Format {
@@ -801,15 +791,6 @@ var clusterNodesCmd = &cobra.Command{
 		nodes, err := c.GetClusterNodes(id)
 		if err != nil {
 			return err
-		}
-
-		if printer.Quiet {
-			names := make([]string, len(nodes))
-			for i, n := range nodes {
-				names[i] = n.Name
-			}
-			printer.PrintIDs(names)
-			return nil
 		}
 
 		switch printer.Format {
@@ -854,15 +835,6 @@ var clusterNamespacesCmd = &cobra.Command{
 			return err
 		}
 
-		if printer.Quiet {
-			names := make([]string, len(namespaces))
-			for i, n := range namespaces {
-				names[i] = n.Name
-			}
-			printer.PrintIDs(names)
-			return nil
-		}
-
 		switch printer.Format {
 		case output.FormatJSON:
 			return printer.PrintJSON(namespaces)
@@ -901,15 +873,6 @@ var clusterUtilizationCmd = &cobra.Command{
 		util, err := c.GetClusterUtilization(id)
 		if err != nil {
 			return err
-		}
-
-		if printer.Quiet {
-			names := make([]string, len(util.Namespaces))
-			for i, ns := range util.Namespaces {
-				names[i] = ns.Namespace
-			}
-			printer.PrintIDs(names)
-			return nil
 		}
 
 		switch printer.Format {

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -392,7 +392,6 @@ Examples:
 	},
 }
 
-// printCluster renders a single cluster in the configured output format.
 // deriveHealthStatus collapses the cluster health summary into a single status
 // label suitable for the table/quiet output modes. `unknown` covers the case
 // where no nodes were reported (registry hasn't seen any, or the cluster is
@@ -408,6 +407,7 @@ func deriveHealthStatus(h *types.ClusterHealthSummary) string {
 	}
 }
 
+// printCluster renders a single cluster in the configured output format.
 func printCluster(cluster *types.Cluster) error {
 	if printer.Quiet {
 		fmt.Fprintln(printer.Writer, cluster.ID)

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -153,20 +153,18 @@ Examples:
 				{Key: "Nodes", Value: strconv.Itoa(cluster.NodeCount)},
 			}
 			if health != nil {
-				readyStatus := "healthy"
-				if health.ReadyNodeCount < health.NodeCount {
-					readyStatus = "degraded"
-				}
 				fields = append(fields,
-					output.KeyValue{Key: "Health", Value: printer.StatusColor(readyStatus)},
+					output.KeyValue{Key: "Health Status", Value: printer.StatusColor(deriveHealthStatus(health))},
 					output.KeyValue{Key: "Ready Nodes", Value: fmt.Sprintf("%d/%d", health.ReadyNodeCount, health.NodeCount)},
-					output.KeyValue{Key: "Total CPU", Value: health.TotalCPU},
-					output.KeyValue{Key: "Total Memory", Value: health.TotalMemory},
+					output.KeyValue{Key: "CPU Allocatable", Value: health.AllocatableCPU},
+					output.KeyValue{Key: "CPU Total", Value: health.TotalCPU},
+					output.KeyValue{Key: "Memory Allocatable", Value: health.AllocatableMemory},
+					output.KeyValue{Key: "Memory Total", Value: health.TotalMemory},
 					output.KeyValue{Key: "Namespaces", Value: strconv.Itoa(health.NamespaceCount)},
 				)
 			} else {
 				fields = append(fields,
-					output.KeyValue{Key: "Health", Value: "unavailable"},
+					output.KeyValue{Key: "Health Status", Value: "unavailable"},
 				)
 			}
 			return printer.PrintSingle(cluster, fields)
@@ -395,6 +393,21 @@ Examples:
 }
 
 // printCluster renders a single cluster in the configured output format.
+// deriveHealthStatus collapses the cluster health summary into a single status
+// label suitable for the table/quiet output modes. `unknown` covers the case
+// where no nodes were reported (registry hasn't seen any, or the cluster is
+// brand new) — distinct from `degraded`, which implies known-but-bad.
+func deriveHealthStatus(h *types.ClusterHealthSummary) string {
+	switch {
+	case h == nil || h.NodeCount == 0:
+		return "unknown"
+	case h.ReadyNodeCount == h.NodeCount:
+		return "healthy"
+	default:
+		return "degraded"
+	}
+}
+
 func printCluster(cluster *types.Cluster) error {
 	if printer.Quiet {
 		fmt.Fprintln(printer.Writer, cluster.ID)
@@ -684,13 +697,12 @@ var clusterSetDefaultCmd = &cobra.Command{
 	},
 }
 
-var clusterTestConnectionCmd = &cobra.Command{
-	Use:   "test-connection <id>",
-	Short: "Test connectivity to a cluster",
-	Long: `Test connectivity to a registered cluster.
+// --- Health & connectivity ---
 
-Examples:
-  stackctl cluster test-connection 1`,
+var clusterTestConnectionCmd = &cobra.Command{
+	Use:          "test-connection <id>",
+	Short:        "Test connectivity to a cluster's API server",
+	Long:         "Issue a lightweight call to the cluster's API server to verify it is reachable.",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -698,48 +710,39 @@ Examples:
 		if err != nil {
 			return err
 		}
-
 		c, err := newClient()
 		if err != nil {
 			return err
 		}
-
-		resp, err := c.TestClusterConnection(id)
+		result, err := c.TestClusterConnection(id)
 		if err != nil {
 			return err
 		}
 
 		if printer.Quiet {
-			fmt.Fprintln(printer.Writer, resp.Status)
+			fmt.Fprintln(printer.Writer, result.Status)
 			return nil
 		}
 
 		switch printer.Format {
 		case output.FormatJSON:
-			return printer.PrintJSON(resp)
+			return printer.PrintJSON(result)
 		case output.FormatYAML:
-			return printer.PrintYAML(resp)
+			return printer.PrintYAML(result)
 		default:
-			fields := []output.KeyValue{
-				{Key: "Status", Value: printer.StatusColor(resp.Status)},
-				{Key: "Message", Value: resp.Message},
-			}
-			if resp.ServerVersion != "" {
-				fields = append(fields, output.KeyValue{Key: "Server Version", Value: resp.ServerVersion})
-			}
-			return printer.PrintSingle(resp, fields)
+			return printer.PrintSingle(result, []output.KeyValue{
+				{Key: "Status", Value: printer.StatusColor(result.Status)},
+				{Key: "Message", Value: result.Message},
+				{Key: "Server Version", Value: result.ServerVersion},
+			})
 		}
 	},
 }
 
 var clusterHealthCmd = &cobra.Command{
-	Use:   "health <id>",
-	Short: "Show health summary for a cluster",
-	Long: `Show health summary (node count, CPU, memory) for a cluster.
-
-Examples:
-  stackctl cluster health 1
-  stackctl cluster health 1 -o json`,
+	Use:          "health <id>",
+	Short:        "Show the cluster health summary",
+	Long:         "Show node counts, ready-node ratio, and aggregate CPU/memory capacity for the cluster.",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -747,19 +750,17 @@ Examples:
 		if err != nil {
 			return err
 		}
-
 		c, err := newClient()
 		if err != nil {
 			return err
 		}
-
 		health, err := c.GetClusterHealth(id)
 		if err != nil {
 			return err
 		}
 
 		if printer.Quiet {
-			fmt.Fprintln(printer.Writer, id)
+			fmt.Fprintln(printer.Writer, deriveHealthStatus(health))
 			return nil
 		}
 
@@ -769,33 +770,23 @@ Examples:
 		case output.FormatYAML:
 			return printer.PrintYAML(health)
 		default:
-			readyStatus := "healthy"
-			if health.ReadyNodeCount < health.NodeCount {
-				readyStatus = "degraded"
-			}
-			fields := []output.KeyValue{
-				{Key: "Status", Value: printer.StatusColor(readyStatus)},
-				{Key: "Nodes", Value: strconv.Itoa(health.NodeCount)},
-				{Key: "Ready Nodes", Value: strconv.Itoa(health.ReadyNodeCount)},
-				{Key: "Total CPU", Value: health.TotalCPU},
-				{Key: "Allocatable CPU", Value: health.AllocatableCPU},
-				{Key: "Total Memory", Value: health.TotalMemory},
-				{Key: "Allocatable Memory", Value: health.AllocatableMemory},
+			return printer.PrintSingle(health, []output.KeyValue{
+				{Key: "Health Status", Value: printer.StatusColor(deriveHealthStatus(health))},
+				{Key: "Ready Nodes", Value: fmt.Sprintf("%d/%d", health.ReadyNodeCount, health.NodeCount)},
+				{Key: "CPU Allocatable", Value: health.AllocatableCPU},
+				{Key: "CPU Total", Value: health.TotalCPU},
+				{Key: "Memory Allocatable", Value: health.AllocatableMemory},
+				{Key: "Memory Total", Value: health.TotalMemory},
 				{Key: "Namespaces", Value: strconv.Itoa(health.NamespaceCount)},
-			}
-			return printer.PrintSingle(health, fields)
+			})
 		}
 	},
 }
 
 var clusterNodesCmd = &cobra.Command{
-	Use:   "nodes <id>",
-	Short: "List nodes in a cluster",
-	Long: `List all nodes in a cluster with status, capacity, and pod count.
-
-Examples:
-  stackctl cluster nodes 1
-  stackctl cluster nodes 1 -o json`,
+	Use:          "nodes <id>",
+	Short:        "List nodes in a cluster with their status",
+	Long:         "List per-node health, pod count, and allocatable CPU/memory for the cluster.",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -803,21 +794,21 @@ Examples:
 		if err != nil {
 			return err
 		}
-
 		c, err := newClient()
 		if err != nil {
 			return err
 		}
-
 		nodes, err := c.GetClusterNodes(id)
 		if err != nil {
 			return err
 		}
 
 		if printer.Quiet {
-			for _, n := range nodes {
-				fmt.Fprintln(printer.Writer, n.Name)
+			names := make([]string, len(nodes))
+			for i, n := range nodes {
+				names[i] = n.Name
 			}
+			printer.PrintIDs(names)
 			return nil
 		}
 
@@ -827,15 +818,15 @@ Examples:
 		case output.FormatYAML:
 			return printer.PrintYAML(nodes)
 		default:
-			headers := []string{"NAME", "STATUS", "CPU", "MEMORY", "PODS"}
+			headers := []string{"NAME", "STATUS", "PODS", "CPU", "MEMORY"}
 			rows := make([][]string, len(nodes))
 			for i, n := range nodes {
 				rows[i] = []string{
 					n.Name,
 					printer.StatusColor(n.Status),
-					n.Capacity.CPU,
-					n.Capacity.Memory,
 					strconv.Itoa(n.PodCount),
+					n.Allocatable.CPU,
+					n.Allocatable.Memory,
 				}
 			}
 			return printer.PrintTable(headers, rows)
@@ -844,13 +835,9 @@ Examples:
 }
 
 var clusterNamespacesCmd = &cobra.Command{
-	Use:   "namespaces <id>",
-	Short: "List stack namespaces in a cluster",
-	Long: `List all stack-* namespaces in a cluster.
-
-Examples:
-  stackctl cluster namespaces 1
-  stackctl cluster namespaces 1 -o json`,
+	Use:          "namespaces <id>",
+	Short:        "List stack-* namespaces present in a cluster",
+	Long:         "List namespaces whose names start with stack-, along with their phase and creation time.",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -858,21 +845,21 @@ Examples:
 		if err != nil {
 			return err
 		}
-
 		c, err := newClient()
 		if err != nil {
 			return err
 		}
-
 		namespaces, err := c.GetClusterNamespaces(id)
 		if err != nil {
 			return err
 		}
 
 		if printer.Quiet {
-			for _, ns := range namespaces {
-				fmt.Fprintln(printer.Writer, ns.Name)
+			names := make([]string, len(namespaces))
+			for i, n := range namespaces {
+				names[i] = n.Name
 			}
+			printer.PrintIDs(names)
 			return nil
 		}
 
@@ -884,12 +871,12 @@ Examples:
 		default:
 			headers := []string{"NAME", "PHASE", "CREATED"}
 			rows := make([][]string, len(namespaces))
-			for i, ns := range namespaces {
-				rows[i] = []string{
-					ns.Name,
-					ns.Phase,
-					ns.CreatedAt.Format("2006-01-02 15:04:05"),
+			for i, n := range namespaces {
+				created := ""
+				if !n.CreatedAt.IsZero() {
+					created = n.CreatedAt.UTC().Format("2006-01-02 15:04:05")
 				}
+				rows[i] = []string{n.Name, printer.StatusColor(n.Phase), created}
 			}
 			return printer.PrintTable(headers, rows)
 		}
@@ -897,13 +884,9 @@ Examples:
 }
 
 var clusterUtilizationCmd = &cobra.Command{
-	Use:   "utilization <id>",
-	Short: "Show per-namespace resource utilization for a cluster",
-	Long: `Show CPU, memory, and pod usage per namespace for a cluster.
-
-Examples:
-  stackctl cluster utilization 1
-  stackctl cluster utilization 1 -o json`,
+	Use:          "utilization <id>",
+	Short:        "Show per-namespace resource utilization",
+	Long:         "Show aggregated CPU/memory/pod usage per stack-* namespace in the cluster.",
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -911,19 +894,21 @@ Examples:
 		if err != nil {
 			return err
 		}
-
 		c, err := newClient()
 		if err != nil {
 			return err
 		}
-
 		util, err := c.GetClusterUtilization(id)
 		if err != nil {
 			return err
 		}
 
 		if printer.Quiet {
-			fmt.Fprintln(printer.Writer, id)
+			names := make([]string, len(util.Namespaces))
+			for i, ns := range util.Namespaces {
+				names[i] = ns.Namespace
+			}
+			printer.PrintIDs(names)
 			return nil
 		}
 
@@ -936,13 +921,17 @@ Examples:
 			headers := []string{"NAMESPACE", "CPU USED", "CPU LIMIT", "MEM USED", "MEM LIMIT", "PODS"}
 			rows := make([][]string, len(util.Namespaces))
 			for i, ns := range util.Namespaces {
+				podCol := strconv.Itoa(ns.PodCount)
+				if ns.PodLimit > 0 {
+					podCol = fmt.Sprintf("%d/%d", ns.PodCount, ns.PodLimit)
+				}
 				rows[i] = []string{
 					ns.Namespace,
 					ns.CPUUsed,
 					ns.CPULimit,
 					ns.MemoryUsed,
 					ns.MemoryLimit,
-					fmt.Sprintf("%d/%d", ns.PodCount, ns.PodLimit),
+					podCol,
 				}
 			}
 			return printer.PrintTable(headers, rows)

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -39,11 +39,11 @@ func sampleClusterHealth() types.ClusterHealthSummary {
 	return types.ClusterHealthSummary{
 		NodeCount:         3,
 		ReadyNodeCount:    3,
-		TotalCPU:          "12",
-		TotalMemory:       "48Gi",
-		AllocatableCPU:    "11.7",
-		AllocatableMemory: "45Gi",
-		NamespaceCount:    7,
+		TotalCPU:          "8",
+		TotalMemory:       "16Gi",
+		AllocatableCPU:    "7",
+		AllocatableMemory: "14Gi",
+		NamespaceCount:    12,
 	}
 }
 
@@ -202,7 +202,8 @@ func TestClusterGetCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "true")
 	assert.Contains(t, out, "healthy")
 	assert.Contains(t, out, "3/3")
-	assert.Contains(t, out, "48Gi")
+	assert.Contains(t, out, "16Gi")
+	assert.Contains(t, out, "14Gi")
 }
 
 func TestClusterGetCmd_HealthUnavailable(t *testing.T) {
@@ -253,7 +254,8 @@ func TestClusterGetCmd_JSONOutput(t *testing.T) {
 	var result map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
 	assert.Contains(t, string(result["cluster"]), "dev-cluster")
-	assert.Contains(t, string(result["health"]), "node_count")
+	assert.Contains(t, string(result["health"]), "ready_node_count")
+	assert.Contains(t, string(result["health"]), "namespace_count")
 }
 
 func TestClusterGetCmd_QuietOutput(t *testing.T) {
@@ -300,7 +302,8 @@ func TestClusterGetCmd_YAMLOutput(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "name: dev-cluster")
-	assert.Contains(t, out, "total_cpu")
+	assert.Contains(t, out, "ready_node_count: 3")
+	assert.Contains(t, out, "namespace_count: 12")
 }
 
 func TestClusterGetCmd_JSONOutput_HealthUnavailable(t *testing.T) {
@@ -1233,68 +1236,24 @@ func TestClusterSetDefaultCmd_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "cluster not found")
 }
 
-// ---------- sample helpers for new types ----------
-
-func sampleTestConnectionResponse() types.TestConnectionResponse {
-	return types.TestConnectionResponse{
-		Status:        "ok",
-		Message:       "Connected successfully",
-		ServerVersion: "v1.28.0",
-	}
-}
-
-func sampleClusterNode() types.ClusterNode {
-	return types.ClusterNode{
-		Name:   "node-1",
-		Status: "ready",
-		Capacity: types.ResourceQuantity{
-			CPU:    "4",
-			Memory: "16Gi",
-			Pods:   "110",
-		},
-		Allocatable: types.ResourceQuantity{
-			CPU:    "3.9",
-			Memory: "15Gi",
-		},
-		PodCount: 12,
-	}
-}
-
-func sampleClusterNamespace() types.ClusterNamespace {
-	return types.ClusterNamespace{
-		Name:      "stack-dev-alice",
-		Phase:     "Active",
-		CreatedAt: time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC),
-	}
-}
-
-func sampleClusterUtilization() types.ClusterUtilization {
-	return types.ClusterUtilization{
-		ClusterID: "1",
-		Namespaces: []types.NamespaceResourceUsage{
-			{
-				Namespace:   "stack-dev-alice",
-				CPUUsed:     "500m",
-				CPULimit:    "2",
-				MemoryUsed:  "256Mi",
-				MemoryLimit: "1Gi",
-				PodCount:    3,
-				PodLimit:    10,
-			},
-		},
-	}
-}
 
 // ---------- cluster test-connection ----------
 
+func sampleTestConnectionResult() types.ClusterTestConnectionResult {
+	return types.ClusterTestConnectionResult{
+		Status:        "success",
+		Message:       "Connection successful",
+		ServerVersion: "v1.29.4",
+	}
+}
+
 func TestClusterTestConnectionCmd_TableOutput(t *testing.T) {
-	resp := sampleTestConnectionResponse()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/clusters/1/test", r.URL.Path)
-		require.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/test", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(sampleTestConnectionResult())
 	}))
 	defer server.Close()
 
@@ -1305,17 +1264,16 @@ func TestClusterTestConnectionCmd_TableOutput(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "Status")
-	assert.Contains(t, out, "ok")
-	assert.Contains(t, out, "Connected successfully")
-	assert.Contains(t, out, "v1.28.0")
+	assert.Contains(t, out, "success")
+	assert.Contains(t, out, "Connection successful")
+	assert.Contains(t, out, "v1.29.4")
 }
 
 func TestClusterTestConnectionCmd_JSONOutput(t *testing.T) {
-	resp := sampleTestConnectionResponse()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(sampleTestConnectionResult())
 	}))
 	defer server.Close()
 
@@ -1325,19 +1283,17 @@ func TestClusterTestConnectionCmd_JSONOutput(t *testing.T) {
 	err := clusterTestConnectionCmd.RunE(clusterTestConnectionCmd, []string{"1"})
 	require.NoError(t, err)
 
-	var result types.TestConnectionResponse
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Equal(t, "ok", result.Status)
-	assert.Equal(t, "Connected successfully", result.Message)
-	assert.Equal(t, "v1.28.0", result.ServerVersion)
+	var got types.ClusterTestConnectionResult
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "success", got.Status)
+	assert.Equal(t, "v1.29.4", got.ServerVersion)
 }
 
 func TestClusterTestConnectionCmd_YAMLOutput(t *testing.T) {
-	resp := sampleTestConnectionResponse()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(sampleTestConnectionResult())
 	}))
 	defer server.Close()
 
@@ -1348,16 +1304,15 @@ func TestClusterTestConnectionCmd_YAMLOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "status: ok")
-	assert.Contains(t, out, "server_version: v1.28.0")
+	assert.Contains(t, out, "status: success")
+	assert.Contains(t, out, "server_version: v1.29.4")
 }
 
 func TestClusterTestConnectionCmd_QuietOutput(t *testing.T) {
-	resp := sampleTestConnectionResponse()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(sampleTestConnectionResult())
 	}))
 	defer server.Close()
 
@@ -1366,27 +1321,14 @@ func TestClusterTestConnectionCmd_QuietOutput(t *testing.T) {
 
 	err := clusterTestConnectionCmd.RunE(clusterTestConnectionCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "ok\n", buf.String())
+	assert.Equal(t, "success\n", buf.String())
 }
 
-func TestClusterTestConnectionCmd_ParseIDError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not reach server")
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterTestConnectionCmd.RunE(clusterTestConnectionCmd, []string{"  "})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must not be empty")
-}
-
-func TestClusterTestConnectionCmd_APIError(t *testing.T) {
+func TestClusterTestConnectionCmd_Unreachable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"status": "error", "message": "Cluster is unreachable"})
 	}))
 	defer server.Close()
 
@@ -1394,19 +1336,17 @@ func TestClusterTestConnectionCmd_APIError(t *testing.T) {
 
 	err := clusterTestConnectionCmd.RunE(clusterTestConnectionCmd, []string{"1"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Internal server error")
 }
 
 // ---------- cluster health ----------
 
 func TestClusterHealthCmd_TableOutput(t *testing.T) {
-	health := sampleClusterHealth()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/clusters/1/health/summary", r.URL.Path)
-		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/health/summary", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(health)
+		json.NewEncoder(w).Encode(sampleClusterHealth())
 	}))
 	defer server.Close()
 
@@ -1416,19 +1356,55 @@ func TestClusterHealthCmd_TableOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "Status")
-	assert.Contains(t, out, "Nodes")
-	assert.Contains(t, out, "3")
-	assert.Contains(t, out, "48Gi")
+	assert.Contains(t, out, "Health Status")
+	assert.Contains(t, out, "healthy")
+	assert.Contains(t, out, "3/3")
+	assert.Contains(t, out, "14Gi")
 	assert.Contains(t, out, "12")
 }
 
-func TestClusterHealthCmd_JSONOutput(t *testing.T) {
-	health := sampleClusterHealth()
+func TestClusterHealthCmd_UnknownWhenZeroNodes(t *testing.T) {
+	zero := types.ClusterHealthSummary{} // NodeCount: 0 — registry hasn't seen any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(health)
+		json.NewEncoder(w).Encode(zero)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "unknown\n", buf.String())
+}
+
+func TestClusterHealthCmd_DegradedWhenSomeNodesNotReady(t *testing.T) {
+	degraded := sampleClusterHealth()
+	degraded.ReadyNodeCount = 2 // 2 of 3 nodes ready
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(degraded)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+
+	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "degraded")
+	assert.Contains(t, out, "2/3")
+}
+
+func TestClusterHealthCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterHealth())
 	}))
 	defer server.Close()
 
@@ -1438,18 +1414,17 @@ func TestClusterHealthCmd_JSONOutput(t *testing.T) {
 	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
 	require.NoError(t, err)
 
-	var result types.ClusterHealthSummary
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Equal(t, 3, result.NodeCount)
-	assert.Equal(t, "48Gi", result.TotalMemory)
+	var got types.ClusterHealthSummary
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, 3, got.NodeCount)
+	assert.Equal(t, 12, got.NamespaceCount)
 }
 
 func TestClusterHealthCmd_YAMLOutput(t *testing.T) {
-	health := sampleClusterHealth()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(health)
+		json.NewEncoder(w).Encode(sampleClusterHealth())
 	}))
 	defer server.Close()
 
@@ -1458,18 +1433,16 @@ func TestClusterHealthCmd_YAMLOutput(t *testing.T) {
 
 	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
 	require.NoError(t, err)
-
 	out := buf.String()
-	assert.Contains(t, out, "node_count: 3")
-	assert.Contains(t, out, "total_memory: 48Gi")
+	assert.Contains(t, out, "ready_node_count: 3")
+	assert.Contains(t, out, "namespace_count: 12")
 }
 
 func TestClusterHealthCmd_QuietOutput(t *testing.T) {
-	health := sampleClusterHealth()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(health)
+		json.NewEncoder(w).Encode(sampleClusterHealth())
 	}))
 	defer server.Close()
 
@@ -1478,71 +1451,73 @@ func TestClusterHealthCmd_QuietOutput(t *testing.T) {
 
 	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "1\n", buf.String())
-}
-
-func TestClusterHealthCmd_ParseIDError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not reach server")
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"  "})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must not be empty")
-}
-
-func TestClusterHealthCmd_APIError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Internal server error")
+	assert.Equal(t, "healthy\n", buf.String())
 }
 
 // ---------- cluster nodes ----------
 
+func sampleClusterNodes() []types.ClusterNodeStatus {
+	return []types.ClusterNodeStatus{
+		{
+			Name: "node-a", Status: "Ready", PodCount: 14,
+			Capacity:    types.ClusterResourceQuantity{CPU: "4", Memory: "8Gi", Pods: "110"},
+			Allocatable: types.ClusterResourceQuantity{CPU: "3800m", Memory: "7Gi"},
+		},
+		{
+			Name: "node-b", Status: "NotReady", PodCount: 0,
+			Capacity:    types.ClusterResourceQuantity{CPU: "4", Memory: "8Gi"},
+			Allocatable: types.ClusterResourceQuantity{CPU: "3800m", Memory: "7Gi"},
+		},
+	}
+}
+
 func TestClusterNodesCmd_TableOutput(t *testing.T) {
-	node := sampleClusterNode()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/clusters/1/health/nodes", r.URL.Path)
-		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/health/nodes", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNode{node})
+		json.NewEncoder(w).Encode(sampleClusterNodes())
 	}))
 	defer server.Close()
 
 	buf := setupClusterTestCmd(t, server.URL)
-
 	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
 	require.NoError(t, err)
 
 	out := buf.String()
 	assert.Contains(t, out, "NAME")
 	assert.Contains(t, out, "STATUS")
-	assert.Contains(t, out, "node-1")
-	assert.Contains(t, out, "ready")
-	assert.Contains(t, out, "4")
-	assert.Contains(t, out, "16Gi")
-	assert.Contains(t, out, "12")
+	assert.Contains(t, out, "PODS")
+	assert.Contains(t, out, "CPU")
+	assert.Contains(t, out, "MEMORY")
+	assert.Contains(t, out, "node-a")
+	assert.Contains(t, out, "node-b")
+	assert.Contains(t, out, "Ready")
+	assert.Contains(t, out, "NotReady")
+	assert.Contains(t, out, "3800m")
 }
 
-func TestClusterNodesCmd_JSONOutput(t *testing.T) {
-	node := sampleClusterNode()
+func TestClusterNodesCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNode{node})
+		json.NewEncoder(w).Encode(sampleClusterNodes())
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "node-a\nnode-b\n", buf.String())
+}
+
+func TestClusterNodesCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterNodes())
 	}))
 	defer server.Close()
 
@@ -1552,19 +1527,17 @@ func TestClusterNodesCmd_JSONOutput(t *testing.T) {
 	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
 	require.NoError(t, err)
 
-	var result []types.ClusterNode
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	require.Len(t, result, 1)
-	assert.Equal(t, "node-1", result[0].Name)
-	assert.Equal(t, "ready", result[0].Status)
+	var got []types.ClusterNodeStatus
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, "node-a", got[0].Name)
 }
 
 func TestClusterNodesCmd_YAMLOutput(t *testing.T) {
-	node := sampleClusterNode()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNode{node})
+		json.NewEncoder(w).Encode(sampleClusterNodes())
 	}))
 	defer server.Close()
 
@@ -1573,91 +1546,65 @@ func TestClusterNodesCmd_YAMLOutput(t *testing.T) {
 
 	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
 	require.NoError(t, err)
-
 	out := buf.String()
-	assert.Contains(t, out, "name: node-1")
-	assert.Contains(t, out, "status: ready")
-}
-
-func TestClusterNodesCmd_QuietOutput(t *testing.T) {
-	n1 := sampleClusterNode()
-	n2 := sampleClusterNode()
-	n2.Name = "node-2"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNode{n1, n2})
-	}))
-	defer server.Close()
-
-	buf := setupClusterTestCmd(t, server.URL)
-	printer.Quiet = true
-
-	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
-	require.NoError(t, err)
-	assert.Equal(t, "node-1\nnode-2\n", buf.String())
-}
-
-func TestClusterNodesCmd_ParseIDError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not reach server")
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"  "})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must not be empty")
-}
-
-func TestClusterNodesCmd_APIError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Internal server error")
+	assert.Contains(t, out, "name: node-a")
+	assert.Contains(t, out, "status: Ready")
 }
 
 // ---------- cluster namespaces ----------
 
+func sampleClusterNamespaces() []types.ClusterNamespace {
+	now := time.Date(2026, 1, 10, 14, 30, 0, 0, time.UTC)
+	return []types.ClusterNamespace{
+		{Name: "stack-prod-web", Phase: "Active", CreatedAt: now},
+		{Name: "stack-dev-api", Phase: "Active", CreatedAt: now},
+	}
+}
+
 func TestClusterNamespacesCmd_TableOutput(t *testing.T) {
-	ns := sampleClusterNamespace()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/clusters/1/namespaces", r.URL.Path)
-		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/namespaces", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNamespace{ns})
+		json.NewEncoder(w).Encode(sampleClusterNamespaces())
 	}))
 	defer server.Close()
 
 	buf := setupClusterTestCmd(t, server.URL)
-
 	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
 	require.NoError(t, err)
 
 	out := buf.String()
 	assert.Contains(t, out, "NAME")
 	assert.Contains(t, out, "PHASE")
-	assert.Contains(t, out, "stack-dev-alice")
+	assert.Contains(t, out, "CREATED")
+	assert.Contains(t, out, "stack-prod-web")
+	assert.Contains(t, out, "stack-dev-api")
 	assert.Contains(t, out, "Active")
-	assert.Contains(t, out, "2025-06-15")
+	assert.Contains(t, out, "2026-01-10 14:30:00")
 }
 
-func TestClusterNamespacesCmd_JSONOutput(t *testing.T) {
-	ns := sampleClusterNamespace()
+func TestClusterNamespacesCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNamespace{ns})
+		json.NewEncoder(w).Encode(sampleClusterNamespaces())
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "stack-prod-web\nstack-dev-api\n", buf.String())
+}
+
+func TestClusterNamespacesCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterNamespaces())
 	}))
 	defer server.Close()
 
@@ -1667,19 +1614,16 @@ func TestClusterNamespacesCmd_JSONOutput(t *testing.T) {
 	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
 	require.NoError(t, err)
 
-	var result []types.ClusterNamespace
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	require.Len(t, result, 1)
-	assert.Equal(t, "stack-dev-alice", result[0].Name)
-	assert.Equal(t, "Active", result[0].Phase)
+	var got []types.ClusterNamespace
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
 }
 
 func TestClusterNamespacesCmd_YAMLOutput(t *testing.T) {
-	ns := sampleClusterNamespace()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNamespace{ns})
+		json.NewEncoder(w).Encode(sampleClusterNamespaces())
 	}))
 	defer server.Close()
 
@@ -1688,69 +1632,29 @@ func TestClusterNamespacesCmd_YAMLOutput(t *testing.T) {
 
 	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
 	require.NoError(t, err)
-
 	out := buf.String()
-	assert.Contains(t, out, "name: stack-dev-alice")
+	assert.Contains(t, out, "name: stack-prod-web")
 	assert.Contains(t, out, "phase: Active")
-}
-
-func TestClusterNamespacesCmd_QuietOutput(t *testing.T) {
-	ns1 := sampleClusterNamespace()
-	ns2 := sampleClusterNamespace()
-	ns2.Name = "stack-prod-bob"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNamespace{ns1, ns2})
-	}))
-	defer server.Close()
-
-	buf := setupClusterTestCmd(t, server.URL)
-	printer.Quiet = true
-
-	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
-	require.NoError(t, err)
-	assert.Equal(t, "stack-dev-alice\nstack-prod-bob\n", buf.String())
-}
-
-func TestClusterNamespacesCmd_ParseIDError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not reach server")
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"  "})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must not be empty")
-}
-
-func TestClusterNamespacesCmd_APIError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Internal server error")
 }
 
 // ---------- cluster utilization ----------
 
+func sampleClusterUtilization() types.ClusterUtilization {
+	return types.ClusterUtilization{
+		ClusterID: "1",
+		Namespaces: []types.NamespaceResourceUsage{
+			{Namespace: "stack-prod", CPUUsed: "1500m", CPULimit: "4", MemoryUsed: "2Gi", MemoryLimit: "8Gi", PodCount: 10, PodLimit: 50},
+			{Namespace: "stack-dev", CPUUsed: "500m", CPULimit: "2", MemoryUsed: "1Gi", MemoryLimit: "4Gi", PodCount: 3},
+		},
+	}
+}
+
 func TestClusterUtilizationCmd_TableOutput(t *testing.T) {
-	util := sampleClusterUtilization()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v1/clusters/1/utilization", r.URL.Path)
-		require.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/utilization", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(util)
+		json.NewEncoder(w).Encode(sampleClusterUtilization())
 	}))
 	defer server.Close()
 
@@ -1762,18 +1666,36 @@ func TestClusterUtilizationCmd_TableOutput(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "NAMESPACE")
 	assert.Contains(t, out, "CPU USED")
-	assert.Contains(t, out, "stack-dev-alice")
-	assert.Contains(t, out, "500m")
-	assert.Contains(t, out, "256Mi")
-	assert.Contains(t, out, "3/10")
+	assert.Contains(t, out, "MEM LIMIT")
+	assert.Contains(t, out, "PODS")
+	assert.Contains(t, out, "stack-prod")
+	assert.Contains(t, out, "1500m")
+	assert.Contains(t, out, "10/50")
+	// stack-dev has no PodLimit — shown as bare PodCount.
+	assert.Contains(t, out, "stack-dev")
 }
 
-func TestClusterUtilizationCmd_JSONOutput(t *testing.T) {
-	util := sampleClusterUtilization()
+func TestClusterUtilizationCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(util)
+		json.NewEncoder(w).Encode(sampleClusterUtilization())
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "stack-prod\nstack-dev\n", buf.String())
+}
+
+func TestClusterUtilizationCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterUtilization())
 	}))
 	defer server.Close()
 
@@ -1783,19 +1705,17 @@ func TestClusterUtilizationCmd_JSONOutput(t *testing.T) {
 	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"1"})
 	require.NoError(t, err)
 
-	var result types.ClusterUtilization
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
-	assert.Equal(t, "1", result.ClusterID)
-	require.Len(t, result.Namespaces, 1)
-	assert.Equal(t, "stack-dev-alice", result.Namespaces[0].Namespace)
+	var got types.ClusterUtilization
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "1", got.ClusterID)
+	assert.Len(t, got.Namespaces, 2)
 }
 
 func TestClusterUtilizationCmd_YAMLOutput(t *testing.T) {
-	util := sampleClusterUtilization()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(util)
+		json.NewEncoder(w).Encode(sampleClusterUtilization())
 	}))
 	defer server.Close()
 
@@ -1804,53 +1724,22 @@ func TestClusterUtilizationCmd_YAMLOutput(t *testing.T) {
 
 	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"1"})
 	require.NoError(t, err)
-
 	out := buf.String()
-	assert.Contains(t, out, "cluster_id: \"1\"")
-	assert.Contains(t, out, "namespace: stack-dev-alice")
+	assert.Contains(t, out, "cluster_id:")
+	assert.Contains(t, out, "namespace: stack-prod")
 }
 
-func TestClusterUtilizationCmd_QuietOutput(t *testing.T) {
-	util := sampleClusterUtilization()
+func TestClusterHealthCmd_NotFound(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(util)
-	}))
-	defer server.Close()
-
-	buf := setupClusterTestCmd(t, server.URL)
-	printer.Quiet = true
-
-	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"1"})
-	require.NoError(t, err)
-	assert.Equal(t, "1\n", buf.String())
-}
-
-func TestClusterUtilizationCmd_ParseIDError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatal("should not reach server")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
 	}))
 	defer server.Close()
 
 	_ = setupClusterTestCmd(t, server.URL)
 
-	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"  "})
+	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"999"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must not be empty")
-}
-
-func TestClusterUtilizationCmd_APIError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	_ = setupClusterTestCmd(t, server.URL)
-
-	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"1"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Internal server error")
+	assert.Contains(t, err.Error(), "cluster not found")
 }

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1308,7 +1308,7 @@ func TestClusterTestConnectionCmd_YAMLOutput(t *testing.T) {
 	assert.Contains(t, out, "server_version: v1.29.4")
 }
 
-func TestClusterTestConnectionCmd_TableOutputIgnoresQuiet(t *testing.T) {
+func TestClusterTestConnectionCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1321,9 +1321,7 @@ func TestClusterTestConnectionCmd_TableOutputIgnoresQuiet(t *testing.T) {
 
 	err := clusterTestConnectionCmd.RunE(clusterTestConnectionCmd, []string{"1"})
 	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "Status")
-	assert.Contains(t, out, "success")
+	assert.Equal(t, "success\n", buf.String())
 }
 
 func TestClusterTestConnectionCmd_Unreachable(t *testing.T) {
@@ -1375,10 +1373,11 @@ func TestClusterHealthCmd_UnknownWhenZeroNodes(t *testing.T) {
 	defer server.Close()
 
 	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
 
 	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Contains(t, buf.String(), "unknown")
+	assert.Equal(t, "unknown\n", buf.String())
 }
 
 func TestClusterHealthCmd_DegradedWhenSomeNodesNotReady(t *testing.T) {
@@ -1439,7 +1438,7 @@ func TestClusterHealthCmd_YAMLOutput(t *testing.T) {
 	assert.Contains(t, out, "namespace_count: 12")
 }
 
-func TestClusterHealthCmd_TableOutputIgnoresQuiet(t *testing.T) {
+func TestClusterHealthCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1452,9 +1451,7 @@ func TestClusterHealthCmd_TableOutputIgnoresQuiet(t *testing.T) {
 
 	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
 	require.NoError(t, err)
-	out := buf.String()
-	assert.Contains(t, out, "Health Status")
-	assert.Contains(t, out, "healthy")
+	assert.Equal(t, "healthy\n", buf.String())
 }
 
 // ---------- cluster nodes ----------

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1497,7 +1497,7 @@ func TestClusterNodesCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "3800m")
 }
 
-func TestClusterNodesCmd_TableOutputIgnoresQuiet(t *testing.T) {
+func TestClusterNodesCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1511,9 +1511,9 @@ func TestClusterNodesCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
 	require.NoError(t, err)
 	out := buf.String()
-	assert.Contains(t, out, "node-a")
-	assert.Contains(t, out, "node-b")
-	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "node-a\n")
+	assert.Contains(t, out, "node-b\n")
+	assert.NotContains(t, out, "NAME")
 }
 
 func TestClusterNodesCmd_JSONOutput(t *testing.T) {
@@ -1587,7 +1587,7 @@ func TestClusterNamespacesCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "2026-01-10 14:30:00")
 }
 
-func TestClusterNamespacesCmd_TableOutputIgnoresQuiet(t *testing.T) {
+func TestClusterNamespacesCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1601,9 +1601,9 @@ func TestClusterNamespacesCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
 	require.NoError(t, err)
 	out := buf.String()
-	assert.Contains(t, out, "stack-prod-web")
-	assert.Contains(t, out, "stack-dev-api")
-	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "stack-prod-web\n")
+	assert.Contains(t, out, "stack-dev-api\n")
+	assert.NotContains(t, out, "NAME")
 }
 
 func TestClusterNamespacesCmd_JSONOutput(t *testing.T) {
@@ -1681,7 +1681,7 @@ func TestClusterUtilizationCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "stack-dev")
 }
 
-func TestClusterUtilizationCmd_TableOutputIgnoresQuiet(t *testing.T) {
+func TestClusterUtilizationCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1695,9 +1695,9 @@ func TestClusterUtilizationCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"1"})
 	require.NoError(t, err)
 	out := buf.String()
-	assert.Contains(t, out, "stack-prod")
-	assert.Contains(t, out, "stack-dev")
-	assert.Contains(t, out, "NAMESPACE")
+	assert.Contains(t, out, "stack-prod\n")
+	assert.Contains(t, out, "stack-dev\n")
+	assert.NotContains(t, out, "NAMESPACE")
 }
 
 func TestClusterUtilizationCmd_JSONOutput(t *testing.T) {

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1559,8 +1559,8 @@ func TestClusterNodesCmd_YAMLOutput(t *testing.T) {
 func sampleClusterNamespaces() []types.ClusterNamespace {
 	now := time.Date(2026, 1, 10, 14, 30, 0, 0, time.UTC)
 	return []types.ClusterNamespace{
-		{Name: "stack-prod-web", Phase: "Active", CreatedAt: now},
-		{Name: "stack-dev-api", Phase: "Active", CreatedAt: now},
+		{Name: "stack-prod-web", Phase: "Active", CreatedAt: &now},
+		{Name: "stack-dev-api", Phase: "Active", CreatedAt: &now},
 	}
 }
 

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1308,7 +1308,7 @@ func TestClusterTestConnectionCmd_YAMLOutput(t *testing.T) {
 	assert.Contains(t, out, "server_version: v1.29.4")
 }
 
-func TestClusterTestConnectionCmd_QuietOutput(t *testing.T) {
+func TestClusterTestConnectionCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1321,14 +1321,16 @@ func TestClusterTestConnectionCmd_QuietOutput(t *testing.T) {
 
 	err := clusterTestConnectionCmd.RunE(clusterTestConnectionCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "success\n", buf.String())
+	out := buf.String()
+	assert.Contains(t, out, "Status")
+	assert.Contains(t, out, "success")
 }
 
 func TestClusterTestConnectionCmd_Unreachable(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
-		json.NewEncoder(w).Encode(map[string]string{"status": "error", "message": "Cluster is unreachable"})
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Cluster is unreachable"})
 	}))
 	defer server.Close()
 
@@ -1373,11 +1375,10 @@ func TestClusterHealthCmd_UnknownWhenZeroNodes(t *testing.T) {
 	defer server.Close()
 
 	buf := setupClusterTestCmd(t, server.URL)
-	printer.Quiet = true
 
 	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "unknown\n", buf.String())
+	assert.Contains(t, buf.String(), "unknown")
 }
 
 func TestClusterHealthCmd_DegradedWhenSomeNodesNotReady(t *testing.T) {
@@ -1438,7 +1439,7 @@ func TestClusterHealthCmd_YAMLOutput(t *testing.T) {
 	assert.Contains(t, out, "namespace_count: 12")
 }
 
-func TestClusterHealthCmd_QuietOutput(t *testing.T) {
+func TestClusterHealthCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1451,7 +1452,9 @@ func TestClusterHealthCmd_QuietOutput(t *testing.T) {
 
 	err := clusterHealthCmd.RunE(clusterHealthCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "healthy\n", buf.String())
+	out := buf.String()
+	assert.Contains(t, out, "Health Status")
+	assert.Contains(t, out, "healthy")
 }
 
 // ---------- cluster nodes ----------
@@ -1497,7 +1500,7 @@ func TestClusterNodesCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "3800m")
 }
 
-func TestClusterNodesCmd_QuietOutput(t *testing.T) {
+func TestClusterNodesCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1510,7 +1513,10 @@ func TestClusterNodesCmd_QuietOutput(t *testing.T) {
 
 	err := clusterNodesCmd.RunE(clusterNodesCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "node-a\nnode-b\n", buf.String())
+	out := buf.String()
+	assert.Contains(t, out, "node-a")
+	assert.Contains(t, out, "node-b")
+	assert.Contains(t, out, "NAME")
 }
 
 func TestClusterNodesCmd_JSONOutput(t *testing.T) {
@@ -1584,7 +1590,7 @@ func TestClusterNamespacesCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "2026-01-10 14:30:00")
 }
 
-func TestClusterNamespacesCmd_QuietOutput(t *testing.T) {
+func TestClusterNamespacesCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1597,7 +1603,10 @@ func TestClusterNamespacesCmd_QuietOutput(t *testing.T) {
 
 	err := clusterNamespacesCmd.RunE(clusterNamespacesCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "stack-prod-web\nstack-dev-api\n", buf.String())
+	out := buf.String()
+	assert.Contains(t, out, "stack-prod-web")
+	assert.Contains(t, out, "stack-dev-api")
+	assert.Contains(t, out, "NAME")
 }
 
 func TestClusterNamespacesCmd_JSONOutput(t *testing.T) {
@@ -1675,7 +1684,7 @@ func TestClusterUtilizationCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "stack-dev")
 }
 
-func TestClusterUtilizationCmd_QuietOutput(t *testing.T) {
+func TestClusterUtilizationCmd_TableOutputIgnoresQuiet(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -1688,7 +1697,10 @@ func TestClusterUtilizationCmd_QuietOutput(t *testing.T) {
 
 	err := clusterUtilizationCmd.RunE(clusterUtilizationCmd, []string{"1"})
 	require.NoError(t, err)
-	assert.Equal(t, "stack-prod\nstack-dev\n", buf.String())
+	out := buf.String()
+	assert.Contains(t, out, "stack-prod")
+	assert.Contains(t, out, "stack-dev")
+	assert.Contains(t, out, "NAMESPACE")
 }
 
 func TestClusterUtilizationCmd_JSONOutput(t *testing.T) {

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1050,41 +1050,40 @@ func (c *Client) GetClusterHealth(id string) (*types.ClusterHealthSummary, error
 	return &health, nil
 }
 
-// TestClusterConnection tests connectivity to a cluster.
-func (c *Client) TestClusterConnection(id string) (*types.TestConnectionResponse, error) {
-	var resp types.TestConnectionResponse
-	err := c.Post(fmt.Sprintf("/api/v1/clusters/%s/test", id), nil, &resp)
-	if err != nil {
+// TestClusterConnection asks the backend to verify connectivity to the
+// cluster's API server. On a reachable cluster the backend responds 200 with
+// status=="success"; on an unreachable cluster it returns a non-2xx response
+// which surfaces here as a client.APIError.
+func (c *Client) TestClusterConnection(id string) (*types.ClusterTestConnectionResult, error) {
+	var result types.ClusterTestConnectionResult
+	if err := c.Post(fmt.Sprintf("/api/v1/clusters/%s/test", id), nil, &result); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	return &result, nil
 }
 
-// GetClusterNodes returns per-node health for a cluster.
-func (c *Client) GetClusterNodes(id string) ([]types.ClusterNode, error) {
-	var nodes []types.ClusterNode
-	err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/health/nodes", id), &nodes)
-	if err != nil {
+// GetClusterNodes returns per-node status for a cluster.
+func (c *Client) GetClusterNodes(id string) ([]types.ClusterNodeStatus, error) {
+	var nodes []types.ClusterNodeStatus
+	if err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/health/nodes", id), &nodes); err != nil {
 		return nil, err
 	}
 	return nodes, nil
 }
 
-// GetClusterNamespaces returns all stack namespaces in a cluster.
+// GetClusterNamespaces returns the stack-* namespaces present in the cluster.
 func (c *Client) GetClusterNamespaces(id string) ([]types.ClusterNamespace, error) {
-	var ns []types.ClusterNamespace
-	err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/namespaces", id), &ns)
-	if err != nil {
+	var namespaces []types.ClusterNamespace
+	if err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/namespaces", id), &namespaces); err != nil {
 		return nil, err
 	}
-	return ns, nil
+	return namespaces, nil
 }
 
-// GetClusterUtilization returns per-namespace resource utilization for a cluster.
+// GetClusterUtilization returns aggregated per-namespace resource utilization.
 func (c *Client) GetClusterUtilization(id string) (*types.ClusterUtilization, error) {
 	var util types.ClusterUtilization
-	err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/utilization", id), &util)
-	if err != nil {
+	if err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/utilization", id), &util); err != nil {
 		return nil, err
 	}
 	return &util, nil

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -197,12 +197,30 @@ func (c *Client) do(method, path string, body interface{}) (*http.Response, erro
 		if ra := resp.Header.Get("Retry-After"); ra != "" {
 			apiErr.retryAfter = parseRetryAfter(ra)
 		}
-		var errResp types.ErrorResponse
+		// Most endpoints return {"error": "..."}, but a few (notably
+		// POST /api/v1/clusters/:id/test on 502) return
+		// {"status": "...", "message": "..."} instead. Decode both
+		// shapes so the backend-provided message surfaces in the
+		// user-facing APIError.
+		var errResp struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		}
 		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
 			apiErr.Message = http.StatusText(resp.StatusCode)
 			return nil, apiErr
 		}
-		apiErr.Message = errResp.Error
+		switch {
+		case errResp.Error != "":
+			apiErr.Message = errResp.Error
+		case errResp.Message != "":
+			apiErr.Message = errResp.Message
+		default:
+			// Decoded successfully but both fields empty — fall back to the
+			// status text so the user-facing rendering still has *some*
+			// context rather than just "Server error.".
+			apiErr.Message = http.StatusText(resp.StatusCode)
+		}
 		return nil, apiErr
 	}
 

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1041,6 +1041,8 @@ func (c *Client) GetCluster(id string) (*types.Cluster, error) {
 }
 
 // GetClusterHealth returns the health summary for a cluster.
+//
+// @see GET /api/v1/clusters/:id/health/summary
 func (c *Client) GetClusterHealth(id string) (*types.ClusterHealthSummary, error) {
 	var health types.ClusterHealthSummary
 	err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/health/summary", id), &health)
@@ -1054,6 +1056,8 @@ func (c *Client) GetClusterHealth(id string) (*types.ClusterHealthSummary, error
 // cluster's API server. On a reachable cluster the backend responds 200 with
 // status=="success"; on an unreachable cluster it returns a non-2xx response
 // which surfaces here as a client.APIError.
+//
+// @see POST /api/v1/clusters/:id/test
 func (c *Client) TestClusterConnection(id string) (*types.ClusterTestConnectionResult, error) {
 	var result types.ClusterTestConnectionResult
 	if err := c.Post(fmt.Sprintf("/api/v1/clusters/%s/test", id), nil, &result); err != nil {
@@ -1063,6 +1067,8 @@ func (c *Client) TestClusterConnection(id string) (*types.ClusterTestConnectionR
 }
 
 // GetClusterNodes returns per-node status for a cluster.
+//
+// @see GET /api/v1/clusters/:id/health/nodes
 func (c *Client) GetClusterNodes(id string) ([]types.ClusterNodeStatus, error) {
 	var nodes []types.ClusterNodeStatus
 	if err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/health/nodes", id), &nodes); err != nil {
@@ -1072,6 +1078,8 @@ func (c *Client) GetClusterNodes(id string) ([]types.ClusterNodeStatus, error) {
 }
 
 // GetClusterNamespaces returns the stack-* namespaces present in the cluster.
+//
+// @see GET /api/v1/clusters/:id/namespaces
 func (c *Client) GetClusterNamespaces(id string) ([]types.ClusterNamespace, error) {
 	var namespaces []types.ClusterNamespace
 	if err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/namespaces", id), &namespaces); err != nil {
@@ -1081,6 +1089,8 @@ func (c *Client) GetClusterNamespaces(id string) ([]types.ClusterNamespace, erro
 }
 
 // GetClusterUtilization returns aggregated per-namespace resource utilization.
+//
+// @see GET /api/v1/clusters/:id/utilization
 func (c *Client) GetClusterUtilization(id string) (*types.ClusterUtilization, error) {
 	var util types.ClusterUtilization
 	if err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/utilization", id), &util); err != nil {

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2100,11 +2100,11 @@ func TestGetClusterHealth_Success(t *testing.T) {
 		json.NewEncoder(w).Encode(types.ClusterHealthSummary{
 			NodeCount:         3,
 			ReadyNodeCount:    3,
-			TotalCPU:          "12",
-			TotalMemory:       "48Gi",
-			AllocatableCPU:    "11.7",
-			AllocatableMemory: "45Gi",
-			NamespaceCount:    7,
+			TotalCPU:          "8",
+			TotalMemory:       "16Gi",
+			AllocatableCPU:    "7",
+			AllocatableMemory: "14Gi",
+			NamespaceCount:    12,
 		})
 	}))
 	defer server.Close()
@@ -2113,8 +2113,10 @@ func TestGetClusterHealth_Success(t *testing.T) {
 	health, err := c.GetClusterHealth("1")
 	require.NoError(t, err)
 	assert.Equal(t, 3, health.NodeCount)
-	assert.Equal(t, "12", health.TotalCPU)
-	assert.Equal(t, "48Gi", health.TotalMemory)
+	assert.Equal(t, 3, health.ReadyNodeCount)
+	assert.Equal(t, "7", health.AllocatableCPU)
+	assert.Equal(t, "16Gi", health.TotalMemory)
+	assert.Equal(t, 12, health.NamespaceCount)
 }
 
 func TestGetClusterHealth_Error(t *testing.T) {
@@ -2129,6 +2131,129 @@ func TestGetClusterHealth_Error(t *testing.T) {
 	health, err := c.GetClusterHealth("1")
 	require.Error(t, err)
 	assert.Nil(t, health)
+}
+
+// ---------- cluster health (additional verbs) ----------
+
+func TestTestClusterConnection_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/test", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.ClusterTestConnectionResult{
+			Status: "success", Message: "Connection successful", ServerVersion: "v1.29.4",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	result, err := c.TestClusterConnection("1")
+	require.NoError(t, err)
+	assert.Equal(t, "success", result.Status)
+	assert.Equal(t, "v1.29.4", result.ServerVersion)
+}
+
+func TestTestClusterConnection_Unreachable(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		json.NewEncoder(w).Encode(map[string]string{"status": "error", "message": "Cluster is unreachable"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	result, err := c.TestClusterConnection("1")
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestGetClusterNodes_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/health/nodes", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]types.ClusterNodeStatus{
+			{
+				Name:        "node-a",
+				Status:      "Ready",
+				PodCount:    14,
+				Capacity:    types.ClusterResourceQuantity{CPU: "4", Memory: "8Gi", Pods: "110"},
+				Allocatable: types.ClusterResourceQuantity{CPU: "3800m", Memory: "7Gi"},
+				Conditions:  []types.ClusterNodeCondition{{Type: "Ready", Status: "True"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	nodes, err := c.GetClusterNodes("1")
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, "node-a", nodes[0].Name)
+	assert.Equal(t, "Ready", nodes[0].Status)
+	assert.Equal(t, 14, nodes[0].PodCount)
+	assert.Equal(t, "3800m", nodes[0].Allocatable.CPU)
+}
+
+func TestGetClusterNodes_Error(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	nodes, err := c.GetClusterNodes("missing")
+	require.Error(t, err)
+	assert.Nil(t, nodes)
+}
+
+func TestGetClusterNamespaces_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/namespaces", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode([]types.ClusterNamespace{
+			{Name: "stack-prod-web", Phase: "Active"},
+			{Name: "stack-dev-api", Phase: "Active"},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	ns, err := c.GetClusterNamespaces("1")
+	require.NoError(t, err)
+	require.Len(t, ns, 2)
+	assert.Equal(t, "stack-prod-web", ns[0].Name)
+}
+
+func TestGetClusterUtilization_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/utilization", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.ClusterUtilization{
+			ClusterID: "1",
+			Namespaces: []types.NamespaceResourceUsage{
+				{Namespace: "stack-prod", CPUUsed: "1500m", CPULimit: "4", MemoryUsed: "2Gi", MemoryLimit: "8Gi", PodCount: 10, PodLimit: 50},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	util, err := c.GetClusterUtilization("1")
+	require.NoError(t, err)
+	require.NotNil(t, util)
+	assert.Equal(t, "1", util.ClusterID)
+	require.Len(t, util.Namespaces, 1)
+	assert.Equal(t, "stack-prod", util.Namespaces[0].Namespace)
+	assert.Equal(t, 10, util.Namespaces[0].PodCount)
 }
 
 // ---------- shared values ----------
@@ -3349,173 +3474,4 @@ func TestSetDefaultCluster_Error(t *testing.T) {
 	c := New(server.URL)
 	err := c.SetDefaultCluster("99")
 	require.Error(t, err)
-}
-
-// ---------- new cluster subcommand client methods ----------
-
-func TestTestClusterConnection_Success(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v1/clusters/1/test", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(types.TestConnectionResponse{
-			Status:        "ok",
-			Message:       "Connected successfully",
-			ServerVersion: "v1.28.0",
-		})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	resp, err := c.TestClusterConnection("1")
-	require.NoError(t, err)
-	assert.Equal(t, "ok", resp.Status)
-	assert.Equal(t, "Connected successfully", resp.Message)
-	assert.Equal(t, "v1.28.0", resp.ServerVersion)
-}
-
-func TestTestClusterConnection_Error(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	resp, err := c.TestClusterConnection("1")
-	require.Error(t, err)
-	assert.Nil(t, resp)
-}
-
-func TestGetClusterNodes_Success(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/clusters/1/health/nodes", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNode{
-			{
-				Name:     "node-1",
-				Status:   "ready",
-				PodCount: 5,
-				Capacity: types.ResourceQuantity{CPU: "4", Memory: "16Gi"},
-			},
-			{
-				Name:     "node-2",
-				Status:   "ready",
-				PodCount: 7,
-				Capacity: types.ResourceQuantity{CPU: "8", Memory: "32Gi"},
-			},
-		})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	nodes, err := c.GetClusterNodes("1")
-	require.NoError(t, err)
-	require.Len(t, nodes, 2)
-	assert.Equal(t, "node-1", nodes[0].Name)
-	assert.Equal(t, "ready", nodes[0].Status)
-	assert.Equal(t, 5, nodes[0].PodCount)
-	assert.Equal(t, "8", nodes[1].Capacity.CPU)
-}
-
-func TestGetClusterNodes_Error(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	nodes, err := c.GetClusterNodes("1")
-	require.Error(t, err)
-	assert.Nil(t, nodes)
-}
-
-func TestGetClusterNamespaces_Success(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/clusters/1/namespaces", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode([]types.ClusterNamespace{
-			{Name: "stack-dev-alice", Phase: "Active", CreatedAt: now},
-			{Name: "stack-prod-bob", Phase: "Active", CreatedAt: now},
-		})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	namespaces, err := c.GetClusterNamespaces("1")
-	require.NoError(t, err)
-	require.Len(t, namespaces, 2)
-	assert.Equal(t, "stack-dev-alice", namespaces[0].Name)
-	assert.Equal(t, "Active", namespaces[0].Phase)
-	assert.Equal(t, "stack-prod-bob", namespaces[1].Name)
-}
-
-func TestGetClusterNamespaces_Error(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	namespaces, err := c.GetClusterNamespaces("1")
-	require.Error(t, err)
-	assert.Nil(t, namespaces)
-}
-
-func TestGetClusterUtilization_Success(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v1/clusters/1/utilization", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(types.ClusterUtilization{
-			ClusterID: "1",
-			Namespaces: []types.NamespaceResourceUsage{
-				{
-					Namespace:   "stack-dev-alice",
-					CPUUsed:     "500m",
-					CPULimit:    "2",
-					MemoryUsed:  "256Mi",
-					MemoryLimit: "1Gi",
-					PodCount:    3,
-					PodLimit:    10,
-				},
-			},
-		})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	util, err := c.GetClusterUtilization("1")
-	require.NoError(t, err)
-	assert.Equal(t, "1", util.ClusterID)
-	require.Len(t, util.Namespaces, 1)
-	assert.Equal(t, "stack-dev-alice", util.Namespaces[0].Namespace)
-	assert.Equal(t, "500m", util.Namespaces[0].CPUUsed)
-	assert.Equal(t, 3, util.Namespaces[0].PodCount)
-}
-
-func TestGetClusterUtilization_Error(t *testing.T) {
-	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Internal server error"})
-	}))
-	defer server.Close()
-
-	c := New(server.URL)
-	util, err := c.GetClusterUtilization("1")
-	require.Error(t, err)
-	assert.Nil(t, util)
 }

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2157,8 +2157,15 @@ func TestTestClusterConnection_Success(t *testing.T) {
 func TestTestClusterConnection_Unreachable(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Real backend wire shape for POST /clusters/:id/test on a 502:
+		// {"status":"error","message":"..."} — NOT the generic {"error":"..."}
+		// envelope. The client decoder must fall back to `message` so the
+		// backend-provided context surfaces in the APIError.
 		w.WriteHeader(http.StatusBadGateway)
-		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Cluster is unreachable"})
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":  "error",
+			"message": "Cluster is unreachable",
+		})
 	}))
 	defer server.Close()
 
@@ -2168,7 +2175,12 @@ func TestTestClusterConnection_Unreachable(t *testing.T) {
 	assert.Nil(t, result)
 	var apiErr *APIError
 	require.ErrorAs(t, err, &apiErr)
-	assert.Contains(t, apiErr.UserFacingError(), "Cluster is unreachable")
+	assert.Equal(t, http.StatusBadGateway, apiErr.StatusCode)
+	assert.Equal(t, "Cluster is unreachable", apiErr.Message,
+		"client decoder must surface the backend `message` field, not the generic 'Bad Gateway' fallback")
+	face := apiErr.UserFacingError()
+	assert.Contains(t, face, "Server error")
+	assert.Contains(t, face, "Cluster is unreachable")
 }
 
 func TestGetClusterNodes_Success(t *testing.T) {

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2158,7 +2158,7 @@ func TestTestClusterConnection_Unreachable(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
-		json.NewEncoder(w).Encode(map[string]string{"status": "error", "message": "Cluster is unreachable"})
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Cluster is unreachable"})
 	}))
 	defer server.Close()
 
@@ -2166,6 +2166,9 @@ func TestTestClusterConnection_Unreachable(t *testing.T) {
 	result, err := c.TestClusterConnection("1")
 	require.Error(t, err)
 	assert.Nil(t, result)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Contains(t, apiErr.UserFacingError(), "Cluster is unreachable")
 }
 
 func TestGetClusterNodes_Success(t *testing.T) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -285,9 +285,18 @@ type GitValidateResponse struct {
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-// ClusterHealthSummary represents a cluster's health summary as returned by
-// GET /api/v1/clusters/:id/health/summary. Field names match the backend
-// k8s.ClusterSummary struct so JSON unmarshaling round-trips correctly.
+// ClusterHealthSummary is the success-path response of
+// GET /api/v1/clusters/:id/health/summary. Field names mirror the backend
+// k8s.ClusterSummary struct so JSON round-trips without renaming.
+//
+// Population: only returned on HTTP 200. On non-2xx the client surfaces an
+// APIError and this struct is left zero-valued by the caller.
+// Field semantics:
+//   - NodeCount, ReadyNodeCount, NamespaceCount — always present (may be 0
+//     for empty/just-registered clusters; 0 is a valid value, not "missing").
+//   - TotalCPU, TotalMemory, AllocatableCPU, AllocatableMemory — populated
+//     when the backend was able to read node capacity; omitted (empty string)
+//     when no nodes were reachable, hence the `omitempty` tags.
 type ClusterHealthSummary struct {
 	NodeCount         int    `json:"node_count" yaml:"node_count"`
 	ReadyNodeCount    int    `json:"ready_node_count" yaml:"ready_node_count"`
@@ -298,35 +307,70 @@ type ClusterHealthSummary struct {
 	NamespaceCount    int    `json:"namespace_count" yaml:"namespace_count"`
 }
 
-// ClusterTestConnectionResult is the response shape of
-// POST /api/v1/clusters/:id/test. On success Status == "success". On an
-// unreachable cluster the backend returns a non-2xx response that the client
-// surfaces as an APIError; this struct is only populated on 200 responses.
+// ClusterTestConnectionResult is the success-path response of
+// POST /api/v1/clusters/:id/test (HTTP 200 only). Populated by
+// Client.TestClusterConnection.
+//
+// Population: only returned on HTTP 200 with Status == "success". On an
+// unreachable cluster the backend returns HTTP 502 with a JSON body of
+// shape {"status":"error","message":"..."}; the client decoder in
+// Client.do() maps that into an APIError (Message set to the backend
+// "message"), so callers never see this struct populated with Status="error".
+// Field semantics:
+//   - Status — always present on the 200 path ("success").
+//   - Message — present on the 200 path; backend uses "Connection successful".
+//   - ServerVersion — populated when the backend's discovery client reported
+//     a Kubernetes git version (e.g. "v1.29.4"); empty when the discovery
+//     response was malformed or the test fake doesn't implement RESTClient.
 type ClusterTestConnectionResult struct {
 	Status        string `json:"status" yaml:"status"`
 	Message       string `json:"message,omitempty" yaml:"message,omitempty"`
 	ServerVersion string `json:"server_version,omitempty" yaml:"server_version,omitempty"`
 }
 
-// ClusterResourceQuantity captures CPU/memory/pod capacity strings, mirroring
-// the backend k8s.ResourceQuantity.
+// ClusterResourceQuantity holds CPU/memory/pod capacity values as strings,
+// mirroring backend k8s.ResourceQuantity. Embedded inside ClusterNodeStatus
+// (Capacity, Allocatable) returned from
+// GET /api/v1/clusters/:id/health/nodes.
+//
+// Field semantics:
+//   - CPU, Memory — always populated for a node returned by the API; format
+//     is Kubernetes resource notation ("3800m", "16Gi").
+//   - Pods — currently always populated by the backend (k8s
+//     ResourceList.Pods().String() returns "0" worst case). The `omitempty`
+//     JSON tag is defensive in case a future backend version stops emitting
+//     the field.
 type ClusterResourceQuantity struct {
 	CPU    string `json:"cpu" yaml:"cpu"`
 	Memory string `json:"memory" yaml:"memory"`
 	Pods   string `json:"pods,omitempty" yaml:"pods,omitempty"`
 }
 
-// ClusterNodeCondition represents a single node condition (Ready,
-// MemoryPressure, etc.), mirroring backend k8s.NodeCondition.
+// ClusterNodeCondition represents one node condition (Ready, MemoryPressure,
+// DiskPressure, PIDPressure, NetworkUnavailable, etc.), mirroring backend
+// k8s.NodeCondition. Embedded inside ClusterNodeStatus.Conditions.
+//
+// Field semantics:
+//   - Type, Status — always present. Status is one of "True"/"False"/"Unknown".
+//   - Message — populated when the controller has additional context (which
+//     in practice is almost always — the kubelet sets a message even on
+//     healthy Ready conditions). The `omitempty` JSON tag only hides
+//     genuinely empty strings.
 type ClusterNodeCondition struct {
 	Type    string `json:"type" yaml:"type"`
 	Status  string `json:"status" yaml:"status"`
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-// ClusterNodeStatus is one node's health snapshot, returned as an element of
-// the array from GET /api/v1/clusters/:id/health/nodes. Mirrors backend
-// k8s.NodeStatus.
+// ClusterNodeStatus is one node's health snapshot, returned as an array
+// element of GET /api/v1/clusters/:id/health/nodes (HTTP 200 only). Mirrors
+// backend k8s.NodeStatus. Populated by Client.GetClusterNodes.
+//
+// Field semantics:
+//   - Name, Status, Capacity, Allocatable, PodCount — always populated; Status
+//     is "Ready" or "NotReady".
+//   - Conditions — omitted when the backend has no conditions to report
+//     (rare); typically a non-empty slice on Linux nodes.
 type ClusterNodeStatus struct {
 	Name        string                  `json:"name" yaml:"name"`
 	Status      string                  `json:"status" yaml:"status"`
@@ -336,16 +380,33 @@ type ClusterNodeStatus struct {
 	PodCount    int                     `json:"pod_count" yaml:"pod_count"`
 }
 
-// ClusterNamespace is one namespace entry from
-// GET /api/v1/clusters/:id/namespaces. Mirrors backend k8s.NamespaceInfo.
+// ClusterNamespace is one namespace entry returned as an array element of
+// GET /api/v1/clusters/:id/namespaces (HTTP 200 only). Mirrors backend
+// k8s.NamespaceInfo (filtered to "stack-*" namespaces). Populated by
+// Client.GetClusterNamespaces.
+//
+// Field semantics:
+//   - Name, Phase — always populated. Phase is the string form of
+//     corev1.NamespacePhase ("Active" or "Terminating").
+//   - CreatedAt — populated from the namespace's metadata.creationTimestamp;
+//     a nil pointer when the backend omitted the field (rare; treated as
+//     "unknown age" by the CLI).
 type ClusterNamespace struct {
 	Name      string     `json:"name" yaml:"name"`
 	Phase     string     `json:"phase" yaml:"phase"`
 	CreatedAt *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
-// NamespaceResourceUsage is the per-namespace utilization entry inside a
-// ClusterUtilization, mirroring backend NamespaceResourceUsage.
+// NamespaceResourceUsage is the per-namespace utilization entry embedded
+// inside ClusterUtilization.Namespaces. Mirrors backend NamespaceResourceUsage.
+//
+// Field semantics:
+//   - Namespace, PodCount, PodLimit — always present (PodLimit is 0 when the
+//     namespace has no quota; CLI renders it as just PodCount in that case).
+//   - CPUUsed/CPULimit/MemoryUsed/MemoryLimit — populated when the backend's
+//     metrics client successfully fetched usage/limits; empty when metrics
+//     were unavailable for that namespace (still returned by the API for
+//     completeness — hence `omitempty`).
 type NamespaceResourceUsage struct {
 	Namespace   string `json:"namespace" yaml:"namespace"`
 	CPUUsed     string `json:"cpu_used,omitempty" yaml:"cpu_used,omitempty"`
@@ -356,8 +417,14 @@ type NamespaceResourceUsage struct {
 	PodLimit    int    `json:"pod_limit" yaml:"pod_limit"`
 }
 
-// ClusterUtilization is the response shape of
-// GET /api/v1/clusters/:id/utilization. Mirrors backend ClusterUtilization.
+// ClusterUtilization is the success-path response of
+// GET /api/v1/clusters/:id/utilization (HTTP 200 only). Mirrors backend
+// ClusterUtilization. Populated by Client.GetClusterUtilization.
+//
+// Field semantics:
+//   - ClusterID — always present, echoes the path parameter.
+//   - Namespaces — always present (empty slice when no stack-* namespaces
+//     exist on the cluster).
 type ClusterUtilization struct {
 	ClusterID  string                   `json:"cluster_id" yaml:"cluster_id"`
 	Namespaces []NamespaceResourceUsage `json:"namespaces" yaml:"namespaces"`

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -299,8 +299,9 @@ type ClusterHealthSummary struct {
 }
 
 // ClusterTestConnectionResult is the response shape of
-// POST /api/v1/clusters/:id/test. On success Status == "success"; on a
-// reachable-but-erroring cluster the backend returns 502 with Status == "error".
+// POST /api/v1/clusters/:id/test. On success Status == "success". On an
+// unreachable cluster the backend returns a non-2xx response that the client
+// surfaces as an APIError; this struct is only populated on 200 responses.
 type ClusterTestConnectionResult struct {
 	Status        string `json:"status" yaml:"status"`
 	Message       string `json:"message,omitempty" yaml:"message,omitempty"`

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -285,70 +285,81 @@ type GitValidateResponse struct {
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-// ClusterHealthSummary represents a cluster's health summary from GET /api/v1/clusters/:id/health/summary.
+// ClusterHealthSummary represents a cluster's health summary as returned by
+// GET /api/v1/clusters/:id/health/summary. Field names match the backend
+// k8s.ClusterSummary struct so JSON unmarshaling round-trips correctly.
 type ClusterHealthSummary struct {
-	TotalCPU          string `json:"total_cpu" yaml:"total_cpu"`
-	TotalMemory       string `json:"total_memory" yaml:"total_memory"`
-	AllocatableCPU    string `json:"allocatable_cpu" yaml:"allocatable_cpu"`
-	AllocatableMemory string `json:"allocatable_memory" yaml:"allocatable_memory"`
 	NodeCount         int    `json:"node_count" yaml:"node_count"`
 	ReadyNodeCount    int    `json:"ready_node_count" yaml:"ready_node_count"`
+	TotalCPU          string `json:"total_cpu,omitempty" yaml:"total_cpu,omitempty"`
+	TotalMemory       string `json:"total_memory,omitempty" yaml:"total_memory,omitempty"`
+	AllocatableCPU    string `json:"allocatable_cpu,omitempty" yaml:"allocatable_cpu,omitempty"`
+	AllocatableMemory string `json:"allocatable_memory,omitempty" yaml:"allocatable_memory,omitempty"`
 	NamespaceCount    int    `json:"namespace_count" yaml:"namespace_count"`
 }
 
-// NodeCondition represents a single node condition.
-type NodeCondition struct {
-	Type    string `json:"type" yaml:"type"`
-	Status  string `json:"status" yaml:"status"`
-	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+// ClusterTestConnectionResult is the response shape of
+// POST /api/v1/clusters/:id/test. On success Status == "success"; on a
+// reachable-but-erroring cluster the backend returns 502 with Status == "error".
+type ClusterTestConnectionResult struct {
+	Status        string `json:"status" yaml:"status"`
+	Message       string `json:"message,omitempty" yaml:"message,omitempty"`
+	ServerVersion string `json:"server_version,omitempty" yaml:"server_version,omitempty"`
 }
 
-// ResourceQuantity holds CPU, memory, and optional pod capacity values as strings.
-type ResourceQuantity struct {
+// ClusterResourceQuantity captures CPU/memory/pod capacity strings, mirroring
+// the backend k8s.ResourceQuantity.
+type ClusterResourceQuantity struct {
 	CPU    string `json:"cpu" yaml:"cpu"`
 	Memory string `json:"memory" yaml:"memory"`
 	Pods   string `json:"pods,omitempty" yaml:"pods,omitempty"`
 }
 
-// ClusterNode represents the health and capacity of a single cluster node.
-type ClusterNode struct {
-	Conditions  []NodeCondition  `json:"conditions" yaml:"conditions"`
-	Capacity    ResourceQuantity `json:"capacity" yaml:"capacity"`
-	Allocatable ResourceQuantity `json:"allocatable" yaml:"allocatable"`
-	Name        string           `json:"name" yaml:"name"`
-	Status      string           `json:"status" yaml:"status"`
-	PodCount    int              `json:"pod_count" yaml:"pod_count"`
+// ClusterNodeCondition represents a single node condition (Ready,
+// MemoryPressure, etc.), mirroring backend k8s.NodeCondition.
+type ClusterNodeCondition struct {
+	Type    string `json:"type" yaml:"type"`
+	Status  string `json:"status" yaml:"status"`
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
-// ClusterNamespace represents a Kubernetes namespace in a cluster.
+// ClusterNodeStatus is one node's health snapshot, returned as an element of
+// the array from GET /api/v1/clusters/:id/health/nodes. Mirrors backend
+// k8s.NodeStatus.
+type ClusterNodeStatus struct {
+	Name        string                  `json:"name" yaml:"name"`
+	Status      string                  `json:"status" yaml:"status"`
+	Conditions  []ClusterNodeCondition  `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	Capacity    ClusterResourceQuantity `json:"capacity" yaml:"capacity"`
+	Allocatable ClusterResourceQuantity `json:"allocatable" yaml:"allocatable"`
+	PodCount    int                     `json:"pod_count" yaml:"pod_count"`
+}
+
+// ClusterNamespace is one namespace entry from
+// GET /api/v1/clusters/:id/namespaces. Mirrors backend k8s.NamespaceInfo.
 type ClusterNamespace struct {
-	CreatedAt time.Time `json:"created_at" yaml:"created_at"`
 	Name      string    `json:"name" yaml:"name"`
 	Phase     string    `json:"phase" yaml:"phase"`
+	CreatedAt time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
-// NamespaceResourceUsage holds resource usage for a single namespace.
+// NamespaceResourceUsage is the per-namespace utilization entry inside a
+// ClusterUtilization, mirroring backend NamespaceResourceUsage.
 type NamespaceResourceUsage struct {
 	Namespace   string `json:"namespace" yaml:"namespace"`
-	CPUUsed     string `json:"cpu_used" yaml:"cpu_used"`
-	CPULimit    string `json:"cpu_limit" yaml:"cpu_limit"`
-	MemoryUsed  string `json:"memory_used" yaml:"memory_used"`
-	MemoryLimit string `json:"memory_limit" yaml:"memory_limit"`
+	CPUUsed     string `json:"cpu_used,omitempty" yaml:"cpu_used,omitempty"`
+	CPULimit    string `json:"cpu_limit,omitempty" yaml:"cpu_limit,omitempty"`
+	MemoryUsed  string `json:"memory_used,omitempty" yaml:"memory_used,omitempty"`
+	MemoryLimit string `json:"memory_limit,omitempty" yaml:"memory_limit,omitempty"`
 	PodCount    int    `json:"pod_count" yaml:"pod_count"`
 	PodLimit    int    `json:"pod_limit" yaml:"pod_limit"`
 }
 
-// ClusterUtilization represents per-namespace resource usage for a cluster.
+// ClusterUtilization is the response shape of
+// GET /api/v1/clusters/:id/utilization. Mirrors backend ClusterUtilization.
 type ClusterUtilization struct {
 	ClusterID  string                   `json:"cluster_id" yaml:"cluster_id"`
 	Namespaces []NamespaceResourceUsage `json:"namespaces" yaml:"namespaces"`
-}
-
-// TestConnectionResponse is the response from POST /api/v1/clusters/:id/test.
-type TestConnectionResponse struct {
-	Status        string `json:"status" yaml:"status"`
-	Message       string `json:"message" yaml:"message"`
-	ServerVersion string `json:"server_version,omitempty" yaml:"server_version,omitempty"`
 }
 
 // ErrorResponse represents an API error response.

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -339,9 +339,9 @@ type ClusterNodeStatus struct {
 // ClusterNamespace is one namespace entry from
 // GET /api/v1/clusters/:id/namespaces. Mirrors backend k8s.NamespaceInfo.
 type ClusterNamespace struct {
-	Name      string    `json:"name" yaml:"name"`
-	Phase     string    `json:"phase" yaml:"phase"`
-	CreatedAt time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	Name      string     `json:"name" yaml:"name"`
+	Phase     string     `json:"phase" yaml:"phase"`
+	CreatedAt *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
 // NamespaceResourceUsage is the per-namespace utilization entry inside a

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -1744,10 +1744,50 @@ func startE2EClusterMockServer(t *testing.T) *httptest.Server {
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(resp)
 
-		// GET /api/v1/clusters/1/health/summary — return 404 so get degrades gracefully
+		// GET /api/v1/clusters/1/health/summary
 		case r.URL.Path == "/api/v1/clusters/1/health/summary" && r.Method == http.MethodGet:
-			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"error": "health not available"})
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"node_count": 3, "ready_node_count": 3,
+				"total_cpu": "8", "total_memory": "16Gi",
+				"allocatable_cpu": "7", "allocatable_memory": "14Gi",
+				"namespace_count": 12,
+			})
+
+		// GET /api/v1/clusters/1/health/nodes
+		case r.URL.Path == "/api/v1/clusters/1/health/nodes" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{
+					"name": "node-a", "status": "Ready", "pod_count": 14,
+					"capacity":    map[string]string{"cpu": "4", "memory": "8Gi", "pods": "110"},
+					"allocatable": map[string]string{"cpu": "3800m", "memory": "7Gi"},
+				},
+			})
+
+		// GET /api/v1/clusters/1/namespaces
+		case r.URL.Path == "/api/v1/clusters/1/namespaces" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"name": "stack-prod-web", "phase": "Active"},
+			})
+
+		// GET /api/v1/clusters/1/utilization
+		case r.URL.Path == "/api/v1/clusters/1/utilization" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"cluster_id": "1",
+				"namespaces": []map[string]interface{}{
+					{"namespace": "stack-prod-web", "cpu_used": "1500m", "cpu_limit": "4", "memory_used": "2Gi", "memory_limit": "8Gi", "pod_count": 10, "pod_limit": 50},
+				},
+			})
+
+		// POST /api/v1/clusters/1/test
+		case r.URL.Path == "/api/v1/clusters/1/test" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{
+				"status": "success", "message": "Connection successful", "server_version": "v1.29.4",
+			})
 
 		// PUT /api/v1/clusters/1 — update
 		case r.URL.Path == "/api/v1/clusters/1" && r.Method == http.MethodPut:
@@ -1872,44 +1912,36 @@ func TestE2EClusterHealth(t *testing.T) {
 		t.Skip("skipping e2e test in short mode")
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/api/v1/clusters/1/health/summary" && r.Method == http.MethodGet:
-			w.WriteHeader(http.StatusOK)
-			resp := map[string]interface{}{
-				"node_count":          3,
-				"ready_node_count":    3,
-				"total_cpu":           "12",
-				"total_memory":        "48Gi",
-				"allocatable_cpu":     "11.7",
-				"allocatable_memory":  "45Gi",
-				"namespace_count":     7,
-			}
-			json.NewEncoder(w).Encode(resp)
-		default:
-			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
-		}
-	}))
+	server := startE2EClusterMockServer(t)
 	defer server.Close()
 
 	dir := t.TempDir()
 	setupE2EStackContext(t, dir, server.URL)
 
-	// table output
+	// table: humans see the key fields.
 	stdout, _, err := runStackctl(t, dir, "cluster", "health", "1")
 	require.NoError(t, err)
-	assert.Contains(t, stdout, "Nodes")
-	assert.Contains(t, stdout, "3")
-	assert.Contains(t, stdout, "48Gi")
-	assert.Contains(t, stdout, "11.7")
+	assert.Contains(t, stdout, "Health Status")
+	assert.Contains(t, stdout, "healthy")
+	assert.Contains(t, stdout, "3/3")
+	assert.Contains(t, stdout, "14Gi")
+	assert.Contains(t, stdout, "12")
 
-	// json output
+	// json: parses back into the documented shape.
 	stdout, _, err = runStackctl(t, dir, "cluster", "health", "1", "--output", "json")
 	require.NoError(t, err)
-	var result map[string]interface{}
-	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
-	assert.Equal(t, float64(3), result["node_count"])
-	assert.Equal(t, "48Gi", result["total_memory"])
+	var got struct {
+		NodeCount      int `json:"node_count"`
+		ReadyNodeCount int `json:"ready_node_count"`
+		NamespaceCount int `json:"namespace_count"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.Equal(t, 3, got.NodeCount)
+	assert.Equal(t, 3, got.ReadyNodeCount)
+	assert.Equal(t, 12, got.NamespaceCount)
+
+	// quiet: single-word health status for shell pipelines.
+	stdout, _, err = runStackctl(t, dir, "cluster", "health", "1", "--quiet")
+	require.NoError(t, err)
+	assert.Equal(t, "healthy\n", stdout)
 }

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -95,6 +95,11 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 				action = parts[1]
 			case 3:
 				// /api/v1/clusters/<id>/health/<sub> — handled below as a special case.
+				if parts[1] != "health" {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+					return
+				}
 				id = parts[0]
 			default:
 				w.WriteHeader(http.StatusNotFound)

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -20,15 +20,17 @@ import (
 
 // clusterMockState holds mutable state for the cluster mock server.
 type clusterMockState struct {
-	mu       sync.Mutex
-	nextID   uint
-	clusters map[string]*types.Cluster
+	mu          sync.Mutex
+	nextID      uint
+	clusters    map[string]*types.Cluster
+	unreachable map[string]bool // cluster IDs that POST /test should report as unreachable
 }
 
 func newClusterMockState() *clusterMockState {
 	return &clusterMockState{
-		nextID:   1,
-		clusters: make(map[string]*types.Cluster),
+		nextID:      1,
+		clusters:    make(map[string]*types.Cluster),
+		unreachable: make(map[string]bool),
 	}
 }
 
@@ -91,6 +93,9 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 			case 2:
 				id = parts[0]
 				action = parts[1]
+			case 3:
+				// /api/v1/clusters/<id>/health/<sub> — handled below as a special case.
+				id = parts[0]
 			default:
 				w.WriteHeader(http.StatusNotFound)
 				json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
@@ -105,6 +110,41 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 			state.mu.Lock()
 			cl, exists := state.clusters[id]
 			state.mu.Unlock()
+
+			// Two-level paths: /api/v1/clusters/<id>/health/<sub> — handle
+			// before the action switch since `action` stays empty for len==3.
+			if len(parts) == 3 && parts[1] == "health" && r.Method == http.MethodGet {
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				switch parts[2] {
+				case "summary":
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(types.ClusterHealthSummary{
+						NodeCount: 3, ReadyNodeCount: 3,
+						TotalCPU: "8", TotalMemory: "16Gi",
+						AllocatableCPU: "7", AllocatableMemory: "14Gi",
+						NamespaceCount: 12,
+					})
+					return
+				case "nodes":
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode([]types.ClusterNodeStatus{
+						{
+							Name: "node-a", Status: "Ready", PodCount: 14,
+							Capacity:    types.ClusterResourceQuantity{CPU: "4", Memory: "8Gi", Pods: "110"},
+							Allocatable: types.ClusterResourceQuantity{CPU: "3800m", Memory: "7Gi"},
+						},
+					})
+					return
+				default:
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+					return
+				}
+			}
 
 			switch {
 			// GET /api/v1/clusters/:id
@@ -174,6 +214,51 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 				cl.IsDefault = true
 				state.mu.Unlock()
 				w.WriteHeader(http.StatusNoContent)
+
+			// POST /api/v1/clusters/:id/test
+			case action == "test" && r.Method == http.MethodPost:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				if state.unreachable[id] {
+					w.WriteHeader(http.StatusBadGateway)
+					json.NewEncoder(w).Encode(map[string]string{"status": "error", "message": "Cluster is unreachable"})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(types.ClusterTestConnectionResult{
+					Status: "success", Message: "Connection successful", ServerVersion: "v1.29.4",
+				})
+
+			// GET /api/v1/clusters/:id/namespaces
+			case action == "namespaces" && r.Method == http.MethodGet:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode([]types.ClusterNamespace{
+					{Name: "stack-prod-web", Phase: "Active"},
+					{Name: "stack-dev-api", Phase: "Active"},
+				})
+
+			// GET /api/v1/clusters/:id/utilization
+			case action == "utilization" && r.Method == http.MethodGet:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(types.ClusterUtilization{
+					ClusterID: id,
+					Namespaces: []types.NamespaceResourceUsage{
+						{Namespace: "stack-prod-web", CPUUsed: "1500m", CPULimit: "4", MemoryUsed: "2Gi", MemoryLimit: "8Gi", PodCount: 10, PodLimit: 50},
+					},
+				})
 
 			default:
 				w.WriteHeader(http.StatusNotFound)
@@ -386,171 +471,115 @@ func TestClusterCobra_CreateListSetDefaultDelete(t *testing.T) {
 	assert.False(t, exists)
 }
 
-// startHealthUtilMockServer starts a mock HTTP server that serves all 5 new
-// cluster subcommand routes plus the basic cluster get route.
-func startHealthUtilMockServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case r.URL.Path == "/api/v1/clusters/1/test" && r.Method == http.MethodPost:
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(types.TestConnectionResponse{
-				Status:        "ok",
-				Message:       "Connected successfully",
-				ServerVersion: "v1.29.0",
-			})
+func TestClusterWorkflow_HealthSurface(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
 
-		case r.URL.Path == "/api/v1/clusters/1/health/summary" && r.Method == http.MethodGet:
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(types.ClusterHealthSummary{
-				NodeCount:         3,
-				ReadyNodeCount:    3,
-				TotalCPU:          "12",
-				TotalMemory:       "48Gi",
-				AllocatableCPU:    "11.7",
-				AllocatableMemory: "45Gi",
-				NamespaceCount:    5,
-			})
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
 
-		case r.URL.Path == "/api/v1/clusters/1/health/nodes" && r.Method == http.MethodGet:
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode([]types.ClusterNode{
-				{
-					Name:     "node-a",
-					Status:   "ready",
-					PodCount: 10,
-					Capacity: types.ResourceQuantity{CPU: "4", Memory: "16Gi"},
-				},
-				{
-					Name:     "node-b",
-					Status:   "ready",
-					PodCount: 8,
-					Capacity: types.ResourceQuantity{CPU: "8", Memory: "32Gi"},
-				},
-			})
+	c := client.New(server.URL)
 
-		case r.URL.Path == "/api/v1/clusters/1/namespaces" && r.Method == http.MethodGet:
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode([]types.ClusterNamespace{
-				{Name: "stack-dev-alice", Phase: "Active", CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)},
-				{Name: "stack-staging-bob", Phase: "Active", CreatedAt: time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)},
-			})
+	cluster, err := c.CreateCluster(&types.CreateClusterRequest{Name: "h-cluster"})
+	require.NoError(t, err)
+	id := cluster.ID
 
-		case r.URL.Path == "/api/v1/clusters/1/utilization" && r.Method == http.MethodGet:
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(types.ClusterUtilization{
-				ClusterID: "1",
-				Namespaces: []types.NamespaceResourceUsage{
-					{
-						Namespace:   "stack-dev-alice",
-						CPUUsed:     "500m",
-						CPULimit:    "2",
-						MemoryUsed:  "256Mi",
-						MemoryLimit: "1Gi",
-						PodCount:    3,
-						PodLimit:    10,
-					},
-				},
-			})
+	// test-connection (success path)
+	res, err := c.TestClusterConnection(id)
+	require.NoError(t, err)
+	assert.Equal(t, "success", res.Status)
+	assert.Equal(t, "v1.29.4", res.ServerVersion)
 
-		default:
-			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
-		}
-	}))
+	// health summary
+	health, err := c.GetClusterHealth(id)
+	require.NoError(t, err)
+	assert.Equal(t, 3, health.NodeCount)
+	assert.Equal(t, 3, health.ReadyNodeCount)
+	assert.Equal(t, 12, health.NamespaceCount)
+
+	// nodes
+	nodes, err := c.GetClusterNodes(id)
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, "Ready", nodes[0].Status)
+
+	// namespaces
+	ns, err := c.GetClusterNamespaces(id)
+	require.NoError(t, err)
+	require.Len(t, ns, 2)
+
+	// utilization
+	util, err := c.GetClusterUtilization(id)
+	require.NoError(t, err)
+	require.Len(t, util.Namespaces, 1)
+	assert.Equal(t, "stack-prod-web", util.Namespaces[0].Namespace)
 }
 
-// TestClusterCobra_HealthTestConnectionUtilization drives the 5 new cluster
-// subcommands in-process via Cobra, validating output and error handling.
-// NOT parallel: drives cmd package globals (rootCmd, printer).
-func TestClusterCobra_HealthTestConnectionUtilization(t *testing.T) {
+func TestClusterWorkflow_TestConnectionUnreachable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	cluster, err := c.CreateCluster(&types.CreateClusterRequest{Name: "broken"})
+	require.NoError(t, err)
+	id := cluster.ID
+
+	state.mu.Lock()
+	state.unreachable[id] = true
+	state.mu.Unlock()
+
+	res, err := c.TestClusterConnection(id)
+	require.Error(t, err)
+	assert.Nil(t, res)
+	// 502 maps through the client error mapper; we just need a non-nil error.
+}
+
+// Cobra in-process drive: cluster health <id> happy path against the mock.
+// NOT parallel: mutates cmd package globals.
+func TestClusterCobra_Health(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	server := startHealthUtilMockServer(t)
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
 	defer server.Close()
 
 	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
 	t.Setenv("STACKCTL_API_URL", server.URL)
 
-	tests := []struct {
-		name       string
-		args       []string
-		wantStrs   []string
-		outputJSON bool
-	}{
-		{
-			name:     "test-connection table",
-			args:     []string{"cluster", "test-connection", "1"},
-			wantStrs: []string{"ok", "Connected successfully", "v1.29.0"},
-		},
-		{
-			name:       "test-connection json",
-			args:       []string{"cluster", "test-connection", "1", "--output", "json"},
-			wantStrs:   []string{`"status"`, `"ok"`, `"server_version"`},
-			outputJSON: true,
-		},
-		{
-			name:     "health table",
-			args:     []string{"cluster", "health", "1"},
-			wantStrs: []string{"Nodes", "3", "48Gi"},
-		},
-		{
-			name:       "health json",
-			args:       []string{"cluster", "health", "1", "--output", "json"},
-			wantStrs:   []string{`"node_count"`, `"total_memory"`, `"48Gi"`},
-			outputJSON: true,
-		},
-		{
-			name:     "nodes table",
-			args:     []string{"cluster", "nodes", "1"},
-			wantStrs: []string{"node-a", "node-b", "ready", "4", "16Gi"},
-		},
-		{
-			name:       "nodes json",
-			args:       []string{"cluster", "nodes", "1", "--output", "json"},
-			wantStrs:   []string{`"node-a"`, `"node-b"`, `"ready"`},
-			outputJSON: true,
-		},
-		{
-			name:     "namespaces table",
-			args:     []string{"cluster", "namespaces", "1"},
-			wantStrs: []string{"stack-dev-alice", "stack-staging-bob", "Active"},
-		},
-		{
-			name:       "namespaces json",
-			args:       []string{"cluster", "namespaces", "1", "--output", "json"},
-			wantStrs:   []string{`"stack-dev-alice"`, `"stack-staging-bob"`},
-			outputJSON: true,
-		},
-		{
-			name:     "utilization table",
-			args:     []string{"cluster", "utilization", "1"},
-			wantStrs: []string{"stack-dev-alice", "500m", "256Mi", "3/10"},
-		},
-		{
-			name:       "utilization json",
-			args:       []string{"cluster", "utilization", "1", "--output", "json"},
-			wantStrs:   []string{`"cluster_id"`, `"stack-dev-alice"`, `"500m"`},
-			outputJSON: true,
-		},
-	}
+	var buf bytes.Buffer
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			cmd.ResetFlagsForTest()
-			var buf bytes.Buffer
-			cmd.SetOut(&buf)
-			cmd.SetArgs(tt.args)
-			require.NoError(t, cmd.Execute())
+	// Seed a cluster via Cobra create so we exercise the same path users hit.
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "create", "--name", "h-cobra"})
+	require.NoError(t, cmd.Execute())
 
-			out := buf.String()
-			for _, want := range tt.wantStrs {
-				assert.Contains(t, out, want)
-			}
-		})
+	state.mu.Lock()
+	var id string
+	for k := range state.clusters {
+		id = k
 	}
+	state.mu.Unlock()
+	require.NotEmpty(t, id)
+
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "health", id})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "Health Status")
+	assert.Contains(t, out, "healthy")
+	assert.Contains(t, out, "3/3")
 }

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -222,9 +222,12 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
 					return
 				}
-				if state.unreachable[id] {
+				state.mu.Lock()
+				unreachable := state.unreachable[id]
+				state.mu.Unlock()
+				if unreachable {
 					w.WriteHeader(http.StatusBadGateway)
-					json.NewEncoder(w).Encode(map[string]string{"status": "error", "message": "Cluster is unreachable"})
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Cluster is unreachable"})
 					return
 				}
 				w.WriteHeader(http.StatusOK)

--- a/entities.json
+++ b/entities.json
@@ -1,0 +1,13 @@
+{
+  "people": [],
+  "projects": [
+    "Command",
+    "Config",
+    "Viper",
+    "Build",
+    "Client",
+    "Table",
+    "Cross",
+    "Release"
+  ]
+}

--- a/mempalace.yaml
+++ b/mempalace.yaml
@@ -1,0 +1,20 @@
+wing: stackctl
+rooms:
+- name: cli
+  description: Files from cli/
+  keywords:
+  - cli
+  - cli
+- name: design
+  description: Files from assets/
+  keywords:
+  - design
+  - assets
+- name: testing
+  description: Files from test/
+  keywords:
+  - testing
+  - test
+- name: general
+  description: Files that don't fit other rooms
+  keywords: []


### PR DESCRIPTION
## Summary
Adds five cluster subcommands wrapping already-shipped k8s-stack-manager endpoints:

| Command | Backend |
| --- | --- |
| `stackctl cluster test-connection <id>` | `POST /api/v1/clusters/:id/test` |
| `stackctl cluster health <id>`          | `GET  /api/v1/clusters/:id/health/summary` |
| `stackctl cluster nodes <id>`           | `GET  /api/v1/clusters/:id/health/nodes` |
| `stackctl cluster namespaces <id>`      | `GET  /api/v1/clusters/:id/namespaces` |
| `stackctl cluster utilization <id>`     | `GET  /api/v1/clusters/:id/utilization` |

Each command supports the standard `--output table|json|yaml` plus `--quiet`. A `deriveHealthStatus` helper collapses the summary into one label — `healthy` (all nodes ready), `degraded` (some not ready), `unknown` (zero nodes registered).

### ⚠️ Breaking (Go API)
`cli/pkg/types.ClusterHealthSummary` is rewritten. The previous fields (`Status`, `CPUUsage`, `MemUsage`, `CPUTotal`, `MemTotal`) didn't match the backend's `k8s.ClusterSummary` JSON shape, so `stackctl cluster get` was silently rendering zero values for those fields. New shape mirrors the wire format:

```go
type ClusterHealthSummary struct {
    NodeCount         int
    ReadyNodeCount    int
    TotalCPU          string
    TotalMemory       string
    AllocatableCPU    string
    AllocatableMemory string
    NamespaceCount    int
}
```

Existing CLI users see *more* health data in `cluster get` after upgrade, not less. Out-of-tree consumers of `cli/pkg/types` need to update field references.

Closes #65

## Test plan
All three layers green locally; `go vet ./...` clean.

- [x] **Unit (cmd)**: every new verb across table/json/yaml/quiet output modes; not-found and unreachable error paths; degraded and unknown health-status branches.
- [x] **Unit (client)**: URL+verb+JSON round-trip for each new client method; error path returns nil result.
- [x] **Integration**: extends `cluster_integration_test.go` mock to handle the five new routes; `TestClusterWorkflow_HealthSurface` walks create → test → health → nodes → namespaces → utilization; `TestClusterWorkflow_TestConnectionUnreachable` covers the 502 path; `TestClusterCobra_Health` drives Cobra in-process.
- [x] **E2E**: `TestE2EClusterHealth` builds the binary and runs `stackctl cluster health 1` in table, json, and quiet modes against the httptest mock.

```
ok  	github.com/omattsson/stackctl/cli/cmd               11.863s
ok  	github.com/omattsson/stackctl/cli/pkg/client         4.489s
ok  	github.com/omattsson/stackctl/cli/test/e2e           5.272s
ok  	github.com/omattsson/stackctl/cli/test/integration  13.842s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster health shows unified Health Status, Ready Nodes, namespaces, and CPU/Memory capacity; quiet mode prints derived label (`unknown`/`healthy`/`degraded`). Default test-connection table includes Message and Server Version.

* **Bug Fixes**
  * Test-connection unreachable cases now surface clear failure results; quiet mode prints status. Namespace Created timestamps formatted in UTC when present.

* **Documentation**
  * Clarified CLI quiet-mode exceptions, stable non-numeric ID outputs, types and testing conventions.

* **Refactor**
  * Reordered cluster tables (PODS before CPU/MEMORY) and improved pod-limit display.

* **Tests**
  * Expanded unit, integration, and e2e coverage for cluster health, connectivity, nodes, namespaces, and utilization.

* **Chores**
  * Added configuration and project metadata (CodeRabbit, mempalace, entities.json).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->