### PR TITLE
feat(cluster): quota get/set/delete commands

### DIFF
--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -1029,6 +1029,20 @@ Examples:
 
 		req := types.SetClusterQuotaRequest{}
 		fromFile, _ := cmd.Flags().GetString("from-file")
+		hasFlagInput := cmd.Flags().Changed("cpu-request") ||
+			cmd.Flags().Changed("cpu-limit") ||
+			cmd.Flags().Changed("memory-request") ||
+			cmd.Flags().Changed("memory-limit") ||
+			cmd.Flags().Changed("storage-limit") ||
+			cmd.Flags().Changed("pod-limit")
+
+		// Fail fast on a bare `quota set <id>` invocation. Without this guard
+		// the pre-fetch path would issue a no-op write (or an empty PUT
+		// against a cluster with no existing quota, silently creating a
+		// zero-valued quota config).
+		if fromFile == "" && !hasFlagInput {
+			return fmt.Errorf("provide --from-file or at least one quota flag (--cpu-request, --cpu-limit, --memory-request, --memory-limit, --storage-limit, --pod-limit)")
+		}
 
 		if fromFile != "" {
 			for _, segment := range strings.Split(filepath.ToSlash(fromFile), "/") {

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -939,6 +940,203 @@ var clusterUtilizationCmd = &cobra.Command{
 	},
 }
 
+// --- Quotas ---
+
+var clusterQuotaCmd = &cobra.Command{
+	Use:   "quota",
+	Short: "Manage cluster-level resource quotas",
+	Long:  "Get, set, and delete the resource-quota config applied to stack-* namespaces on a cluster.",
+}
+
+var clusterQuotaGetCmd = &cobra.Command{
+	Use:          "get <cluster-id>",
+	Short:        "Show the resource-quota config for a cluster",
+	Long:         "Show the resource-quota config that the backend applies to stack-* namespaces on this cluster. Returns a not-found error when no quota is configured.",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		quota, err := c.GetClusterQuota(id)
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, quota.ID)
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(quota)
+		case output.FormatYAML:
+			return printer.PrintYAML(quota)
+		default:
+			return printer.PrintSingle(quota, []output.KeyValue{
+				{Key: "ID", Value: quota.ID},
+				{Key: "Cluster ID", Value: quota.ClusterID},
+				{Key: "CPU Request", Value: quota.CPURequest},
+				{Key: "CPU Limit", Value: quota.CPULimit},
+				{Key: "Memory Request", Value: quota.MemoryRequest},
+				{Key: "Memory Limit", Value: quota.MemoryLimit},
+				{Key: "Storage Limit", Value: quota.StorageLimit},
+				{Key: "Pod Limit", Value: strconv.Itoa(quota.PodLimit)},
+			})
+		}
+	},
+}
+
+var clusterQuotaSetCmd = &cobra.Command{
+	Use:   "set <cluster-id>",
+	Short: "Create or update the resource-quota config for a cluster (admin only)",
+	Long: `Create or update the resource-quota config the backend applies to stack-* namespaces on this cluster.
+
+Provide the payload via --from-file (JSON or YAML), or via individual flags
+(--cpu-request, --cpu-limit, --memory-request, --memory-limit,
+--storage-limit, --pod-limit). When both are provided, individual flags
+override the file.
+
+The backend PUT is a full upsert — any field absent from the request body is
+treated as cleared (string fields) or "no limit" (--pod-limit 0). To preserve
+unspecified fields when using individual flags, the command first fetches the
+existing quota and uses its values as defaults; you only need to specify the
+fields you want to change. With --from-file, the file contents are sent
+verbatim — no merge — so include every field you want to keep.
+
+Examples:
+  stackctl cluster quota set 1 --from-file quota.json
+  stackctl cluster quota set 1 --cpu-limit 8 --memory-limit 16Gi --pod-limit 50
+  stackctl cluster quota set 1 --pod-limit 100   # other fields preserved from current quota`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		req := types.SetClusterQuotaRequest{}
+		fromFile, _ := cmd.Flags().GetString("from-file")
+
+		if fromFile != "" {
+			data, err := os.ReadFile(filepath.Clean(fromFile))
+			if err != nil {
+				return fmt.Errorf("reading file %s: %w", fromFile, err)
+			}
+			if err := json.Unmarshal(data, &req); err != nil {
+				if yamlErr := yaml.Unmarshal(data, &req); yamlErr != nil {
+					return fmt.Errorf("invalid JSON/YAML in file %s (json: %v): %w", fromFile, err, yamlErr)
+				}
+			}
+		} else {
+			// PUT is a full upsert — pre-fetch the existing quota so omitted
+			// flags preserve their current values instead of silently clearing
+			// them. A 404 means "no quota yet" — start from a zero value.
+			existing, getErr := c.GetClusterQuota(id)
+			if getErr == nil {
+				req = types.SetClusterQuotaRequest{
+					CPURequest:    existing.CPURequest,
+					CPULimit:      existing.CPULimit,
+					MemoryRequest: existing.MemoryRequest,
+					MemoryLimit:   existing.MemoryLimit,
+					StorageLimit:  existing.StorageLimit,
+					PodLimit:      existing.PodLimit,
+				}
+			} else {
+				var apiErr *client.APIError
+				if !errors.As(getErr, &apiErr) || apiErr.StatusCode != http.StatusNotFound {
+					return getErr
+				}
+			}
+		}
+
+		// Individual flags override file/existing values when set on the command line.
+		if cmd.Flags().Changed("cpu-request") {
+			req.CPURequest, _ = cmd.Flags().GetString("cpu-request")
+		}
+		if cmd.Flags().Changed("cpu-limit") {
+			req.CPULimit, _ = cmd.Flags().GetString("cpu-limit")
+		}
+		if cmd.Flags().Changed("memory-request") {
+			req.MemoryRequest, _ = cmd.Flags().GetString("memory-request")
+		}
+		if cmd.Flags().Changed("memory-limit") {
+			req.MemoryLimit, _ = cmd.Flags().GetString("memory-limit")
+		}
+		if cmd.Flags().Changed("storage-limit") {
+			req.StorageLimit, _ = cmd.Flags().GetString("storage-limit")
+		}
+		if cmd.Flags().Changed("pod-limit") {
+			req.PodLimit, _ = cmd.Flags().GetInt("pod-limit")
+		}
+
+		quota, err := c.SetClusterQuota(id, &req)
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, quota.ID)
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(quota)
+		case output.FormatYAML:
+			return printer.PrintYAML(quota)
+		default:
+			// Render the persisted quota so the user can confirm the server's
+			// view (post-validation, with timestamps).
+			return printer.PrintSingle(quota, []output.KeyValue{
+				{Key: "ID", Value: quota.ID},
+				{Key: "Cluster ID", Value: quota.ClusterID},
+				{Key: "CPU Request", Value: quota.CPURequest},
+				{Key: "CPU Limit", Value: quota.CPULimit},
+				{Key: "Memory Request", Value: quota.MemoryRequest},
+				{Key: "Memory Limit", Value: quota.MemoryLimit},
+				{Key: "Storage Limit", Value: quota.StorageLimit},
+				{Key: "Pod Limit", Value: strconv.Itoa(quota.PodLimit)},
+			})
+		}
+	},
+}
+
+var clusterQuotaDeleteCmd = &cobra.Command{
+	Use:   "delete <cluster-id>",
+	Short: "Delete the resource-quota config for a cluster (admin only)",
+	Long: `Remove the resource-quota config so the backend no longer applies limits to stack-* namespaces on this cluster.
+
+This is a destructive operation. You will be prompted for confirmation
+unless --yes is specified.
+
+Examples:
+  stackctl cluster quota delete 1
+  stackctl cluster quota delete 1 --yes`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return deleteByID(cmd, args,
+			"This will remove the resource-quota config for cluster %s. Continue? (y/n): ",
+			passthroughID,
+			func(c *client.Client, id string) error { return c.DeleteClusterQuota(id) },
+			"Deleted resource-quota config for cluster %s",
+		)
+	},
+}
+
 func init() {
 	// shared-values set flags
 	clusterSharedValuesSetCmd.Flags().String("name", "", "Name for the shared values entry (required)")
@@ -975,6 +1173,24 @@ func init() {
 	clusterSharedValuesCmd.AddCommand(clusterSharedValuesSetCmd)
 	clusterSharedValuesCmd.AddCommand(clusterSharedValuesDeleteCmd)
 
+	// cluster quota set flags
+	clusterQuotaSetCmd.Flags().String("from-file", "", "JSON or YAML file with the SetClusterQuotaRequest payload")
+	clusterQuotaSetCmd.Flags().String("cpu-request", "", "CPU request limit (Kubernetes resource notation, e.g. \"500m\")")
+	clusterQuotaSetCmd.Flags().String("cpu-limit", "", "CPU limit")
+	clusterQuotaSetCmd.Flags().String("memory-request", "", "Memory request limit (e.g. \"2Gi\")")
+	clusterQuotaSetCmd.Flags().String("memory-limit", "", "Memory limit")
+	clusterQuotaSetCmd.Flags().String("storage-limit", "", "Storage limit")
+	clusterQuotaSetCmd.Flags().Int("pod-limit", 0, "Pod-count limit (0 = no limit)")
+
+	// cluster quota delete flags
+	clusterQuotaDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	clusterQuotaDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+
+	// Wire up quota subcommands
+	clusterQuotaCmd.AddCommand(clusterQuotaGetCmd)
+	clusterQuotaCmd.AddCommand(clusterQuotaSetCmd)
+	clusterQuotaCmd.AddCommand(clusterQuotaDeleteCmd)
+
 	clusterCmd.AddCommand(clusterListCmd)
 	clusterCmd.AddCommand(clusterGetCmd)
 	clusterCmd.AddCommand(clusterSharedValuesCmd)
@@ -987,5 +1203,6 @@ func init() {
 	clusterCmd.AddCommand(clusterNodesCmd)
 	clusterCmd.AddCommand(clusterNamespacesCmd)
 	clusterCmd.AddCommand(clusterUtilizationCmd)
+	clusterCmd.AddCommand(clusterQuotaCmd)
 	rootCmd.AddCommand(clusterCmd)
 }

--- a/cli/cmd/cluster.go
+++ b/cli/cmd/cluster.go
@@ -1031,7 +1031,13 @@ Examples:
 		fromFile, _ := cmd.Flags().GetString("from-file")
 
 		if fromFile != "" {
-			data, err := os.ReadFile(filepath.Clean(fromFile))
+			for _, segment := range strings.Split(filepath.ToSlash(fromFile), "/") {
+				if segment == ".." {
+					return fmt.Errorf("file path must not contain '..' segments")
+				}
+			}
+			fromFile = filepath.Clean(fromFile)
+			data, err := os.ReadFile(fromFile)
 			if err != nil {
 				return fmt.Errorf("reading file %s: %w", fromFile, err)
 			}

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -2060,6 +2060,22 @@ func TestClusterQuotaSetCmd_Forbidden(t *testing.T) {
 	assert.Contains(t, err.Error(), "Permission denied")
 }
 
+// Without --from-file or any quota flag, `set` previously issued a silent
+// no-op (or zero-value-creating) PUT. The fail-fast guard makes the contract
+// explicit.
+func TestClusterQuotaSetCmd_RejectsBareInvocation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("backend should NOT be called when no payload is provided; got %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provide --from-file or at least one quota flag")
+}
+
 func TestClusterQuotaSetCmd_RejectsPathTraversal(t *testing.T) {
 	// Mirrors cluster create / update / shared-values set: any `..` segment
 	// in the --from-file path is rejected before opening the file.

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1752,3 +1752,403 @@ func TestClusterHealthCmd_NotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cluster not found")
 }
+
+// ---------- cluster quota ----------
+
+// resetFlag sets a flag value AND clears its Changed marker. Plain
+// `flags.Set(name, "")` resets the value but leaves Changed=true, which leaks
+// across tests that use `cmd.Flags().Changed(...)` to detect explicit flags.
+func resetFlag(fs *pflag.FlagSet, name, value string) {
+	_ = fs.Set(name, value)
+	if f := fs.Lookup(name); f != nil {
+		f.Changed = false
+	}
+}
+
+func sampleClusterQuota() types.ClusterQuota {
+	now := time.Date(2026, 1, 10, 14, 30, 0, 0, time.UTC)
+	return types.ClusterQuota{
+		ID: "q1", ClusterID: "1",
+		CPURequest: "500m", CPULimit: "4",
+		MemoryRequest: "1Gi", MemoryLimit: "16Gi",
+		StorageLimit: "100Gi", PodLimit: 50,
+		CreatedAt: now, UpdatedAt: now,
+	}
+}
+
+func TestClusterQuotaGetCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterQuota())
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	err := clusterQuotaGetCmd.RunE(clusterQuotaGetCmd, []string{"1"})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "CPU Request")
+	assert.Contains(t, out, "500m")
+	assert.Contains(t, out, "16Gi")
+	assert.Contains(t, out, "50")
+}
+
+func TestClusterQuotaGetCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterQuota())
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	err := clusterQuotaGetCmd.RunE(clusterQuotaGetCmd, []string{"1"})
+	require.NoError(t, err)
+
+	var got types.ClusterQuota
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "q1", got.ID)
+	assert.Equal(t, 50, got.PodLimit)
+}
+
+func TestClusterQuotaGetCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterQuota())
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	err := clusterQuotaGetCmd.RunE(clusterQuotaGetCmd, []string{"1"})
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "id: q1")
+	assert.Contains(t, out, "pod_limit: 50")
+}
+
+func TestClusterQuotaGetCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterQuota())
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	err := clusterQuotaGetCmd.RunE(clusterQuotaGetCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "q1\n", buf.String())
+}
+
+func TestClusterQuotaGetCmd_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "resource quota config not found"})
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	err := clusterQuotaGetCmd.RunE(clusterQuotaGetCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestClusterQuotaSetCmd_FromFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
+		require.Equal(t, http.MethodPut, r.Method)
+
+		var got types.SetClusterQuotaRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "4", got.CPULimit)
+		assert.Equal(t, "16Gi", got.MemoryLimit)
+		assert.Equal(t, 50, got.PodLimit)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterQuota())
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "quota.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"cpu_limit":"4","memory_limit":"16Gi","pod_limit":50}`), 0o600))
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterQuotaSetCmd.Flags().Set("from-file", path)
+	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "") })
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.NoError(t, err)
+	out := buf.String()
+	// `set` now renders the persisted quota (post-validation, with timestamps)
+	// so the user can confirm the server's view.
+	assert.Contains(t, out, "Cluster ID")
+	assert.Contains(t, out, "Pod Limit")
+	assert.Contains(t, out, "q1")
+}
+
+func TestClusterQuotaSetCmd_FlagsOverrideFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got types.SetClusterQuotaRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		// File supplied cpu_limit=4 and pod_limit=50; --pod-limit=100 overrides.
+		assert.Equal(t, "4", got.CPULimit)
+		assert.Equal(t, 100, got.PodLimit)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(sampleClusterQuota())
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "quota.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"cpu_limit":"4","pod_limit":50}`), 0o600))
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterQuotaSetCmd.Flags().Set("from-file", path)
+	clusterQuotaSetCmd.Flags().Set("pod-limit", "100")
+	t.Cleanup(func() {
+		resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "")
+		resetFlag(clusterQuotaSetCmd.Flags(), "pod-limit", "0")
+	})
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.NoError(t, err)
+}
+
+func TestClusterQuotaSetCmd_FromFlagsOnly(t *testing.T) {
+	// Flag-only `set` triggers a pre-fetch GET so unspecified fields preserve
+	// their current values. Mock both: 404 on GET (no existing quota) +
+	// 200 on PUT echoing the request shape.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "resource quota config not found"})
+		case http.MethodPut:
+			var got types.SetClusterQuotaRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+			assert.Equal(t, "8", got.CPULimit)
+			assert.Equal(t, "32Gi", got.MemoryLimit)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(sampleClusterQuota())
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterQuotaSetCmd.Flags().Set("cpu-limit", "8")
+	clusterQuotaSetCmd.Flags().Set("memory-limit", "32Gi")
+	t.Cleanup(func() {
+		resetFlag(clusterQuotaSetCmd.Flags(), "cpu-limit", "")
+		resetFlag(clusterQuotaSetCmd.Flags(), "memory-limit", "")
+	})
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.NoError(t, err)
+}
+
+// Regression test for the "PUT wipes unspecified fields" hazard: flag-only set
+// with only --pod-limit must preserve CPU/memory limits from the existing
+// quota, not silently clear them.
+func TestClusterQuotaSetCmd_FlagsMergeWithExisting(t *testing.T) {
+	existing := sampleClusterQuota() // CPULimit "4", MemoryLimit "16Gi", PodLimit 50
+	var putBody types.SetClusterQuotaRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(existing)
+		case http.MethodPut:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&putBody))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(existing)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterQuotaSetCmd.Flags().Set("pod-limit", "100")
+	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "pod-limit", "0") })
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.NoError(t, err)
+
+	// pod-limit changed; everything else preserved from the existing quota.
+	assert.Equal(t, 100, putBody.PodLimit)
+	assert.Equal(t, "4", putBody.CPULimit, "CPU limit must be preserved from existing quota")
+	assert.Equal(t, "16Gi", putBody.MemoryLimit, "Memory limit must be preserved from existing quota")
+	assert.Equal(t, "500m", putBody.CPURequest, "CPU request must be preserved from existing quota")
+}
+
+func TestClusterQuotaSetCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "resource quota config not found"})
+		case http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(sampleClusterQuota())
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+	clusterQuotaSetCmd.Flags().Set("cpu-limit", "4")
+	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "cpu-limit", "") })
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, "q1\n", buf.String())
+}
+
+func TestClusterQuotaSetCmd_Forbidden(t *testing.T) {
+	// Realistic admin-gating: GET (devops) returns 404 (no quota yet),
+	// PUT (admin) returns 403 — we want to surface the PUT 403 cleanly.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "resource quota config not found"})
+		case http.MethodPut:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterQuotaSetCmd.Flags().Set("cpu-limit", "4")
+	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "cpu-limit", "") })
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Permission denied")
+}
+
+func TestClusterQuotaSetCmd_BadFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json {;;}"), 0o600))
+
+	_ = setupClusterTestCmd(t, "http://unused")
+	clusterQuotaSetCmd.Flags().Set("from-file", path)
+	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "") })
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON/YAML")
+}
+
+func TestClusterQuotaDeleteCmd_WithYesFlag(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
+		require.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterQuotaDeleteCmd.Flags().Set("yes", "true")
+	t.Cleanup(func() { resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false") })
+
+	err := clusterQuotaDeleteCmd.RunE(clusterQuotaDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Contains(t, buf.String(), "Deleted resource-quota config for cluster 1")
+}
+
+func TestClusterQuotaDeleteCmd_ConfirmAccept(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterQuotaDeleteCmd.Flags().Set("yes", "false")
+	t.Cleanup(func() {
+		resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false")
+		clusterQuotaDeleteCmd.SetIn(nil)
+		clusterQuotaDeleteCmd.SetErr(nil)
+	})
+	clusterQuotaDeleteCmd.SetIn(strings.NewReader("y\n"))
+	clusterQuotaDeleteCmd.SetErr(&bytes.Buffer{})
+
+	err := clusterQuotaDeleteCmd.RunE(clusterQuotaDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Contains(t, buf.String(), "Deleted resource-quota config")
+}
+
+func TestClusterQuotaDeleteCmd_Declined(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API should NOT be called when user declines")
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	clusterQuotaDeleteCmd.Flags().Set("yes", "false")
+	t.Cleanup(func() {
+		resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false")
+		clusterQuotaDeleteCmd.SetIn(nil)
+		clusterQuotaDeleteCmd.SetErr(nil)
+	})
+	clusterQuotaDeleteCmd.SetIn(strings.NewReader("n\n"))
+	clusterQuotaDeleteCmd.SetErr(&bytes.Buffer{})
+
+	err := clusterQuotaDeleteCmd.RunE(clusterQuotaDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Aborted")
+}
+
+func TestClusterQuotaDeleteCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+	}))
+	defer server.Close()
+
+	_ = setupClusterTestCmd(t, server.URL)
+	clusterQuotaDeleteCmd.Flags().Set("yes", "true")
+	t.Cleanup(func() { resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false") })
+
+	err := clusterQuotaDeleteCmd.RunE(clusterQuotaDeleteCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Permission denied")
+}

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1758,8 +1758,10 @@ func TestClusterHealthCmd_NotFound(t *testing.T) {
 // resetFlag sets a flag value AND clears its Changed marker. Plain
 // `flags.Set(name, "")` resets the value but leaves Changed=true, which leaks
 // across tests that use `cmd.Flags().Changed(...)` to detect explicit flags.
-func resetFlag(fs *pflag.FlagSet, name, value string) {
-	_ = fs.Set(name, value)
+// Surfaces fs.Set errors via require so a typo in a flag name fails fast.
+func resetFlag(t *testing.T, fs *pflag.FlagSet, name, value string) {
+	t.Helper()
+	require.NoError(t, fs.Set(name, value), "resetFlag: setting %q to %q", name, value)
 	if f := fs.Lookup(name); f != nil {
 		f.Changed = false
 	}
@@ -1890,7 +1892,7 @@ func TestClusterQuotaSetCmd_FromFile(t *testing.T) {
 
 	buf := setupClusterTestCmd(t, server.URL)
 	clusterQuotaSetCmd.Flags().Set("from-file", path)
-	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaSetCmd.Flags(), "from-file", "") })
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
 	require.NoError(t, err)
@@ -1924,8 +1926,8 @@ func TestClusterQuotaSetCmd_FlagsOverrideFile(t *testing.T) {
 	clusterQuotaSetCmd.Flags().Set("from-file", path)
 	clusterQuotaSetCmd.Flags().Set("pod-limit", "100")
 	t.Cleanup(func() {
-		resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "")
-		resetFlag(clusterQuotaSetCmd.Flags(), "pod-limit", "0")
+		resetFlag(t, clusterQuotaSetCmd.Flags(), "from-file", "")
+		resetFlag(t, clusterQuotaSetCmd.Flags(), "pod-limit", "0")
 	})
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
@@ -1937,6 +1939,7 @@ func TestClusterQuotaSetCmd_FromFlagsOnly(t *testing.T) {
 	// their current values. Mock both: 404 on GET (no existing quota) +
 	// 200 on PUT echoing the request shape.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
 		switch r.Method {
 		case http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
@@ -1960,8 +1963,8 @@ func TestClusterQuotaSetCmd_FromFlagsOnly(t *testing.T) {
 	clusterQuotaSetCmd.Flags().Set("cpu-limit", "8")
 	clusterQuotaSetCmd.Flags().Set("memory-limit", "32Gi")
 	t.Cleanup(func() {
-		resetFlag(clusterQuotaSetCmd.Flags(), "cpu-limit", "")
-		resetFlag(clusterQuotaSetCmd.Flags(), "memory-limit", "")
+		resetFlag(t, clusterQuotaSetCmd.Flags(), "cpu-limit", "")
+		resetFlag(t, clusterQuotaSetCmd.Flags(), "memory-limit", "")
 	})
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
@@ -1975,6 +1978,7 @@ func TestClusterQuotaSetCmd_FlagsMergeWithExisting(t *testing.T) {
 	existing := sampleClusterQuota() // CPULimit "4", MemoryLimit "16Gi", PodLimit 50
 	var putBody types.SetClusterQuotaRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
 		switch r.Method {
 		case http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
@@ -1993,7 +1997,7 @@ func TestClusterQuotaSetCmd_FlagsMergeWithExisting(t *testing.T) {
 
 	_ = setupClusterTestCmd(t, server.URL)
 	clusterQuotaSetCmd.Flags().Set("pod-limit", "100")
-	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "pod-limit", "0") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaSetCmd.Flags(), "pod-limit", "0") })
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
 	require.NoError(t, err)
@@ -2007,6 +2011,7 @@ func TestClusterQuotaSetCmd_FlagsMergeWithExisting(t *testing.T) {
 
 func TestClusterQuotaSetCmd_QuietOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
 		switch r.Method {
 		case http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
@@ -2025,7 +2030,7 @@ func TestClusterQuotaSetCmd_QuietOutput(t *testing.T) {
 	buf := setupClusterTestCmd(t, server.URL)
 	printer.Quiet = true
 	clusterQuotaSetCmd.Flags().Set("cpu-limit", "4")
-	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "cpu-limit", "") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaSetCmd.Flags(), "cpu-limit", "") })
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
 	require.NoError(t, err)
@@ -2036,6 +2041,7 @@ func TestClusterQuotaSetCmd_Forbidden(t *testing.T) {
 	// Realistic admin-gating: GET (devops) returns 404 (no quota yet),
 	// PUT (admin) returns 403 — we want to surface the PUT 403 cleanly.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
 		switch r.Method {
 		case http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
@@ -2053,7 +2059,7 @@ func TestClusterQuotaSetCmd_Forbidden(t *testing.T) {
 
 	_ = setupClusterTestCmd(t, server.URL)
 	clusterQuotaSetCmd.Flags().Set("cpu-limit", "4")
-	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "cpu-limit", "") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaSetCmd.Flags(), "cpu-limit", "") })
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
 	require.Error(t, err)
@@ -2081,7 +2087,7 @@ func TestClusterQuotaSetCmd_RejectsPathTraversal(t *testing.T) {
 	// in the --from-file path is rejected before opening the file.
 	_ = setupClusterTestCmd(t, "http://unused")
 	clusterQuotaSetCmd.Flags().Set("from-file", "../escape.json")
-	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaSetCmd.Flags(), "from-file", "") })
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
 	require.Error(t, err)
@@ -2095,7 +2101,7 @@ func TestClusterQuotaSetCmd_BadFile(t *testing.T) {
 
 	_ = setupClusterTestCmd(t, "http://unused")
 	clusterQuotaSetCmd.Flags().Set("from-file", path)
-	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaSetCmd.Flags(), "from-file", "") })
 
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
 	require.Error(t, err)
@@ -2114,12 +2120,35 @@ func TestClusterQuotaDeleteCmd_WithYesFlag(t *testing.T) {
 
 	buf := setupClusterTestCmd(t, server.URL)
 	clusterQuotaDeleteCmd.Flags().Set("yes", "true")
-	t.Cleanup(func() { resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaDeleteCmd.Flags(), "yes", "false") })
 
 	err := clusterQuotaDeleteCmd.RunE(clusterQuotaDeleteCmd, []string{"1"})
 	require.NoError(t, err)
 	assert.True(t, called)
 	assert.Contains(t, buf.String(), "Deleted resource-quota config for cluster 1")
+}
+
+// Quiet mode for `cluster quota delete` echoes the cluster ID only (no
+// descriptive message), via the shared deleteByID helper.
+func TestClusterQuotaDeleteCmd_QuietOutput(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		require.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
+		require.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupClusterTestCmd(t, server.URL)
+	printer.Quiet = true
+	clusterQuotaDeleteCmd.Flags().Set("yes", "true")
+	t.Cleanup(func() { resetFlag(t, clusterQuotaDeleteCmd.Flags(), "yes", "false") })
+
+	err := clusterQuotaDeleteCmd.RunE(clusterQuotaDeleteCmd, []string{"1"})
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, "1\n", buf.String(), "quiet mode must echo only the cluster ID")
 }
 
 func TestClusterQuotaDeleteCmd_ConfirmAccept(t *testing.T) {
@@ -2133,7 +2162,7 @@ func TestClusterQuotaDeleteCmd_ConfirmAccept(t *testing.T) {
 	buf := setupClusterTestCmd(t, server.URL)
 	clusterQuotaDeleteCmd.Flags().Set("yes", "false")
 	t.Cleanup(func() {
-		resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false")
+		resetFlag(t, clusterQuotaDeleteCmd.Flags(), "yes", "false")
 		clusterQuotaDeleteCmd.SetIn(nil)
 		clusterQuotaDeleteCmd.SetErr(nil)
 	})
@@ -2155,7 +2184,7 @@ func TestClusterQuotaDeleteCmd_Declined(t *testing.T) {
 	buf := setupClusterTestCmd(t, server.URL)
 	clusterQuotaDeleteCmd.Flags().Set("yes", "false")
 	t.Cleanup(func() {
-		resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false")
+		resetFlag(t, clusterQuotaDeleteCmd.Flags(), "yes", "false")
 		clusterQuotaDeleteCmd.SetIn(nil)
 		clusterQuotaDeleteCmd.SetErr(nil)
 	})
@@ -2177,7 +2206,7 @@ func TestClusterQuotaDeleteCmd_Forbidden(t *testing.T) {
 
 	_ = setupClusterTestCmd(t, server.URL)
 	clusterQuotaDeleteCmd.Flags().Set("yes", "true")
-	t.Cleanup(func() { resetFlag(clusterQuotaDeleteCmd.Flags(), "yes", "false") })
+	t.Cleanup(func() { resetFlag(t, clusterQuotaDeleteCmd.Flags(), "yes", "false") })
 
 	err := clusterQuotaDeleteCmd.RunE(clusterQuotaDeleteCmd, []string{"1"})
 	require.Error(t, err)

--- a/cli/cmd/cluster_test.go
+++ b/cli/cmd/cluster_test.go
@@ -1768,11 +1768,14 @@ func resetFlag(fs *pflag.FlagSet, name, value string) {
 func sampleClusterQuota() types.ClusterQuota {
 	now := time.Date(2026, 1, 10, 14, 30, 0, 0, time.UTC)
 	return types.ClusterQuota{
-		ID: "q1", ClusterID: "1",
-		CPURequest: "500m", CPULimit: "4",
-		MemoryRequest: "1Gi", MemoryLimit: "16Gi",
-		StorageLimit: "100Gi", PodLimit: 50,
-		CreatedAt: now, UpdatedAt: now,
+		Base:          types.Base{ID: "q1", CreatedAt: now, UpdatedAt: now},
+		ClusterID:     "1",
+		CPURequest:    "500m",
+		CPULimit:      "4",
+		MemoryRequest: "1Gi",
+		MemoryLimit:   "16Gi",
+		StorageLimit:  "100Gi",
+		PodLimit:      50,
 	}
 }
 
@@ -2055,6 +2058,18 @@ func TestClusterQuotaSetCmd_Forbidden(t *testing.T) {
 	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Permission denied")
+}
+
+func TestClusterQuotaSetCmd_RejectsPathTraversal(t *testing.T) {
+	// Mirrors cluster create / update / shared-values set: any `..` segment
+	// in the --from-file path is rejected before opening the file.
+	_ = setupClusterTestCmd(t, "http://unused")
+	clusterQuotaSetCmd.Flags().Set("from-file", "../escape.json")
+	t.Cleanup(func() { resetFlag(clusterQuotaSetCmd.Flags(), "from-file", "") })
+
+	err := clusterQuotaSetCmd.RunE(clusterQuotaSetCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'..' segments")
 }
 
 func TestClusterQuotaSetCmd_BadFile(t *testing.T) {

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1106,6 +1106,40 @@ func (c *Client) GetClusterNamespaces(id string) ([]types.ClusterNamespace, erro
 	return namespaces, nil
 }
 
+// GetClusterQuota returns the resource-quota config for a cluster.
+// The backend responds 404 when no quota is configured for the cluster;
+// that surfaces here as a *client.APIError with StatusCode == 404.
+//
+// @see GET /api/v1/clusters/:id/quotas
+func (c *Client) GetClusterQuota(id string) (*types.ClusterQuota, error) {
+	var quota types.ClusterQuota
+	if err := c.Get(fmt.Sprintf("/api/v1/clusters/%s/quotas", id), &quota); err != nil {
+		return nil, err
+	}
+	return &quota, nil
+}
+
+// SetClusterQuota upserts the resource-quota config for a cluster (admin only).
+// The backend re-reads the saved config so the returned struct has ID and
+// timestamps populated.
+//
+// @see PUT /api/v1/clusters/:id/quotas
+func (c *Client) SetClusterQuota(id string, req *types.SetClusterQuotaRequest) (*types.ClusterQuota, error) {
+	var quota types.ClusterQuota
+	if err := c.Put(fmt.Sprintf("/api/v1/clusters/%s/quotas", id), req, &quota); err != nil {
+		return nil, err
+	}
+	return &quota, nil
+}
+
+// DeleteClusterQuota removes the resource-quota config for a cluster (admin
+// only). Returns nil on the 204 path; APIError on 403/404/5xx.
+//
+// @see DELETE /api/v1/clusters/:id/quotas
+func (c *Client) DeleteClusterQuota(id string) error {
+	return c.Delete(fmt.Sprintf("/api/v1/clusters/%s/quotas", id))
+}
+
 // GetClusterUtilization returns aggregated per-namespace resource utilization.
 //
 // @see GET /api/v1/clusters/:id/utilization

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2281,8 +2281,9 @@ func TestGetClusterQuota_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.ClusterQuota{
-			ID: "q1", ClusterID: "1",
-			CPULimit: "4", MemoryLimit: "16Gi", PodLimit: 50,
+			Base:      types.Base{ID: "q1"},
+			ClusterID: "1",
+			CPULimit:  "4", MemoryLimit: "16Gi", PodLimit: 50,
 		})
 	}))
 	defer server.Close()
@@ -2329,8 +2330,9 @@ func TestSetClusterQuota_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.ClusterQuota{
-			ID: "q1", ClusterID: "1",
-			CPULimit: got.CPULimit, PodLimit: got.PodLimit,
+			Base:      types.Base{ID: "q1"},
+			ClusterID: "1",
+			CPULimit:  got.CPULimit, PodLimit: got.PodLimit,
 		})
 	}))
 	defer server.Close()

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2271,6 +2271,129 @@ func TestGetClusterUtilization_Success(t *testing.T) {
 	assert.Equal(t, 10, util.Namespaces[0].PodCount)
 }
 
