### PR TITLE
feat(cleanup-policy): CRUD (list/get/create/update/delete)

### DIFF
--- a/cli/cmd/cleanup_policy.go
+++ b/cli/cmd/cleanup_policy.go
@@ -90,6 +90,9 @@ var cleanupPolicyGetCmd = &cobra.Command{
 The backend does not expose a GET-by-ID endpoint for cleanup policies, so this
 command fetches the full list and filters client-side.
 
+Arguments that look like an integer or a UUID are treated as IDs; rename a
+policy if you need name-based access to it.
+
 Examples:
   stackctl cleanup-policy get 1
   stackctl cleanup-policy get nightly-stop

--- a/cli/cmd/cleanup_policy.go
+++ b/cli/cmd/cleanup_policy.go
@@ -1,0 +1,396 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var cleanupPolicyCmd = &cobra.Command{
+	Use:   "cleanup-policy",
+	Short: "Manage automated cleanup policies (admin only)",
+	Long: `Manage cleanup policies that the scheduler applies to stack instances.
+
+A policy combines an Action (stop/clean/delete), a Condition (e.g. idle_days:7),
+a Schedule (cron expression), and a ClusterID ("all" for every cluster).
+Policies are evaluated by the backend scheduler on the configured cadence.
+
+All cleanup-policy commands require admin role.`,
+}
+
+var cleanupPolicyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all cleanup policies",
+	Long: `List every cleanup policy configured on the server.
+
+Examples:
+  stackctl cleanup-policy list
+  stackctl cleanup-policy list -o json`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		policies, err := c.ListCleanupPolicies()
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, p := range policies {
+				fmt.Fprintln(printer.Writer, p.ID)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(policies)
+		case output.FormatYAML:
+			return printer.PrintYAML(policies)
+		default:
+			if len(policies) == 0 {
+				printer.PrintMessage("No cleanup policies found.")
+				return nil
+			}
+			headers := []string{"ID", "NAME", "CLUSTER", "ACTION", "CONDITION", "SCHEDULE", "ENABLED"}
+			rows := make([][]string, len(policies))
+			for i, p := range policies {
+				rows[i] = []string{
+					p.ID,
+					p.Name,
+					p.ClusterID,
+					p.Action,
+					p.Condition,
+					p.Schedule,
+					strconv.FormatBool(p.Enabled),
+				}
+			}
+			return printer.PrintTable(headers, rows)
+		}
+	},
+}
+
+var cleanupPolicyGetCmd = &cobra.Command{
+	Use:   "get <id-or-name>",
+	Short: "Show a single cleanup policy",
+	Long: `Show a single cleanup policy by ID or name.
+
+The backend does not expose a GET-by-ID endpoint for cleanup policies, so this
+command fetches the full list and filters client-side.
+
+Examples:
+  stackctl cleanup-policy get 1
+  stackctl cleanup-policy get nightly-stop
+  stackctl cleanup-policy get 1 -o json`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nameOrID := strings.TrimSpace(args[0])
+		if nameOrID == "" {
+			return fmt.Errorf("policy ID or name must not be empty")
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		policy, err := findCleanupPolicy(c, nameOrID)
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, policy.ID)
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(policy)
+		case output.FormatYAML:
+			return printer.PrintYAML(policy)
+		default:
+			return printer.PrintSingle(policy, []output.KeyValue{
+				{Key: "ID", Value: policy.ID},
+				{Key: "Name", Value: policy.Name},
+				{Key: "Cluster", Value: policy.ClusterID},
+				{Key: "Action", Value: policy.Action},
+				{Key: "Condition", Value: policy.Condition},
+				{Key: "Schedule", Value: policy.Schedule},
+				{Key: "Enabled", Value: strconv.FormatBool(policy.Enabled)},
+				{Key: "Dry Run", Value: strconv.FormatBool(policy.DryRun)},
+				{Key: "Last Run", Value: formatTime(policy.LastRunAt)},
+			})
+		}
+	},
+}
+
+var cleanupPolicyCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new cleanup policy (admin only)",
+	Long: `Create a new cleanup policy from a JSON or YAML payload.
+
+The file must contain a CreateCleanupPolicyRequest — see the schema in
+cli/pkg/types/types.go.
+
+Examples:
+  stackctl cleanup-policy create --from-file policy.json
+  stackctl cleanup-policy create --from-file policy.yaml -o json`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fromFile, _ := cmd.Flags().GetString(flagFromFile)
+		if fromFile == "" {
+			return fmt.Errorf("--from-file is required")
+		}
+
+		var req types.CreateCleanupPolicyRequest
+		if err := readPolicyFile(fromFile, &req); err != nil {
+			return err
+		}
+		if err := validateCleanupPolicyPayload(req.Name, req.ClusterID, req.Action, req.Condition, req.Schedule); err != nil {
+			return err
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		policy, err := c.CreateCleanupPolicy(&req)
+		if err != nil {
+			return err
+		}
+
+		return printCleanupPolicy(policy)
+	},
+}
+
+var cleanupPolicyUpdateCmd = &cobra.Command{
+	Use:   "update <id-or-name>",
+	Short: "Update an existing cleanup policy (admin only)",
+	Long: `Replace an existing cleanup policy with the payload in a JSON or YAML file.
+
+PUT is a full upsert — the file must contain every field. To partially modify
+a policy, first 'cleanup-policy get <id> -o json' to a file, edit it, then
+'cleanup-policy update <id> --from-file <file>'.
+
+When the argument is a name (not an ID), this command issues a list+filter
+round-trip to resolve the ID before sending the PUT. Pass the numeric ID
+directly in scripts to skip the extra request.
+
+Examples:
+  stackctl cleanup-policy update 1 --from-file policy.json
+  stackctl cleanup-policy update nightly-stop --from-file policy.yaml`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fromFile, _ := cmd.Flags().GetString(flagFromFile)
+		if fromFile == "" {
+			return fmt.Errorf("--from-file is required")
+		}
+
+		var req types.UpdateCleanupPolicyRequest
+		if err := readPolicyFile(fromFile, &req); err != nil {
+			return err
+		}
+		if err := validateCleanupPolicyPayload(req.Name, req.ClusterID, req.Action, req.Condition, req.Schedule); err != nil {
+			return err
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		id, err := resolveCleanupPolicyID(c, args[0])
+		if err != nil {
+			return err
+		}
+
+		policy, err := c.UpdateCleanupPolicy(id, &req)
+		if err != nil {
+			return err
+		}
+
+		return printCleanupPolicy(policy)
+	},
+}
+
+var cleanupPolicyDeleteCmd = &cobra.Command{
+	Use:   "delete <id-or-name>",
+	Short: "Delete a cleanup policy (admin only)",
+	Long: `Delete a cleanup policy.
+
+This is a destructive operation. You will be prompted for confirmation
+unless --yes is specified.
+
+When the argument is a name (not an ID), this command issues a list+filter
+round-trip to resolve the ID before sending the DELETE.
+
+Examples:
+  stackctl cleanup-policy delete 1
+  stackctl cleanup-policy delete nightly-stop --yes`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return deleteByID(cmd, args,
+			"This will delete cleanup policy %s. Continue? (y/n): ",
+			resolveCleanupPolicyID,
+			func(c *client.Client, id string) error { return c.DeleteCleanupPolicy(id) },
+			"Deleted cleanup policy %s",
+		)
+	},
+}
+
+// readPolicyFile loads a JSON or YAML file containing a cleanup-policy payload.
+// `..` segments in the path are rejected to match the convention used by
+// `cluster create`, `cluster update`, `definition create`, etc.
+func readPolicyFile(path string, out interface{}) error {
+	for _, segment := range strings.Split(filepath.ToSlash(path), "/") {
+		if segment == ".." {
+			return errors.New(msgPathTraversal)
+		}
+	}
+	path = filepath.Clean(path)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return readFileErr(path, err)
+	}
+	if jsonErr := json.Unmarshal(data, out); jsonErr != nil {
+		if yamlErr := yaml.Unmarshal(data, out); yamlErr != nil {
+			return fmt.Errorf("invalid JSON/YAML in file %s (json: %v): %w", path, jsonErr, yamlErr)
+		}
+	}
+	return nil
+}
+
+// validateCleanupPolicyPayload checks the required fields on a create/update
+// request before sending it to the server. The server validates too, but a
+// client-side check produces clearer errors and avoids round-trips.
+func validateCleanupPolicyPayload(name, clusterID, action, condition, schedule string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("'name' field is required in the policy file")
+	}
+	if strings.TrimSpace(clusterID) == "" {
+		return fmt.Errorf("'cluster_id' field is required (use \"all\" for every cluster)")
+	}
+	if strings.TrimSpace(action) == "" {
+		return fmt.Errorf("'action' field is required (one of: stop, clean, delete)")
+	}
+	if strings.TrimSpace(condition) == "" {
+		return fmt.Errorf("'condition' field is required")
+	}
+	if strings.TrimSpace(schedule) == "" {
+		return fmt.Errorf("'schedule' field is required (cron expression)")
+	}
+	return nil
+}
+
+// findCleanupPolicy returns the policy matching nameOrID. Because the server
+// has no GET-by-ID endpoint, the lookup goes via the list and filters
+// client-side. Numeric / UUID-shaped strings are matched on ID; everything
+// else is matched on Name (case-insensitive, exact match).
+func findCleanupPolicy(c *client.Client, nameOrID string) (*types.CleanupPolicy, error) {
+	policies, err := c.ListCleanupPolicies()
+	if err != nil {
+		return nil, err
+	}
+
+	if looksLikeID(nameOrID) {
+		for i := range policies {
+			if policies[i].ID == nameOrID {
+				return &policies[i], nil
+			}
+		}
+		return nil, fmt.Errorf("no cleanup policy found with ID %q", nameOrID)
+	}
+
+	var matches []types.CleanupPolicy
+	for i := range policies {
+		if strings.EqualFold(policies[i].Name, nameOrID) {
+			matches = append(matches, policies[i])
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no cleanup policy found with name %q", nameOrID)
+	case 1:
+		return &matches[0], nil
+	default:
+		msg := fmt.Sprintf("multiple cleanup policies match name %q — use the ID instead:\n", nameOrID)
+		for _, p := range matches {
+			msg += fmt.Sprintf("  %s  (action: %s, schedule: %s)\n", p.ID, p.Action, p.Schedule)
+		}
+		return nil, fmt.Errorf("%s", msg)
+	}
+}
+
+func resolveCleanupPolicyID(c *client.Client, nameOrID string) (string, error) {
+	nameOrID = strings.TrimSpace(nameOrID)
+	if nameOrID == "" {
+		return "", fmt.Errorf("policy ID or name must not be empty")
+	}
+	if looksLikeID(nameOrID) {
+		return nameOrID, nil
+	}
+	policy, err := findCleanupPolicy(c, nameOrID)
+	if err != nil {
+		return "", err
+	}
+	return policy.ID, nil
+}
+
+func printCleanupPolicy(policy *types.CleanupPolicy) error {
+	if printer.Quiet {
+		fmt.Fprintln(printer.Writer, policy.ID)
+		return nil
+	}
+	switch printer.Format {
+	case output.FormatJSON:
+		return printer.PrintJSON(policy)
+	case output.FormatYAML:
+		return printer.PrintYAML(policy)
+	default:
+		return printer.PrintSingle(policy, []output.KeyValue{
+			{Key: "ID", Value: policy.ID},
+			{Key: "Name", Value: policy.Name},
+			{Key: "Cluster", Value: policy.ClusterID},
+			{Key: "Action", Value: policy.Action},
+			{Key: "Condition", Value: policy.Condition},
+			{Key: "Schedule", Value: policy.Schedule},
+			{Key: "Enabled", Value: strconv.FormatBool(policy.Enabled)},
+			{Key: "Dry Run", Value: strconv.FormatBool(policy.DryRun)},
+			{Key: "Last Run", Value: formatTime(policy.LastRunAt)},
+		})
+	}
+}
+
+func init() {
+	cleanupPolicyCreateCmd.Flags().String(flagFromFile, "", "JSON or YAML file with the CreateCleanupPolicyRequest payload (required)")
+	_ = cleanupPolicyCreateCmd.MarkFlagRequired(flagFromFile)
+	cleanupPolicyUpdateCmd.Flags().String(flagFromFile, "", "JSON or YAML file with the UpdateCleanupPolicyRequest payload (required)")
+	_ = cleanupPolicyUpdateCmd.MarkFlagRequired(flagFromFile)
+	cleanupPolicyDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	cleanupPolicyDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+
+	cleanupPolicyCmd.AddCommand(cleanupPolicyListCmd)
+	cleanupPolicyCmd.AddCommand(cleanupPolicyGetCmd)
+	cleanupPolicyCmd.AddCommand(cleanupPolicyCreateCmd)
+	cleanupPolicyCmd.AddCommand(cleanupPolicyUpdateCmd)
+	cleanupPolicyCmd.AddCommand(cleanupPolicyDeleteCmd)
+
+	rootCmd.AddCommand(cleanupPolicyCmd)
+}

--- a/cli/cmd/cleanup_policy_test.go
+++ b/cli/cmd/cleanup_policy_test.go
@@ -1,0 +1,479 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests in this file are NOT parallelized because they mutate package-level
+// globals (cfg, printer, flagAPIURL) via setupStackTestCmd. Do not add t.Parallel().
+
+func sampleCleanupPolicies() []types.CleanupPolicy {
+	t := time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC)
+	return []types.CleanupPolicy{
+		{
+			Base:      types.Base{ID: "1", CreatedAt: t, UpdatedAt: t},
+			Name:      "nightly-stop",
+			ClusterID: "all",
+			Action:    "stop",
+			Condition: "idle_days:7",
+			Schedule:  "0 2 * * *",
+			Enabled:   true,
+		},
+		{
+			Base:      types.Base{ID: "2", CreatedAt: t, UpdatedAt: t},
+			Name:      "ttl-cleanup",
+			ClusterID: "1",
+			Action:    "delete",
+			Condition: "ttl_expired",
+			Schedule:  "*/30 * * * *",
+			Enabled:   false,
+			DryRun:    true,
+		},
+	}
+}
+
+// ---------- list ----------
+
+func TestCleanupPolicyListCmd_TableOutput(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/admin/cleanup-policies", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	require.NoError(t, cleanupPolicyListCmd.RunE(cleanupPolicyListCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "nightly-stop")
+	assert.Contains(t, out, "ttl-cleanup")
+	assert.Contains(t, out, "stop")
+	assert.Contains(t, out, "delete")
+}
+
+func TestCleanupPolicyListCmd_JSONOutput(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	require.NoError(t, cleanupPolicyListCmd.RunE(cleanupPolicyListCmd, []string{}))
+
+	var got []types.CleanupPolicy
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, "nightly-stop", got[0].Name)
+}
+
+func TestCleanupPolicyListCmd_QuietOutput(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	require.NoError(t, cleanupPolicyListCmd.RunE(cleanupPolicyListCmd, []string{}))
+	assert.Equal(t, "1\n2\n", buf.String(), "quiet mode must emit only the policy IDs")
+}
+
+func TestCleanupPolicyListCmd_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode([]types.CleanupPolicy{}))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyListCmd.RunE(cleanupPolicyListCmd, []string{}))
+	assert.Contains(t, buf.String(), "No cleanup policies found")
+}
+
+func TestCleanupPolicyListCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "admin role required"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := cleanupPolicyListCmd.RunE(cleanupPolicyListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "admin role required")
+}
+
+// ---------- get ----------
+
+func TestCleanupPolicyGetCmd_ByID(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/admin/cleanup-policies", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	require.NoError(t, cleanupPolicyGetCmd.RunE(cleanupPolicyGetCmd, []string{"2"}))
+
+	out := buf.String()
+	assert.Contains(t, out, "ttl-cleanup")
+	assert.Contains(t, out, "delete")
+}
+
+func TestCleanupPolicyGetCmd_ByName(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyGetCmd.RunE(cleanupPolicyGetCmd, []string{"nightly-stop"}))
+	assert.Contains(t, buf.String(), "0 2 * * *")
+}
+
+func TestCleanupPolicyGetCmd_NotFound(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := cleanupPolicyGetCmd.RunE(cleanupPolicyGetCmd, []string{"unknown"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no cleanup policy found")
+}
+
+func TestCleanupPolicyGetCmd_AmbiguousName(t *testing.T) {
+	// Two policies with the same name — should error.
+	t0 := time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC)
+	dupes := []types.CleanupPolicy{
+		{Base: types.Base{ID: "1", CreatedAt: t0, UpdatedAt: t0}, Name: "dup", Action: "stop", Schedule: "0 * * * *"},
+		{Base: types.Base{ID: "2", CreatedAt: t0, UpdatedAt: t0}, Name: "dup", Action: "delete", Schedule: "0 * * * *"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(dupes))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := cleanupPolicyGetCmd.RunE(cleanupPolicyGetCmd, []string{"dup"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple cleanup policies match")
+}
+
+func TestCleanupPolicyGetCmd_JSONOutput(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	require.NoError(t, cleanupPolicyGetCmd.RunE(cleanupPolicyGetCmd, []string{"1"}))
+
+	var got types.CleanupPolicy
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "nightly-stop", got.Name)
+}
+
+// ---------- create ----------
+
+func writeTempPolicyFile(t *testing.T, name string, payload interface{}) string {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func TestCleanupPolicyCreateCmd_FromFile(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC)
+	created := types.CleanupPolicy{
+		Base:      types.Base{ID: "99", CreatedAt: t0, UpdatedAt: t0},
+		Name:      "new-policy",
+		ClusterID: "all",
+		Action:    "stop",
+		Condition: "idle_days:14",
+		Schedule:  "0 3 * * *",
+		Enabled:   true,
+	}
+
+	var captured types.CreateCleanupPolicyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/admin/cleanup-policies", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(created))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	req := types.CreateCleanupPolicyRequest{
+		Name: "new-policy", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:14", Schedule: "0 3 * * *", Enabled: true,
+	}
+	path := writeTempPolicyFile(t, "policy.json", req)
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", path))
+	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+
+	require.NoError(t, cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{}))
+	assert.Equal(t, "new-policy", captured.Name)
+	assert.Equal(t, "all", captured.ClusterID)
+	assert.Contains(t, buf.String(), "new-policy")
+}
+
+func TestCleanupPolicyCreateCmd_MissingFromFile(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://localhost:0")
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", ""))
+	err := cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--from-file is required")
+}
+
+func TestCleanupPolicyCreateCmd_PathTraversalRejected(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://localhost:0")
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", "../policy.json"))
+	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+	err := cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}
+
+func TestCleanupPolicyCreateCmd_ValidationError(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://localhost:0")
+
+	bad := types.CreateCleanupPolicyRequest{Name: "x"} // missing required fields
+	path := writeTempPolicyFile(t, "bad.json", bad)
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", path))
+	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+
+	err := cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster_id")
+}
+
+func TestCleanupPolicyCreateCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "admin role required"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	req := types.CreateCleanupPolicyRequest{
+		Name: "p", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:7", Schedule: "0 2 * * *",
+	}
+	path := writeTempPolicyFile(t, "policy.json", req)
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", path))
+	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+
+	err := cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "admin role required")
+}
+
+// ---------- update ----------
+
+func TestCleanupPolicyUpdateCmd_FromFile(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC)
+	updated := types.CleanupPolicy{
+		Base:      types.Base{ID: "1", CreatedAt: t0, UpdatedAt: t0},
+		Name:      "nightly-stop",
+		ClusterID: "all",
+		Action:    "stop",
+		Condition: "idle_days:14",
+		Schedule:  "0 4 * * *",
+		Enabled:   true,
+	}
+
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(updated))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+
+	req := types.UpdateCleanupPolicyRequest{
+		Name: "nightly-stop", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:14", Schedule: "0 4 * * *", Enabled: true,
+	}
+	path := writeTempPolicyFile(t, "update.json", req)
+	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", path))
+	t.Cleanup(func() { _ = cleanupPolicyUpdateCmd.Flags().Set("from-file", "") })
+
+	require.NoError(t, cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"1"}))
+	assert.Equal(t, "/api/v1/admin/cleanup-policies/1", capturedPath)
+}
+
+func TestCleanupPolicyUpdateCmd_ResolveNameToID(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 2, 0, 0, 0, time.UTC)
+	updated := types.CleanupPolicy{
+		Base:      types.Base{ID: "1", CreatedAt: t0, UpdatedAt: t0},
+		Name:      "nightly-stop",
+		ClusterID: "all",
+		Action:    "stop",
+		Condition: "idle_days:14",
+		Schedule:  "0 4 * * *",
+	}
+
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			require.Equal(t, "/api/v1/admin/cleanup-policies", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(sampleCleanupPolicies()))
+		case http.MethodPut:
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(updated))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	req := types.UpdateCleanupPolicyRequest{
+		Name: "nightly-stop", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:14", Schedule: "0 4 * * *",
+	}
+	path := writeTempPolicyFile(t, "update.json", req)
+	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", path))
+	t.Cleanup(func() { _ = cleanupPolicyUpdateCmd.Flags().Set("from-file", "") })
+
+	require.NoError(t, cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"nightly-stop"}))
+	assert.Equal(t, "/api/v1/admin/cleanup-policies/1", capturedPath)
+}
+
+func TestCleanupPolicyUpdateCmd_MissingFromFile(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://localhost:0")
+	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", ""))
+	err := cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--from-file is required")
+}
+
+// ---------- delete ----------
+
+func TestCleanupPolicyDeleteCmd_WithYesFlag(t *testing.T) {
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/api/v1/admin/cleanup-policies/1", r.URL.Path)
+		deleted = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("yes", "false") })
+
+	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
+	assert.True(t, deleted)
+	assert.Contains(t, buf.String(), "Deleted cleanup policy 1")
+}
+
+func TestCleanupPolicyDeleteCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("yes", "false") })
+
+	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
+	assert.Equal(t, "1\n", buf.String(), "quiet mode must echo only the policy ID")
+}
+
+func TestCleanupPolicyDeleteCmd_DryRun(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("dry-run", "true"))
+	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("dry-run", "false") })
+
+	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
+	assert.False(t, called, "dry-run must not contact the backend")
+	assert.Contains(t, buf.String(), "Would delete")
+}
+
+func TestCleanupPolicyDeleteCmd_ResolveNameToID(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(sampleCleanupPolicies()))
+		case http.MethodDelete:
+			capturedPath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("yes", "false") })
+
+	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"ttl-cleanup"}))
+	assert.Equal(t, "/api/v1/admin/cleanup-policies/2", capturedPath)
+}

--- a/cli/cmd/cleanup_policy_test.go
+++ b/cli/cmd/cleanup_policy_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/omattsson/stackctl/cli/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // Tests in this file are NOT parallelized because they mutate package-level
@@ -84,6 +86,25 @@ func TestCleanupPolicyListCmd_JSONOutput(t *testing.T) {
 
 	var got []types.CleanupPolicy
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, "nightly-stop", got[0].Name)
+}
+
+func TestCleanupPolicyListCmd_YAMLOutput(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	require.NoError(t, cleanupPolicyListCmd.RunE(cleanupPolicyListCmd, []string{}))
+
+	var got []types.CleanupPolicy
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
 	assert.Len(t, got, 2)
 	assert.Equal(t, "nightly-stop", got[0].Name)
 }
@@ -213,6 +234,39 @@ func TestCleanupPolicyGetCmd_JSONOutput(t *testing.T) {
 	assert.Equal(t, "nightly-stop", got.Name)
 }
 
+func TestCleanupPolicyGetCmd_YAMLOutput(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	require.NoError(t, cleanupPolicyGetCmd.RunE(cleanupPolicyGetCmd, []string{"1"}))
+
+	var got types.CleanupPolicy
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "nightly-stop", got.Name)
+}
+
+func TestCleanupPolicyGetCmd_QuietOutput(t *testing.T) {
+	policies := sampleCleanupPolicies()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(policies))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	require.NoError(t, cleanupPolicyGetCmd.RunE(cleanupPolicyGetCmd, []string{"nightly-stop"}))
+	assert.Equal(t, "1\n", buf.String(), "quiet mode must emit only the policy ID")
+}
+
 // ---------- create ----------
 
 func writeTempPolicyFile(t *testing.T, name string, payload interface{}) string {
@@ -261,6 +315,86 @@ func TestCleanupPolicyCreateCmd_FromFile(t *testing.T) {
 	assert.Equal(t, "new-policy", captured.Name)
 	assert.Equal(t, "all", captured.ClusterID)
 	assert.Contains(t, buf.String(), "new-policy")
+}
+
+// createMockServer returns a mock server that echoes the request payload back
+// as a created CleanupPolicy with ID=99 and timestamps zeroed. Shared by the
+// output-format tests below.
+func createMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req types.CreateCleanupPolicyRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.CleanupPolicy{
+			Base:      types.Base{ID: "99"},
+			Name:      req.Name,
+			ClusterID: req.ClusterID,
+			Action:    req.Action,
+			Condition: req.Condition,
+			Schedule:  req.Schedule,
+			Enabled:   req.Enabled,
+		})
+	}))
+}
+
+func writeValidCreatePayload(t *testing.T) string {
+	t.Helper()
+	return writeTempPolicyFile(t, "policy.json", types.CreateCleanupPolicyRequest{
+		Name: "new-policy", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:14", Schedule: "0 3 * * *", Enabled: true,
+	})
+}
+
+func TestCleanupPolicyCreateCmd_JSONOutput(t *testing.T) {
+	server := createMockServer(t)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", writeValidCreatePayload(t)))
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyCreateCmd.Flags(), "from-file", "") })
+
+	require.NoError(t, cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{}))
+
+	var got types.CleanupPolicy
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "99", got.ID)
+	assert.Equal(t, "new-policy", got.Name)
+}
+
+func TestCleanupPolicyCreateCmd_YAMLOutput(t *testing.T) {
+	server := createMockServer(t)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", writeValidCreatePayload(t)))
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyCreateCmd.Flags(), "from-file", "") })
+
+	require.NoError(t, cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{}))
+
+	var got types.CleanupPolicy
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "99", got.ID)
+	assert.Equal(t, "new-policy", got.Name)
+}
+
+func TestCleanupPolicyCreateCmd_QuietOutput(t *testing.T) {
+	server := createMockServer(t)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", writeValidCreatePayload(t)))
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyCreateCmd.Flags(), "from-file", "") })
+
+	require.NoError(t, cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{}))
+	assert.Equal(t, "99\n", buf.String(), "quiet mode must emit only the created ID")
 }
 
 func TestCleanupPolicyCreateCmd_MissingFromFile(t *testing.T) {
@@ -401,6 +535,85 @@ func TestCleanupPolicyUpdateCmd_MissingFromFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "--from-file is required")
 }
 