+// ---------- cluster quota ----------
+
+func TestGetClusterQuota_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.ClusterQuota{
+			ID: "q1", ClusterID: "1",
+			CPULimit: "4", MemoryLimit: "16Gi", PodLimit: 50,
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	quota, err := c.GetClusterQuota("1")
+	require.NoError(t, err)
+	assert.Equal(t, "q1", quota.ID)
+	assert.Equal(t, "1", quota.ClusterID)
+	assert.Equal(t, "4", quota.CPULimit)
+	assert.Equal(t, 50, quota.PodLimit)
+}
+
+func TestGetClusterQuota_NotFound(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "resource quota config not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	quota, err := c.GetClusterQuota("1")
+	require.Error(t, err)
+	assert.Nil(t, quota)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+}
+
+func TestSetClusterQuota_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
+		// Verify body shape — `pod_limit` must serialize even when 0 (backend
+		// treats 0 as "no limit", not "field absent").
+		var got types.SetClusterQuotaRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "4", got.CPULimit)
+		assert.Equal(t, 50, got.PodLimit)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.ClusterQuota{
+			ID: "q1", ClusterID: "1",
+			CPULimit: got.CPULimit, PodLimit: got.PodLimit,
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	quota, err := c.SetClusterQuota("1", &types.SetClusterQuotaRequest{
+		CPULimit: "4", PodLimit: 50,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "q1", quota.ID)
+	assert.Equal(t, "4", quota.CPULimit)
+	assert.Equal(t, 50, quota.PodLimit)
+}
+
+func TestSetClusterQuota_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	quota, err := c.SetClusterQuota("1", &types.SetClusterQuotaRequest{CPULimit: "4"})
+	require.Error(t, err)
+	assert.Nil(t, quota)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+	assert.Contains(t, apiErr.UserFacingError(), "Permission denied")
+}
+
+func TestDeleteClusterQuota_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/clusters/1/quotas", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.DeleteClusterQuota("1"))
+}
+
+func TestDeleteClusterQuota_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.DeleteClusterQuota("1")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
 // ---------- shared values ----------
 
 func TestListSharedValues_Success(t *testing.T) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -417,6 +417,53 @@ type NamespaceResourceUsage struct {
 	PodLimit    int    `json:"pod_limit" yaml:"pod_limit"`
 }
 