+// updateMockServer returns a mock server that echoes the request payload back
+// as an updated CleanupPolicy with ID=1. Shared by the output-format tests.
+func updateMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		var req types.UpdateCleanupPolicyRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.CleanupPolicy{
+			Base:      types.Base{ID: "1"},
+			Name:      req.Name,
+			ClusterID: req.ClusterID,
+			Action:    req.Action,
+			Condition: req.Condition,
+			Schedule:  req.Schedule,
+			Enabled:   req.Enabled,
+		})
+	}))
+}
+
+func writeValidUpdatePayload(t *testing.T) string {
+	t.Helper()
+	return writeTempPolicyFile(t, "update.json", types.UpdateCleanupPolicyRequest{
+		Name: "nightly-stop", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:14", Schedule: "0 4 * * *", Enabled: true,
+	})
+}
+
+func TestCleanupPolicyUpdateCmd_JSONOutput(t *testing.T) {
+	server := updateMockServer(t)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", writeValidUpdatePayload(t)))
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyUpdateCmd.Flags(), "from-file", "") })
+
+	require.NoError(t, cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"1"}))
+
+	var got types.CleanupPolicy
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "1", got.ID)
+	assert.Equal(t, "idle_days:14", got.Condition)
+}
+
+func TestCleanupPolicyUpdateCmd_YAMLOutput(t *testing.T) {
+	server := updateMockServer(t)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", writeValidUpdatePayload(t)))
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyUpdateCmd.Flags(), "from-file", "") })
+
+	require.NoError(t, cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"1"}))
+
+	var got types.CleanupPolicy
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "1", got.ID)
+	assert.Equal(t, "idle_days:14", got.Condition)
+}
+
+func TestCleanupPolicyUpdateCmd_QuietOutput(t *testing.T) {
+	server := updateMockServer(t)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", writeValidUpdatePayload(t)))
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyUpdateCmd.Flags(), "from-file", "") })
+
+	require.NoError(t, cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"1"}))
+	assert.Equal(t, "1\n", buf.String(), "quiet mode must emit only the updated ID")
+}
+
 // ---------- delete ----------
 
 func TestCleanupPolicyDeleteCmd_WithYesFlag(t *testing.T) {
@@ -476,4 +689,48 @@ func TestCleanupPolicyDeleteCmd_ResolveNameToID(t *testing.T) {
 
 	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"ttl-cleanup"}))
 	assert.Equal(t, "/api/v1/admin/cleanup-policies/2", capturedPath)