+// ClusterQuota is the success-path response of
+// GET /api/v1/clusters/:id/quotas and the response of
+// PUT /api/v1/clusters/:id/quotas after upsert. Mirrors the backend
+// models.ResourceQuotaConfig struct. Populated by Client.GetClusterQuota /
+// Client.SetClusterQuota.
+//
+// The backend returns 404 when no quota is set for the cluster — the client
+// surfaces that as an APIError with StatusCode 404, and the CLI distinguishes
+// "no quota configured" from a missing cluster by checking that error.
+//
+// Field semantics:
+//   - ID, ClusterID, CreatedAt, UpdatedAt — always populated on the 200 path
+//     (server-owned; ignored if sent in a PUT body).
+//   - CPURequest, CPULimit, MemoryRequest, MemoryLimit, StorageLimit — empty
+//     string when that dimension has no limit set. Kubernetes resource notation
+//     when populated ("2", "500m", "4Gi").
+//   - PodLimit — 0 means "no pod-count limit"; positive integers cap namespace
+//     pod count.
+type ClusterQuota struct {
+	ID            string    `json:"id" yaml:"id"`
+	ClusterID     string    `json:"cluster_id" yaml:"cluster_id"`
+	CPURequest    string    `json:"cpu_request,omitempty" yaml:"cpu_request,omitempty"`
+	CPULimit      string    `json:"cpu_limit,omitempty" yaml:"cpu_limit,omitempty"`
+	MemoryRequest string    `json:"memory_request,omitempty" yaml:"memory_request,omitempty"`
+	MemoryLimit   string    `json:"memory_limit,omitempty" yaml:"memory_limit,omitempty"`
+	StorageLimit  string    `json:"storage_limit,omitempty" yaml:"storage_limit,omitempty"`
+	PodLimit      int       `json:"pod_limit" yaml:"pod_limit"`
+	CreatedAt     time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt     time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+}
+
+// SetClusterQuotaRequest is the body for PUT /api/v1/clusters/:id/quotas
+// (admin-only). Mirrors the backend handlers.UpdateQuotaRequest. Used by
+// Client.SetClusterQuota.
+//
+// Field semantics:
+//   - Any string field left empty removes that dimension's limit on upsert.
+//   - PodLimit == 0 means "no pod-count limit" (not "leave unchanged").
+type SetClusterQuotaRequest struct {
+	CPURequest    string `json:"cpu_request" yaml:"cpu_request"`
+	CPULimit      string `json:"cpu_limit" yaml:"cpu_limit"`
+	MemoryRequest string `json:"memory_request" yaml:"memory_request"`
+	MemoryLimit   string `json:"memory_limit" yaml:"memory_limit"`
+	StorageLimit  string `json:"storage_limit" yaml:"storage_limit"`
+	PodLimit      int    `json:"pod_limit" yaml:"pod_limit"`
+}
+
 // ClusterUtilization is the success-path response of
 // GET /api/v1/clusters/:id/utilization (HTTP 200 only). Mirrors backend
 // ClusterUtilization. Populated by Client.GetClusterUtilization.

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -423,29 +423,33 @@ type NamespaceResourceUsage struct {
 // models.ResourceQuotaConfig struct. Populated by Client.GetClusterQuota /
 // Client.SetClusterQuota.
 //
+// Embeds Base per the repo convention for resource entities. The backend's
+// ResourceQuotaConfig does not include a Version field, so the embedded
+// Base.Version is always the zero string on the read path.
+//
 // The backend returns 404 when no quota is set for the cluster — the client
 // surfaces that as an APIError with StatusCode 404, and the CLI distinguishes
 // "no quota configured" from a missing cluster by checking that error.
 //
 // Field semantics:
-//   - ID, ClusterID, CreatedAt, UpdatedAt — always populated on the 200 path
-//     (server-owned; ignored if sent in a PUT body).
+//   - Base.ID, ClusterID, Base.CreatedAt, Base.UpdatedAt — always populated on
+//     the 200 path (server-owned; ignored if sent in a PUT body).
+//   - Base.Version, Base.DeletedAt — not used by this resource; left as zero
+//     values for convention compliance.
 //   - CPURequest, CPULimit, MemoryRequest, MemoryLimit, StorageLimit — empty
 //     string when that dimension has no limit set. Kubernetes resource notation
 //     when populated ("2", "500m", "4Gi").
 //   - PodLimit — 0 means "no pod-count limit"; positive integers cap namespace
 //     pod count.
 type ClusterQuota struct {
-	ID            string    `json:"id" yaml:"id"`
-	ClusterID     string    `json:"cluster_id" yaml:"cluster_id"`
-	CPURequest    string    `json:"cpu_request,omitempty" yaml:"cpu_request,omitempty"`
-	CPULimit      string    `json:"cpu_limit,omitempty" yaml:"cpu_limit,omitempty"`
-	MemoryRequest string    `json:"memory_request,omitempty" yaml:"memory_request,omitempty"`
-	MemoryLimit   string    `json:"memory_limit,omitempty" yaml:"memory_limit,omitempty"`
-	StorageLimit  string    `json:"storage_limit,omitempty" yaml:"storage_limit,omitempty"`
-	PodLimit      int       `json:"pod_limit" yaml:"pod_limit"`
-	CreatedAt     time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	UpdatedAt     time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	Base
+	ClusterID     string `json:"cluster_id" yaml:"cluster_id"`
+	CPURequest    string `json:"cpu_request,omitempty" yaml:"cpu_request,omitempty"`
+	CPULimit      string `json:"cpu_limit,omitempty" yaml:"cpu_limit,omitempty"`
+	MemoryRequest string `json:"memory_request,omitempty" yaml:"memory_request,omitempty"`
+	MemoryLimit   string `json:"memory_limit,omitempty" yaml:"memory_limit,omitempty"`
+	StorageLimit  string `json:"storage_limit,omitempty" yaml:"storage_limit,omitempty"`
+	PodLimit      int    `json:"pod_limit" yaml:"pod_limit"`
 }
 
 // SetClusterQuotaRequest is the body for PUT /api/v1/clusters/:id/quotas

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -1817,6 +1817,32 @@ func startE2EClusterMockServer(t *testing.T) *httptest.Server {
 		case r.URL.Path == "/api/v1/clusters/1/default" && r.Method == http.MethodPost:
 			w.WriteHeader(http.StatusNoContent)
 
+		// PUT /api/v1/clusters/1/quotas
+		case r.URL.Path == "/api/v1/clusters/1/quotas" && r.Method == http.MethodPut:
+			var req map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "q1", "cluster_id": "1",
+				"cpu_request": req["cpu_request"], "cpu_limit": req["cpu_limit"],
+				"memory_request": req["memory_request"], "memory_limit": req["memory_limit"],
+				"storage_limit": req["storage_limit"], "pod_limit": req["pod_limit"],
+				"created_at": "2026-01-10T14:30:00Z", "updated_at": "2026-01-10T14:30:00Z",
+			})
+
+		// GET /api/v1/clusters/1/quotas
+		case r.URL.Path == "/api/v1/clusters/1/quotas" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "q1", "cluster_id": "1",
+				"cpu_limit": "4", "memory_limit": "16Gi", "pod_limit": 50,
+				"created_at": "2026-01-10T14:30:00Z", "updated_at": "2026-01-10T14:30:00Z",
+			})
+
+		// DELETE /api/v1/clusters/1/quotas
+		case r.URL.Path == "/api/v1/clusters/1/quotas" && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
@@ -1944,4 +1970,47 @@ func TestE2EClusterHealth(t *testing.T) {
 	stdout, _, err = runStackctl(t, dir, "cluster", "health", "1", "--quiet")
 	require.NoError(t, err)
 	assert.Equal(t, "healthy\n", stdout)
+}
+
+func TestE2EClusterQuotaSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EClusterMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	// Write a quota payload to a temp file.
+	quotaFile := filepath.Join(dir, "quota.json")
+	require.NoError(t, os.WriteFile(quotaFile, []byte(`{
+  "cpu_limit": "4",
+  "memory_limit": "16Gi",
+  "pod_limit": 50
+}`), 0o600))
+
+	// stackctl cluster quota set 1 --from-file quota.json
+	stdout, _, err := runStackctl(t, dir, "cluster", "quota", "set", "1", "--from-file", quotaFile)
+	require.NoError(t, err)
+	// `set` renders the persisted quota in default mode so users can confirm
+	// the server's view (post-validation, with timestamps).
+	assert.Contains(t, stdout, "Cluster ID")
+	assert.Contains(t, stdout, "Pod Limit")
+
+	// stackctl cluster quota get 1 -o json — verify the returned shape.
+	stdout, _, err = runStackctl(t, dir, "cluster", "quota", "get", "1", "--output", "json")
+	require.NoError(t, err)
+	var got struct {
+		ID       string `json:"id"`
+		PodLimit int    `json:"pod_limit"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.Equal(t, "q1", got.ID)
+	assert.Equal(t, 50, got.PodLimit)
+
+	// stackctl cluster quota delete 1 --yes
+	_, _, err = runStackctl(t, dir, "cluster", "quota", "delete", "1", "--yes")
+	require.NoError(t, err)
 }

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -1701,6 +1701,16 @@ func TestE2E_BulkTemplateDelete_NoConfirmation(t *testing.T) {
 // startE2EClusterMockServer starts a mock API with cluster lifecycle endpoints for e2e tests.
 func startE2EClusterMockServer(t *testing.T) *httptest.Server {
 	t.Helper()
+	// Persistent quota state so PUT → GET reflects the body the CLI actually
+	// sent, instead of a hard-coded fixture. Catches regressions where the
+	// CLI stops sending or merging a quota field.
+	quota := map[string]interface{}{
+		"id": "q1", "cluster_id": "1",
+		"cpu_request": "", "cpu_limit": "4",
+		"memory_request": "", "memory_limit": "16Gi",
+		"storage_limit": "", "pod_limit": 50,
+		"created_at": "2026-01-10T14:30:00Z", "updated_at": "2026-01-10T14:30:00Z",
+	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -1820,24 +1830,25 @@ func startE2EClusterMockServer(t *testing.T) *httptest.Server {
 		// PUT /api/v1/clusters/1/quotas
 		case r.URL.Path == "/api/v1/clusters/1/quotas" && r.Method == http.MethodPut:
 			var req map[string]interface{}
-			_ = json.NewDecoder(r.Body).Decode(&req)
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+				return
+			}
+			// Persist every quota field from the request body so the
+			// subsequent GET reflects exactly what the CLI sent (round-trip).
+			for _, k := range []string{"cpu_request", "cpu_limit", "memory_request", "memory_limit", "storage_limit", "pod_limit"} {
+				if v, ok := req[k]; ok {
+					quota[k] = v
+				}
+			}
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"id": "q1", "cluster_id": "1",
-				"cpu_request": req["cpu_request"], "cpu_limit": req["cpu_limit"],
-				"memory_request": req["memory_request"], "memory_limit": req["memory_limit"],
-				"storage_limit": req["storage_limit"], "pod_limit": req["pod_limit"],
-				"created_at": "2026-01-10T14:30:00Z", "updated_at": "2026-01-10T14:30:00Z",
-			})
+			_ = json.NewEncoder(w).Encode(quota)
 
 		// GET /api/v1/clusters/1/quotas
 		case r.URL.Path == "/api/v1/clusters/1/quotas" && r.Method == http.MethodGet:
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"id": "q1", "cluster_id": "1",
-				"cpu_limit": "4", "memory_limit": "16Gi", "pod_limit": 50,
-				"created_at": "2026-01-10T14:30:00Z", "updated_at": "2026-01-10T14:30:00Z",
-			})
+			_ = json.NewEncoder(w).Encode(quota)
 
 		// DELETE /api/v1/clusters/1/quotas
 		case r.URL.Path == "/api/v1/clusters/1/quotas" && r.Method == http.MethodDelete:

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -316,7 +316,11 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 					existing.UpdatedAt = now
 				} else {
 					existing = &types.ClusterQuota{
-						ID:            fmt.Sprintf("q%d", state.nextQuotaID),
+						Base: types.Base{
+							ID:        fmt.Sprintf("q%d", state.nextQuotaID),
+							CreatedAt: now,
+							UpdatedAt: now,
+						},
 						ClusterID:     id,
 						CPURequest:    req.CPURequest,
 						CPULimit:      req.CPULimit,
@@ -324,8 +328,6 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 						MemoryLimit:   req.MemoryLimit,
 						StorageLimit:  req.StorageLimit,
 						PodLimit:      req.PodLimit,
-						CreatedAt:     now,
-						UpdatedAt:     now,
 					}
 					state.nextQuotaID++
 					state.quotas[id] = existing
@@ -343,6 +345,12 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 					return
 				}
 				state.mu.Lock()
+				if _, hasQuota := state.quotas[id]; !hasQuota {
+					state.mu.Unlock()
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "resource quota config not found"})
+					return
+				}
 				delete(state.quotas, id)
 				state.mu.Unlock()
 				w.WriteHeader(http.StatusNoContent)

--- a/cli/test/integration/cluster_integration_test.go
+++ b/cli/test/integration/cluster_integration_test.go
@@ -22,14 +22,18 @@ import (
 type clusterMockState struct {
 	mu          sync.Mutex
 	nextID      uint
+	nextQuotaID uint
 	clusters    map[string]*types.Cluster
-	unreachable map[string]bool // cluster IDs that POST /test should report as unreachable
+	quotas      map[string]*types.ClusterQuota // keyed by cluster ID
+	unreachable map[string]bool                // cluster IDs that POST /test should report as unreachable
 }
 
 func newClusterMockState() *clusterMockState {
 	return &clusterMockState{
 		nextID:      1,
+		nextQuotaID: 1,
 		clusters:    make(map[string]*types.Cluster),
+		quotas:      make(map[string]*types.ClusterQuota),
 		unreachable: make(map[string]bool),
 	}
 }
@@ -267,6 +271,81 @@ func startClusterMockServer(t *testing.T, state *clusterMockState) *httptest.Ser
 						{Namespace: "stack-prod-web", CPUUsed: "1500m", CPULimit: "4", MemoryUsed: "2Gi", MemoryLimit: "8Gi", PodCount: 10, PodLimit: 50},
 					},
 				})
+
+			// GET /api/v1/clusters/:id/quotas
+			case action == "quotas" && r.Method == http.MethodGet:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				state.mu.Lock()
+				q, ok := state.quotas[id]
+				state.mu.Unlock()
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "resource quota config not found"})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(*q)
+
+			// PUT /api/v1/clusters/:id/quotas
+			case action == "quotas" && r.Method == http.MethodPut:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				var req types.SetClusterQuotaRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+					return
+				}
+				state.mu.Lock()
+				existing, hasExisting := state.quotas[id]
+				now := time.Now()
+				if hasExisting {
+					existing.CPURequest = req.CPURequest
+					existing.CPULimit = req.CPULimit
+					existing.MemoryRequest = req.MemoryRequest
+					existing.MemoryLimit = req.MemoryLimit
+					existing.StorageLimit = req.StorageLimit
+					existing.PodLimit = req.PodLimit
+					existing.UpdatedAt = now
+				} else {
+					existing = &types.ClusterQuota{
+						ID:            fmt.Sprintf("q%d", state.nextQuotaID),
+						ClusterID:     id,
+						CPURequest:    req.CPURequest,
+						CPULimit:      req.CPULimit,
+						MemoryRequest: req.MemoryRequest,
+						MemoryLimit:   req.MemoryLimit,
+						StorageLimit:  req.StorageLimit,
+						PodLimit:      req.PodLimit,
+						CreatedAt:     now,
+						UpdatedAt:     now,
+					}
+					state.nextQuotaID++
+					state.quotas[id] = existing
+				}
+				saved := *existing
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(saved)
+
+			// DELETE /api/v1/clusters/:id/quotas
+			case action == "quotas" && r.Method == http.MethodDelete:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cluster not found"})
+					return
+				}
+				state.mu.Lock()
+				delete(state.quotas, id)
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
 
 			default:
 				w.WriteHeader(http.StatusNotFound)
@@ -590,4 +669,122 @@ func TestClusterCobra_Health(t *testing.T) {
 	assert.Contains(t, out, "Health Status")
 	assert.Contains(t, out, "healthy")
 	assert.Contains(t, out, "3/3")
+}
+
+func TestClusterWorkflow_QuotaRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	cluster, err := c.CreateCluster(&types.CreateClusterRequest{Name: "q-cluster"})
+	require.NoError(t, err)
+	id := cluster.ID
+
+	// 1. GET before set — backend returns 404.
+	got, err := c.GetClusterQuota(id)
+	require.Error(t, err)
+	assert.Nil(t, got)
+
+	// 2. SET — upsert quota.
+	saved, err := c.SetClusterQuota(id, &types.SetClusterQuotaRequest{
+		CPULimit: "4", MemoryLimit: "16Gi", PodLimit: 50,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, saved.ID)
+	assert.Equal(t, "4", saved.CPULimit)
+	assert.Equal(t, 50, saved.PodLimit)
+
+	// 3. GET — round-trip values match what was set.
+	got, err = c.GetClusterQuota(id)
+	require.NoError(t, err)
+	assert.Equal(t, "4", got.CPULimit)
+	assert.Equal(t, "16Gi", got.MemoryLimit)
+	assert.Equal(t, 50, got.PodLimit)
+
+	// 4. SET again — upsert overwrites; PodLimit drops to 0 (no limit).
+	updated, err := c.SetClusterQuota(id, &types.SetClusterQuotaRequest{
+		CPULimit: "8", MemoryLimit: "32Gi", PodLimit: 0,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "8", updated.CPULimit)
+	assert.Equal(t, 0, updated.PodLimit)
+
+	// 5. DELETE — restores "no quota" state.
+	require.NoError(t, c.DeleteClusterQuota(id))
+
+	// 6. GET after delete — backend returns 404 again.
+	got, err = c.GetClusterQuota(id)
+	require.Error(t, err)
+	assert.Nil(t, got)
+	var apiErr *client.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+}
+
+// Cobra in-process drive: cluster quota set → get round-trip happy path.
+// NOT parallel: mutates cmd package globals.
+func TestClusterCobra_QuotaSetGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	state := newClusterMockState()
+	server := startClusterMockServer(t, state)
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+
+	// Seed a cluster.
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "create", "--name", "q-cobra"})
+	require.NoError(t, cmd.Execute())
+
+	state.mu.Lock()
+	var id string
+	for k := range state.clusters {
+		id = k
+	}
+	state.mu.Unlock()
+	require.NotEmpty(t, id)
+
+	// set via flags
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "quota", "set", id, "--cpu-limit", "4", "--memory-limit", "16Gi", "--pod-limit", "50"})
+	require.NoError(t, cmd.Execute())
+	// `set` renders the persisted quota (post-validation) in default mode.
+	setOut := buf.String()
+	assert.Contains(t, setOut, "Cluster ID")
+	assert.Contains(t, setOut, "Pod Limit")
+
+	// get — verify round-trip
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "quota", "get", id})
+	require.NoError(t, cmd.Execute())
+	out := buf.String()
+	assert.Contains(t, out, "4")
+	assert.Contains(t, out, "16Gi")
+	assert.Contains(t, out, "50")
+
+	// delete
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cluster", "quota", "delete", id, "--yes"})
+	require.NoError(t, cmd.Execute())
+
+	state.mu.Lock()
+	_, hasQuota := state.quotas[id]
+	state.mu.Unlock()
+	assert.False(t, hasQuota, "quota should be removed from mock state after delete")
 }


### PR DESCRIPTION
## Summary
Adds the nested `cluster quota` subcommand group wrapping the existing k8s-stack-manager endpoints:

| Command | Backend |
| --- | --- |
| `stackctl cluster quota get <id>`               | `GET    /api/v1/clusters/:id/quotas` (devops) |
| `stackctl cluster quota set <id> [flags or --from-file]` | `PUT    /api/v1/clusters/:id/quotas` (admin) |
| `stackctl cluster quota delete <id> [--yes]`    | `DELETE /api/v1/clusters/:id/quotas` (admin) |

`set` accepts either `--from-file` (JSON or YAML) or individual flags (`--cpu-request`, `--cpu-limit`, `--memory-request`, `--memory-limit`, `--storage-limit`, `--pod-limit`). The backend PUT is a full upsert, so when running in flag-only mode the command pre-fetches the existing quota and uses its values as defaults — `--pod-limit 100` preserves untouched CPU/memory limits instead of silently clearing them. `--from-file` sends the file verbatim. Default-mode output renders the persisted quota so users can confirm the server's view post-validation.

`delete` reuses the shared `deleteByID` helper so `--yes`, `--dry-run`, and confirmation behave identically to `cluster delete`.

Closes #66

## Test plan
All three layers green locally; `go vet ./...` clean.

- [x] **Unit (cmd)**: `get`/`set`/`delete` across table/json/yaml/quiet output modes; 403 path on `set`/`delete`; confirmation accept/decline on `delete`; flag-merge regression (`--pod-limit 100` preserves CPU/memory from the existing quota); bad-file error path.
- [x] **Unit (client)**: URL+verb+JSON round-trip for each method; 403/404 paths assert through to `APIError`; `pod_limit:0` round-trips through JSON (no stray `omitempty` on the request struct).
- [x] **Integration**: extends the cluster mock with quota CRUD state; `TestClusterWorkflow_QuotaRoundTrip` walks `404 GET → SET → GET → SET (upsert) → DELETE → 404 GET`; `TestClusterCobra_QuotaSetGet` drives Cobra in-process.
- [x] **E2E**: `TestE2EClusterQuotaSet` builds the binary and runs `quota set --from-file → quota get -o json → quota delete --yes`.

```
ok  	github.com/omattsson/stackctl/cli/cmd               10.733s
ok  	github.com/omattsson/stackctl/cli/pkg/client         4.448s
ok  	github.com/omattsson/stackctl/cli/test/e2e           4.459s
ok  	github.com/omattsson/stackctl/cli/test/integration  12.965s
```

## Notes
- A small test helper `resetFlag` clears both the value AND the `Changed` marker on a pflag. The repo's existing `cmd.Flags().Set(name, "")` cleanup pattern leaves `Changed=true`, which leaks across tests now that flag-override semantics depend on `cmd.Flags().Changed(...)`. Applied only to the new quota tests; existing cleanups left as-is for blast-radius minimisation.
- Pre-fetch on flag-only `set` adds one extra GET per command invocation. Acceptable: the get is cheap (single row lookup), and it eliminates a silent data-loss footgun for the common interactive workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `cluster quota` commands: `get` (table/JSON/YAML/quiet), `set` (from file or per-field flags), and `delete` (confirmation, `--yes`, `--dry-run`).

* **Improvements**
  * `set` merges flag-only updates with existing quota (preserving unspecified fields); better error messages and output modes for quota operations.

* **Tests**
  * Added comprehensive unit, integration, and e2e tests covering get/set/delete flows, formats, permission handling, file parsing, and confirmations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->