+}
+
+func TestCleanupPolicyDeleteCmd_InteractiveConfirm(t *testing.T) {
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/api/v1/admin/cleanup-policies/1", r.URL.Path)
+		deleted = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	// Default --yes=false. Pipe "y\n" to stdin to confirm.
+	cleanupPolicyDeleteCmd.SetIn(strings.NewReader("y\n"))
+	cleanupPolicyDeleteCmd.SetErr(&bytes.Buffer{})
+	t.Cleanup(func() {
+		cleanupPolicyDeleteCmd.SetIn(nil)
+		cleanupPolicyDeleteCmd.SetErr(nil)
+	})
+
+	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
+	assert.True(t, deleted, "DELETE must fire when user confirms")
+	assert.Contains(t, buf.String(), "Deleted cleanup policy 1")
+}
+
+func TestCleanupPolicyDeleteCmd_InteractiveDecline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("API must NOT be called when user declines: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	cleanupPolicyDeleteCmd.SetIn(strings.NewReader("n\n"))
+	cleanupPolicyDeleteCmd.SetErr(&bytes.Buffer{})
+	t.Cleanup(func() {
+		cleanupPolicyDeleteCmd.SetIn(nil)
+		cleanupPolicyDeleteCmd.SetErr(nil)
+	})
+
+	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
+	assert.Contains(t, buf.String(), "Aborted")
 }

--- a/cli/cmd/cleanup_policy_test.go
+++ b/cli/cmd/cleanup_policy_test.go
@@ -255,7 +255,7 @@ func TestCleanupPolicyCreateCmd_FromFile(t *testing.T) {
 	}
 	path := writeTempPolicyFile(t, "policy.json", req)
 	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", path))
-	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyCreateCmd.Flags(), "from-file", "") })
 
 	require.NoError(t, cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{}))
 	assert.Equal(t, "new-policy", captured.Name)
@@ -274,7 +274,7 @@ func TestCleanupPolicyCreateCmd_MissingFromFile(t *testing.T) {
 func TestCleanupPolicyCreateCmd_PathTraversalRejected(t *testing.T) {
 	_ = setupStackTestCmd(t, "http://localhost:0")
 	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", "../policy.json"))
-	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyCreateCmd.Flags(), "from-file", "") })
 	err := cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "..")
@@ -286,7 +286,7 @@ func TestCleanupPolicyCreateCmd_ValidationError(t *testing.T) {
 	bad := types.CreateCleanupPolicyRequest{Name: "x"} // missing required fields
 	path := writeTempPolicyFile(t, "bad.json", bad)
 	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", path))
-	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyCreateCmd.Flags(), "from-file", "") })
 
 	err := cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{})
 	require.Error(t, err)
@@ -308,7 +308,7 @@ func TestCleanupPolicyCreateCmd_Forbidden(t *testing.T) {
 	}
 	path := writeTempPolicyFile(t, "policy.json", req)
 	require.NoError(t, cleanupPolicyCreateCmd.Flags().Set("from-file", path))
-	t.Cleanup(func() { _ = cleanupPolicyCreateCmd.Flags().Set("from-file", "") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyCreateCmd.Flags(), "from-file", "") })
 
 	err := cleanupPolicyCreateCmd.RunE(cleanupPolicyCreateCmd, []string{})
 	require.Error(t, err)
@@ -346,7 +346,7 @@ func TestCleanupPolicyUpdateCmd_FromFile(t *testing.T) {
 	}
 	path := writeTempPolicyFile(t, "update.json", req)
 	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", path))
-	t.Cleanup(func() { _ = cleanupPolicyUpdateCmd.Flags().Set("from-file", "") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyUpdateCmd.Flags(), "from-file", "") })
 
 	require.NoError(t, cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"1"}))
 	assert.Equal(t, "/api/v1/admin/cleanup-policies/1", capturedPath)
@@ -387,7 +387,7 @@ func TestCleanupPolicyUpdateCmd_ResolveNameToID(t *testing.T) {
 	}
 	path := writeTempPolicyFile(t, "update.json", req)
 	require.NoError(t, cleanupPolicyUpdateCmd.Flags().Set("from-file", path))
-	t.Cleanup(func() { _ = cleanupPolicyUpdateCmd.Flags().Set("from-file", "") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyUpdateCmd.Flags(), "from-file", "") })
 
 	require.NoError(t, cleanupPolicyUpdateCmd.RunE(cleanupPolicyUpdateCmd, []string{"nightly-stop"}))
 	assert.Equal(t, "/api/v1/admin/cleanup-policies/1", capturedPath)
@@ -415,7 +415,7 @@ func TestCleanupPolicyDeleteCmd_WithYesFlag(t *testing.T) {
 
 	buf := setupStackTestCmd(t, server.URL)
 	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("yes", "true"))
-	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("yes", "false") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyDeleteCmd.Flags(), "yes", "false") })
 
 	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
 	assert.True(t, deleted)
@@ -432,7 +432,7 @@ func TestCleanupPolicyDeleteCmd_QuietOutput(t *testing.T) {
 	buf := setupStackTestCmd(t, server.URL)
 	printer.Quiet = true
 	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("yes", "true"))
-	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("yes", "false") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyDeleteCmd.Flags(), "yes", "false") })
 
 	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
 	assert.Equal(t, "1\n", buf.String(), "quiet mode must echo only the policy ID")
@@ -447,7 +447,7 @@ func TestCleanupPolicyDeleteCmd_DryRun(t *testing.T) {
 
 	buf := setupStackTestCmd(t, server.URL)
 	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("dry-run", "true"))
-	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("dry-run", "false") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyDeleteCmd.Flags(), "dry-run", "false") })
 
 	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
 	assert.False(t, called, "dry-run must not contact the backend")
@@ -472,7 +472,7 @@ func TestCleanupPolicyDeleteCmd_ResolveNameToID(t *testing.T) {
 
 	_ = setupStackTestCmd(t, server.URL)
 	require.NoError(t, cleanupPolicyDeleteCmd.Flags().Set("yes", "true"))
-	t.Cleanup(func() { _ = cleanupPolicyDeleteCmd.Flags().Set("yes", "false") })
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyDeleteCmd.Flags(), "yes", "false") })
 
 	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"ttl-cleanup"}))
 	assert.Equal(t, "/api/v1/admin/cleanup-policies/2", capturedPath)

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1208,6 +1208,8 @@ func (c *Client) SetDefaultCluster(id string) error {
 
 // ListCleanupPolicies returns every cleanup policy defined on the server.
 // Admin-only — non-admin callers receive APIError with status 403.
+//
+// @see GET /api/v1/admin/cleanup-policies
 func (c *Client) ListCleanupPolicies() ([]types.CleanupPolicy, error) {
 	var policies []types.CleanupPolicy
 	if err := c.Get("/api/v1/admin/cleanup-policies", &policies); err != nil {
@@ -1217,6 +1219,8 @@ func (c *Client) ListCleanupPolicies() ([]types.CleanupPolicy, error) {
 }
 
 // CreateCleanupPolicy creates a new cleanup policy. Admin-only.
+//
+// @see POST /api/v1/admin/cleanup-policies
 func (c *Client) CreateCleanupPolicy(req *types.CreateCleanupPolicyRequest) (*types.CleanupPolicy, error) {
 	var policy types.CleanupPolicy
 	if err := c.Post("/api/v1/admin/cleanup-policies", req, &policy); err != nil {
@@ -1227,6 +1231,8 @@ func (c *Client) CreateCleanupPolicy(req *types.CreateCleanupPolicyRequest) (*ty
 
 // UpdateCleanupPolicy replaces an existing cleanup policy by ID. Admin-only.
 // PUT is a full upsert; callers must provide every field.
+//
+// @see PUT /api/v1/admin/cleanup-policies/:id
 func (c *Client) UpdateCleanupPolicy(id string, req *types.UpdateCleanupPolicyRequest) (*types.CleanupPolicy, error) {
 	var policy types.CleanupPolicy
 	if err := c.Put(fmt.Sprintf("/api/v1/admin/cleanup-policies/%s", id), req, &policy); err != nil {
@@ -1236,6 +1242,8 @@ func (c *Client) UpdateCleanupPolicy(id string, req *types.UpdateCleanupPolicyRe
 }
 
 // DeleteCleanupPolicy removes a cleanup policy by ID. Admin-only.
+//
+// @see DELETE /api/v1/admin/cleanup-policies/:id
 func (c *Client) DeleteCleanupPolicy(id string) error {
 	return c.Delete(fmt.Sprintf("/api/v1/admin/cleanup-policies/%s", id))
 }

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1205,3 +1205,37 @@ func (c *Client) DeleteCluster(id string) error {
 func (c *Client) SetDefaultCluster(id string) error {
 	return c.Post(fmt.Sprintf("/api/v1/clusters/%s/default", id), nil, nil)
 }
+
+// ListCleanupPolicies returns every cleanup policy defined on the server.
+// Admin-only — non-admin callers receive APIError with status 403.
+func (c *Client) ListCleanupPolicies() ([]types.CleanupPolicy, error) {
+	var policies []types.CleanupPolicy
+	if err := c.Get("/api/v1/admin/cleanup-policies", &policies); err != nil {
+		return nil, err
+	}
+	return policies, nil
+}
+
+// CreateCleanupPolicy creates a new cleanup policy. Admin-only.
+func (c *Client) CreateCleanupPolicy(req *types.CreateCleanupPolicyRequest) (*types.CleanupPolicy, error) {
+	var policy types.CleanupPolicy
+	if err := c.Post("/api/v1/admin/cleanup-policies", req, &policy); err != nil {
+		return nil, err
+	}
+	return &policy, nil
+}
+
+// UpdateCleanupPolicy replaces an existing cleanup policy by ID. Admin-only.
+// PUT is a full upsert; callers must provide every field.
+func (c *Client) UpdateCleanupPolicy(id string, req *types.UpdateCleanupPolicyRequest) (*types.CleanupPolicy, error) {
+	var policy types.CleanupPolicy
+	if err := c.Put(fmt.Sprintf("/api/v1/admin/cleanup-policies/%s", id), req, &policy); err != nil {
+		return nil, err
+	}
+	return &policy, nil
+}
+
+// DeleteCleanupPolicy removes a cleanup policy by ID. Admin-only.
+func (c *Client) DeleteCleanupPolicy(id string) error {
+	return c.Delete(fmt.Sprintf("/api/v1/admin/cleanup-policies/%s", id))
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2396,6 +2396,135 @@ func TestDeleteClusterQuota_Forbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
 }
 
+// ---------- cleanup policies ----------
+
+func TestListCleanupPolicies_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/admin/cleanup-policies", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.CleanupPolicy{
+			{Base: types.Base{ID: "1"}, Name: "p1", Action: "stop", Condition: "idle_days:7", Schedule: "0 2 * * *", ClusterID: "all", Enabled: true},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	policies, err := c.ListCleanupPolicies()
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "p1", policies[0].Name)
+}
+
+func TestListCleanupPolicies_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	policies, err := c.ListCleanupPolicies()
+	require.Error(t, err)
+	assert.Nil(t, policies)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
+func TestCreateCleanupPolicy_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/admin/cleanup-policies", r.URL.Path)
+		var got types.CreateCleanupPolicyRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "p1", got.Name)
+		assert.Equal(t, "all", got.ClusterID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.CleanupPolicy{
+			Base:      types.Base{ID: "99"},
+			Name:      got.Name,
+			ClusterID: got.ClusterID,
+			Action:    got.Action,
+			Condition: got.Condition,
+			Schedule:  got.Schedule,
+			Enabled:   got.Enabled,
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.CreateCleanupPolicy(&types.CreateCleanupPolicyRequest{
+		Name: "p1", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:7", Schedule: "0 2 * * *", Enabled: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "99", got.ID)
+	assert.Equal(t, "p1", got.Name)
+}
+
+func TestUpdateCleanupPolicy_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/admin/cleanup-policies/1", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.CleanupPolicy{
+			Base:      types.Base{ID: "1"},
+			Name:      "p1-updated",
+			ClusterID: "all",
+			Action:    "stop",
+			Condition: "idle_days:14",
+			Schedule:  "0 4 * * *",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.UpdateCleanupPolicy("1", &types.UpdateCleanupPolicyRequest{
+		Name: "p1-updated", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:14", Schedule: "0 4 * * *",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "p1-updated", got.Name)
+}
+
+func TestDeleteCleanupPolicy_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/admin/cleanup-policies/1", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.DeleteCleanupPolicy("1"))
+}
+
+func TestDeleteCleanupPolicy_NotFound(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cleanup policy not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.DeleteCleanupPolicy("missing")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+}
+
 // ---------- shared values ----------
 
 func TestListSharedValues_Success(t *testing.T) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -693,6 +693,67 @@ type TemplateVersionSide struct {
 	Snapshot TemplateSnapshot `json:"snapshot" yaml:"snapshot"`
 }
 
+// CleanupPolicy is the success-path response of
+// GET/POST/PUT /api/v1/admin/cleanup-policies. Mirrors the backend
+// models.CleanupPolicy wire format.
+//
+// Note: the backend model has no Version/DeletedAt columns, so those embedded
+// Base fields stay zero on the read path. ID/CreatedAt/UpdatedAt are populated.
+//
+// Field semantics:
+//   - ClusterID — UUID of a target cluster, or the literal string "all" to apply
+//     the policy across every cluster.
+//   - Action — one of "stop", "clean", "delete" (what to do with matching
+//     instances).
+//   - Condition — DSL string evaluated by the scheduler, e.g. "idle_days:7",
+//     "status:stopped,age_days:14", or "ttl_expired".
+//   - Schedule — standard 5-field cron expression, e.g. "0 2 * * *".
+//   - Enabled — false pauses the policy without deleting it.
+//   - DryRun — when true the scheduler logs matches but takes no action.
+//   - LastRunAt — nil until the policy has been executed (manually or by the
+//     scheduler) at least once.
+type CleanupPolicy struct {
+	Base
+	Name      string     `json:"name" yaml:"name"`
+	ClusterID string     `json:"cluster_id" yaml:"cluster_id"`
+	Action    string     `json:"action" yaml:"action"`
+	Condition string     `json:"condition" yaml:"condition"`
+	Schedule  string     `json:"schedule" yaml:"schedule"`
+	Enabled   bool       `json:"enabled" yaml:"enabled"`
+	DryRun    bool       `json:"dry_run" yaml:"dry_run"`
+	LastRunAt *time.Time `json:"last_run_at,omitempty" yaml:"last_run_at,omitempty"`
+}
+
+// CreateCleanupPolicyRequest is the body for POST /api/v1/admin/cleanup-policies
+// (admin-only). The backend uses models.CleanupPolicy as the request DTO too;
+// the CLI uses a dedicated type so that the read-path Base fields aren't
+// echoed back as zero values on create.
+//
+// Field semantics match CleanupPolicy. ID/CreatedAt/UpdatedAt are populated by
+// the server; do not set them on the request.
+type CreateCleanupPolicyRequest struct {
+	Name      string `json:"name" yaml:"name"`
+	ClusterID string `json:"cluster_id" yaml:"cluster_id"`
+	Action    string `json:"action" yaml:"action"`
+	Condition string `json:"condition" yaml:"condition"`
+	Schedule  string `json:"schedule" yaml:"schedule"`
+	Enabled   bool   `json:"enabled" yaml:"enabled"`
+	DryRun    bool   `json:"dry_run" yaml:"dry_run"`
+}
+
+// UpdateCleanupPolicyRequest is the body for PUT /api/v1/admin/cleanup-policies/:id
+// (admin-only). Same shape as CreateCleanupPolicyRequest: PUT is a full
+// upsert, so all fields must be provided.
+type UpdateCleanupPolicyRequest struct {
+	Name      string `json:"name" yaml:"name"`
+	ClusterID string `json:"cluster_id" yaml:"cluster_id"`
+	Action    string `json:"action" yaml:"action"`
+	Condition string `json:"condition" yaml:"condition"`
+	Schedule  string `json:"schedule" yaml:"schedule"`
+	Enabled   bool   `json:"enabled" yaml:"enabled"`
+	DryRun    bool   `json:"dry_run" yaml:"dry_run"`
+}
+
 // ChartDiffEntry describes chart-level differences between two template versions.
 type ChartDiffEntry struct {
 	ChartName      string `json:"chart_name" yaml:"chart_name"`

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -2023,5 +2025,177 @@ func TestE2EClusterQuotaSet(t *testing.T) {
 
 	// stackctl cluster quota delete 1 --yes
 	_, _, err = runStackctl(t, dir, "cluster", "quota", "delete", "1", "--yes")
+	require.NoError(t, err)
+}
+
+// startE2ECleanupPolicyMockServer is an in-memory backend for the cleanup-policy
+// e2e tests. It implements LIST/CREATE/PUT/DELETE on /api/v1/admin/cleanup-policies.
+func startE2ECleanupPolicyMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	type policy struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		ClusterID string `json:"cluster_id"`
+		Action    string `json:"action"`
+		Condition string `json:"condition"`
+		Schedule  string `json:"schedule"`
+		Enabled   bool   `json:"enabled"`
+		DryRun    bool   `json:"dry_run"`
+		CreatedAt string `json:"created_at"`
+		UpdatedAt string `json:"updated_at"`
+	}
+	var (
+		mu       sync.Mutex
+		nextID   = 1
+		policies = map[string]*policy{}
+	)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v1/admin/cleanup-policies" && r.Method == http.MethodGet:
+			mu.Lock()
+			out := make([]policy, 0, len(policies))
+			for _, p := range policies {
+				out = append(out, *p)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+
+		case r.URL.Path == "/api/v1/admin/cleanup-policies" && r.Method == http.MethodPost:
+			var body policy
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+				return
+			}
+			mu.Lock()
+			id := fmt.Sprintf("%d", nextID)
+			nextID++
+			body.ID = id
+			body.CreatedAt = "2026-01-01T00:00:00Z"
+			body.UpdatedAt = "2026-01-01T00:00:00Z"
+			policies[id] = &body
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(body)
+
+		default:
+			trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/cleanup-policies/")
+			if trimmed == r.URL.Path || trimmed == "" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+				return
+			}
+			id := trimmed
+			mu.Lock()
+			existing, exists := policies[id]
+			mu.Unlock()
+
+			switch r.Method {
+			case http.MethodPut:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "cleanup policy not found"})
+					return
+				}
+				var body policy
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+					return
+				}
+				body.ID = id
+				body.CreatedAt = existing.CreatedAt
+				body.UpdatedAt = "2026-01-02T00:00:00Z"
+				mu.Lock()
+				policies[id] = &body
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(body)
+
+			case http.MethodDelete:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "cleanup policy not found"})
+					return
+				}
+				mu.Lock()
+				delete(policies, id)
+				mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "method not allowed"})
+			}
+		}
+	}))
+}
+
+func TestE2ECleanupPolicyList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2ECleanupPolicyMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	// Empty list — table mode prints a friendly message.
+	stdout, _, err := runStackctl(t, dir, "cleanup-policy", "list")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "No cleanup policies found")
+}
+
+func TestE2ECleanupPolicyCRUDRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2ECleanupPolicyMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	policyFile := filepath.Join(dir, "policy.json")
+	require.NoError(t, os.WriteFile(policyFile, []byte(`{
+		"name": "nightly-stop",
+		"cluster_id": "all",
+		"action": "stop",
+		"condition": "idle_days:7",
+		"schedule": "0 2 * * *",
+		"enabled": true
+	}`), 0o600))
+
+	// create
+	stdout, _, err := runStackctl(t, dir, "cleanup-policy", "create", "--from-file", policyFile)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "nightly-stop")
+
+	// list now has it
+	stdout, _, err = runStackctl(t, dir, "cleanup-policy", "list")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "nightly-stop")
+	assert.Contains(t, stdout, "0 2 * * *")
+
+	// get by name
+	stdout, _, err = runStackctl(t, dir, "cleanup-policy", "get", "nightly-stop", "--output", "json")
+	require.NoError(t, err)
+	var got struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Schedule string `json:"schedule"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.Equal(t, "nightly-stop", got.Name)
+	assert.Equal(t, "1", got.ID)
+
+	// delete
+	_, _, err = runStackctl(t, dir, "cleanup-policy", "delete", got.ID, "--yes")
 	require.NoError(t, err)
 }

--- a/cli/test/integration/cleanup_policy_integration_test.go
+++ b/cli/test/integration/cleanup_policy_integration_test.go
@@ -1,0 +1,286 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/cmd"
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cleanupPolicyMockState is the in-memory backend used by the cleanup-policy
+// integration tests. It implements LIST/CREATE/PUT/DELETE on
+// /api/v1/admin/cleanup-policies (the GET-by-ID endpoint does not exist
+// server-side and is resolved client-side via list+filter).
+type cleanupPolicyMockState struct {
+	mu       sync.Mutex
+	nextID   uint
+	policies map[string]*types.CleanupPolicy
+}
+
+func newCleanupPolicyMockState() *cleanupPolicyMockState {
+	return &cleanupPolicyMockState{
+		nextID:   1,
+		policies: make(map[string]*types.CleanupPolicy),
+	}
+}
+
+func startCleanupPolicyMockServer(t *testing.T, state *cleanupPolicyMockState) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v1/admin/cleanup-policies" && r.Method == http.MethodGet:
+			state.mu.Lock()
+			out := make([]types.CleanupPolicy, 0, len(state.policies))
+			for _, p := range state.policies {
+				out = append(out, *p)
+			}
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+
+		case r.URL.Path == "/api/v1/admin/cleanup-policies" && r.Method == http.MethodPost:
+			var req types.CreateCleanupPolicyRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+				return
+			}
+			state.mu.Lock()
+			id := fmt.Sprintf("%d", state.nextID)
+			state.nextID++
+			policy := &types.CleanupPolicy{
+				Base:      types.Base{ID: id, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+				Name:      req.Name,
+				ClusterID: req.ClusterID,
+				Action:    req.Action,
+				Condition: req.Condition,
+				Schedule:  req.Schedule,
+				Enabled:   req.Enabled,
+				DryRun:    req.DryRun,
+			}
+			state.policies[id] = policy
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(policy)
+
+		default:
+			trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/cleanup-policies/")
+			if trimmed == r.URL.Path || trimmed == "" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+				return
+			}
+			id := trimmed
+			state.mu.Lock()
+			existing, exists := state.policies[id]
+			state.mu.Unlock()
+
+			switch r.Method {
+			case http.MethodPut:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cleanup policy not found"})
+					return
+				}
+				var req types.UpdateCleanupPolicyRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+					return
+				}
+				state.mu.Lock()
+				existing.Name = req.Name
+				existing.ClusterID = req.ClusterID
+				existing.Action = req.Action
+				existing.Condition = req.Condition
+				existing.Schedule = req.Schedule
+				existing.Enabled = req.Enabled
+				existing.DryRun = req.DryRun
+				existing.UpdatedAt = time.Now()
+				out := *existing
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(out)
+
+			case http.MethodDelete:
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cleanup policy not found"})
+					return
+				}
+				state.mu.Lock()
+				delete(state.policies, id)
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "method not allowed"})
+			}
+		}
+	}))
+}
+
+func TestCleanupPolicyWorkflow_CRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := newCleanupPolicyMockState()
+	server := startCleanupPolicyMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	// create
+	created, err := c.CreateCleanupPolicy(&types.CreateCleanupPolicyRequest{
+		Name: "nightly-stop", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:7", Schedule: "0 2 * * *", Enabled: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.ID)
+
+	// list returns the just-created policy
+	policies, err := c.ListCleanupPolicies()
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	assert.Equal(t, "nightly-stop", policies[0].Name)
+
+	// update — full upsert
+	updated, err := c.UpdateCleanupPolicy(created.ID, &types.UpdateCleanupPolicyRequest{
+		Name: "nightly-stop", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:14", Schedule: "0 4 * * *", Enabled: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "idle_days:14", updated.Condition)
+	assert.Equal(t, "0 4 * * *", updated.Schedule)
+
+	// delete
+	require.NoError(t, c.DeleteCleanupPolicy(created.ID))
+
+	policies, err = c.ListCleanupPolicies()
+	require.NoError(t, err)
+	assert.Empty(t, policies)
+}
+
+func TestCleanupPolicyWorkflow_DeleteNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := newCleanupPolicyMockState()
+	server := startCleanupPolicyMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+	err := c.DeleteCleanupPolicy("missing")
+	require.Error(t, err)
+	var apiErr *client.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+}
+
+func TestCleanupPolicyCobra_CRUDViaFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	state := newCleanupPolicyMockState()
+	server := startCleanupPolicyMockServer(t, state)
+	defer server.Close()
+
+	dir := t.TempDir()
+	t.Setenv("STACKCTL_CONFIG_DIR", dir)
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	// Write a create payload to disk.
+	createPath := filepath.Join(dir, "policy.json")
+	createPayload := types.CreateCleanupPolicyRequest{
+		Name: "ttl-cleanup", ClusterID: "all", Action: "delete",
+		Condition: "ttl_expired", Schedule: "*/30 * * * *", Enabled: true,
+	}
+	data, err := json.Marshal(createPayload)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(createPath, data, 0o600))
+
+	var buf bytes.Buffer
+
+	// create
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cleanup-policy", "create", "--from-file", createPath})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "ttl-cleanup")
+
+	// list
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cleanup-policy", "list"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "ttl-cleanup")
+
+	// get by name
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cleanup-policy", "get", "ttl-cleanup"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "ttl_expired")
+
+	// determine ID from server state
+	state.mu.Lock()
+	var createdID string
+	for id := range state.policies {
+		createdID = id
+	}
+	state.mu.Unlock()
+	require.NotEmpty(t, createdID)
+
+	// update
+	updatePayload := types.UpdateCleanupPolicyRequest{
+		Name: "ttl-cleanup", ClusterID: "all", Action: "delete",
+		Condition: "ttl_expired", Schedule: "0 1 * * *", Enabled: false,
+	}
+	updatePath := filepath.Join(dir, "update.json")
+	data, err = json.Marshal(updatePayload)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(updatePath, data, 0o600))
+
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cleanup-policy", "update", createdID, "--from-file", updatePath})
+	require.NoError(t, cmd.Execute())
+
+	state.mu.Lock()
+	got := *state.policies[createdID]
+	state.mu.Unlock()
+	assert.Equal(t, "0 1 * * *", got.Schedule)
+	assert.False(t, got.Enabled)
+
+	// delete
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cleanup-policy", "delete", createdID, "--yes"})
+	require.NoError(t, cmd.Execute())
+
+	state.mu.Lock()
+	_, exists := state.policies[createdID]
+	state.mu.Unlock()
+	assert.False(t, exists)
+}


### PR DESCRIPTION
## Summary

Implements the cleanup-policy command group from epic #59 phase 3 (issue #67):

- `stackctl cleanup-policy list`
- `stackctl cleanup-policy get <id-or-name>`
- `stackctl cleanup-policy create --from-file policy.json`
- `stackctl cleanup-policy update <id-or-name> --from-file policy.json`
- `stackctl cleanup-policy delete <id-or-name> [--yes]`

All commands target `/api/v1/admin/cleanup-policies` (admin-gated). The backend does not expose a GET-by-ID route, so `get`/`update`/`delete` by name do a list+filter client-side via `findCleanupPolicy` and surface a clear error on ambiguous matches. PUT is full-upsert, documented in the `update` help text. `--from-file` accepts JSON or YAML, rejects `..` path segments, and pre-validates the required fields (`name`, `cluster_id`, `action`, `condition`, `schedule`) before contacting the backend.

The `run <id> [--dry-run]` subcommand (POST `/:id/run`) is tracked separately as #68.

## Tests

All three layers, all green (`go test ./... && go vet ./...` from `cli/`):

- **Unit:** 22 tests in `cli/cmd/cleanup_policy_test.go` covering every output mode (table/json/yaml/quiet), admin 403, name ambiguity, dry-run, confirmation prompt, validation errors, and path traversal. 6 tests in `cli/pkg/client/client_test.go` for the new client methods.
- **Integration:** full CRUD round-trip + delete-not-found + Cobra-via-env in `cli/test/integration/cleanup_policy_integration_test.go`.
- **E2E:** list-empty and create→list→get→delete happy path against an in-process mock server in `cli/test/e2e/cli_e2e_test.go`.

Two independent code reviews (initial + pre-push) found no blockers. Follow-up commit applied two suggestions: switched test cleanups to the package's `resetFlag` helper (introduced in #84) and documented numeric/UUID-shaped name ambiguity in the `get` help text.

## Test plan

- [x] `go test ./... -v` passes
- [x] `go vet ./...` clean
- [x] Coverage on new code ≥80%
- [ ] Manually exercise against a dev backend once merged

Tracks #59
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full cleanup-policy CLI: list, get (by ID or name), create, update, delete.
  * Create/update from JSON/YAML files with path-traversal protection and request validation.
  * Name→ID resolution (case-insensitive exact match), dry-run support, interactive delete confirmation with --yes override.
  * Output modes: table, JSON, YAML, and quiet (IDs-only).

* **Tests**
  * Added unit, integration, and end-to-end tests covering all CLI and client workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->