### PR TITLE
feat(cleanup-policy): run <id> [--dry-run]

### DIFF
--- a/cli/cmd/cleanup_policy.go
+++ b/cli/cmd/cleanup_policy.go
@@ -258,6 +258,116 @@ Examples:
 	},
 }
 
+var cleanupPolicyRunCmd = &cobra.Command{
+	Use:   "run <id-or-name>",
+	Short: "Execute a cleanup policy immediately (admin only)",
+	Long: `Trigger a one-off run of a cleanup policy, outside its normal schedule.
+
+Use --dry-run to preview the affected stack instances without applying the
+policy's action (stop/clean/delete). Without --dry-run the backend applies
+the action and returns one result per matched instance.
+
+The command exits non-zero when the backend reports any per-instance error,
+even if other instances succeeded — partial failures are surfaced so scripts
+can branch on the exit code.
+
+When the argument is a name (not an ID), this command issues a list+filter
+round-trip to resolve the ID before sending the run request.
+
+Examples:
+  stackctl cleanup-policy run 1 --dry-run
+  stackctl cleanup-policy run nightly-stop
+  stackctl cleanup-policy run 1 -o json`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+
+		id, err := resolveCleanupPolicyID(c, args[0])
+		if err != nil {
+			return err
+		}
+
+		results, err := c.RunCleanupPolicy(id, dryRun)
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, r := range results {
+				fmt.Fprintln(printer.Writer, r.InstanceID)
+			}
+			return runExitOnPartialFailure(results)
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			if err := printer.PrintJSON(results); err != nil {
+				return err
+			}
+		case output.FormatYAML:
+			if err := printer.PrintYAML(results); err != nil {
+				return err
+			}
+		default:
+			if len(results) == 0 {
+				printer.PrintMessage("No instances matched policy %s.", args[0])
+			} else {
+				headers := []string{"INSTANCE ID", "INSTANCE", "NAMESPACE", "OWNER", "ACTION", "STATUS", "ERROR"}
+				rows := make([][]string, len(results))
+				for i, r := range results {
+					rows[i] = []string{r.InstanceID, r.InstanceName, r.Namespace, r.OwnerID, r.Action, r.Status, r.Error}
+				}
+				if err := printer.PrintTable(headers, rows); err != nil {
+					return err
+				}
+			}
+			success, errored, dry := cleanupResultCounts(results)
+			printer.PrintMessage("Summary: %d success, %d error, %d dry-run.", success, errored, dry)
+		}
+
+		return runExitOnPartialFailure(results)
+	},
+}
+
+// cleanupResultCounts buckets the results by Status. Anything outside the
+// three documented statuses ("success", "error", "dry_run") is ignored for
+// counting — unknown statuses still appear in the table.
+func cleanupResultCounts(results []types.CleanupResult) (success, errored, dryRun int) {
+	for _, r := range results {
+		switch r.Status {
+		case "success":
+			success++
+		case "error":
+			errored++
+		case "dry_run":
+			dryRun++
+		}
+	}
+	return
+}
+
+// runExitOnPartialFailure returns a non-nil error (which Cobra turns into a
+// non-zero exit code) when at least one result reports Status == "error".
+// SilenceUsage on the command keeps cobra from printing the usage banner.
+func runExitOnPartialFailure(results []types.CleanupResult) error {
+	n := 0
+	for _, r := range results {
+		if r.Status == "error" {
+			n++
+		}
+	}
+	if n > 0 {
+		return fmt.Errorf("cleanup policy reported %d per-instance failure(s); see results above", n)
+	}
+	return nil
+}
+
 // readPolicyFile loads a JSON or YAML file containing a cleanup-policy payload.
 // `..` segments in the path are rejected to match the convention used by
 // `cluster create`, `cluster update`, `definition create`, etc.
@@ -389,11 +499,14 @@ func init() {
 	cleanupPolicyDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
 	cleanupPolicyDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
 
+	cleanupPolicyRunCmd.Flags().Bool("dry-run", false, "Preview the affected stack instances without applying the policy's action")
+
 	cleanupPolicyCmd.AddCommand(cleanupPolicyListCmd)
 	cleanupPolicyCmd.AddCommand(cleanupPolicyGetCmd)
 	cleanupPolicyCmd.AddCommand(cleanupPolicyCreateCmd)
 	cleanupPolicyCmd.AddCommand(cleanupPolicyUpdateCmd)
 	cleanupPolicyCmd.AddCommand(cleanupPolicyDeleteCmd)
+	cleanupPolicyCmd.AddCommand(cleanupPolicyRunCmd)
 
 	rootCmd.AddCommand(cleanupPolicyCmd)
 }

--- a/cli/cmd/cleanup_policy_test.go
+++ b/cli/cmd/cleanup_policy_test.go
@@ -734,3 +734,177 @@ func TestCleanupPolicyDeleteCmd_InteractiveDecline(t *testing.T) {
 	require.NoError(t, cleanupPolicyDeleteCmd.RunE(cleanupPolicyDeleteCmd, []string{"1"}))
 	assert.Contains(t, buf.String(), "Aborted")
 }
+
+// ---------- run ----------
+
+func sampleRunResults() []types.CleanupResult {
+	return []types.CleanupResult{
+		{InstanceID: "i1", InstanceName: "app-1", Namespace: "stack-app-1", OwnerID: "alice", Action: "stop", Status: "success"},
+		{InstanceID: "i2", InstanceName: "app-2", Namespace: "stack-app-2", OwnerID: "bob", Action: "stop", Status: "dry_run"},
+	}
+}
+
+func TestCleanupPolicyRunCmd_DryRun(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/admin/cleanup-policies/1/run", r.URL.Path)
+		require.Equal(t, "true", r.URL.Query().Get("dry_run"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleRunResults())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyRunCmd.Flags().Set("dry-run", "true"))
+	t.Cleanup(func() { resetFlag(t, cleanupPolicyRunCmd.Flags(), "dry-run", "false") })
+
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"}))
+	assert.True(t, called)
+	out := buf.String()
+	assert.Contains(t, out, "app-1")
+	assert.Contains(t, out, "Summary: 1 success, 0 error, 1 dry-run")
+}
+
+func TestCleanupPolicyRunCmd_RealRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/admin/cleanup-policies/1/run", r.URL.Path)
+		require.Empty(t, r.URL.Query().Get("dry_run"), "real run must NOT send dry_run param")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.CleanupResult{
+			{InstanceID: "i1", InstanceName: "app-1", Action: "stop", Status: "success"},
+		})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"}))
+}
+
+func TestCleanupPolicyRunCmd_PartialFailureExitCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.CleanupResult{
+			{InstanceID: "i1", Action: "delete", Status: "success"},
+			{InstanceID: "i2", Action: "delete", Status: "error", Error: "namespace stuck terminating"},
+			{InstanceID: "i3", Action: "delete", Status: "error", Error: "kubeconfig expired"},
+		})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"})
+	require.Error(t, err, "partial failure must surface as a non-nil error so cobra exits non-zero")
+	assert.Contains(t, err.Error(), "2 per-instance failure")
+}
+
+func TestCleanupPolicyRunCmd_AllSuccessExitsZero(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.CleanupResult{
+			{InstanceID: "i1", Action: "stop", Status: "success"},
+		})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"}))
+}
+
+func TestCleanupPolicyRunCmd_NoMatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.CleanupResult{})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"}))
+	assert.Contains(t, buf.String(), "No instances matched")
+}
+
+func TestCleanupPolicyRunCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleRunResults())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"}))
+
+	var got []types.CleanupResult
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, "i1", got[0].InstanceID)
+}
+
+func TestCleanupPolicyRunCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleRunResults())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"}))
+
+	var got []types.CleanupResult
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestCleanupPolicyRunCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleRunResults())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"}))
+	assert.Equal(t, "i1\ni2\n", buf.String(), "quiet mode must emit one instance ID per line")
+}
+
+func TestCleanupPolicyRunCmd_ResolveNameToID(t *testing.T) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(sampleCleanupPolicies())
+		case http.MethodPost:
+			capturedPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]types.CleanupResult{})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"nightly-stop"}))
+	assert.Equal(t, "/api/v1/admin/cleanup-policies/1/run", capturedPath)
+}
+
+func TestCleanupPolicyRunCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "admin role required"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := cleanupPolicyRunCmd.RunE(cleanupPolicyRunCmd, []string{"1"})
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "admin role required")
+}

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1247,3 +1247,26 @@ func (c *Client) UpdateCleanupPolicy(id string, req *types.UpdateCleanupPolicyRe
 func (c *Client) DeleteCleanupPolicy(id string) error {
 	return c.Delete(fmt.Sprintf("/api/v1/admin/cleanup-policies/%s", id))
 }
+
+// RunCleanupPolicy executes a cleanup policy immediately. When dryRun is true
+// the scheduler only logs the matched instances; otherwise it applies the
+// policy's action. Admin-only. The dry-run flag is sent as a query parameter,
+// matching the backend handler which reads c.Query("dry_run").
+//
+// Returns one CleanupResult per matched instance — never nil, may be empty if
+// nothing matched. A successful HTTP response can still contain results with
+// Status == "error" (partial failure on a per-instance basis); callers should
+// inspect each result rather than relying on the absence of an error return.
+//
+// @see POST /api/v1/admin/cleanup-policies/:id/run
+func (c *Client) RunCleanupPolicy(id string, dryRun bool) ([]types.CleanupResult, error) {
+	path := fmt.Sprintf("/api/v1/admin/cleanup-policies/%s/run", id)
+	if dryRun {
+		path += "?dry_run=true"
+	}
+	var results []types.CleanupResult
+	if err := c.Post(path, nil, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2508,6 +2508,62 @@ func TestDeleteCleanupPolicy_Success(t *testing.T) {
 	require.NoError(t, c.DeleteCleanupPolicy("1"))
 }
 
+func TestRunCleanupPolicy_DryRun(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/admin/cleanup-policies/1/run", r.URL.Path)
+		assert.Equal(t, "true", r.URL.Query().Get("dry_run"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.CleanupResult{
+			{InstanceID: "i1", Action: "stop", Status: "dry_run"},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	results, err := c.RunCleanupPolicy("1", true)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "dry_run", results[0].Status)
+}
+
+func TestRunCleanupPolicy_RealRun(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.URL.Query().Get("dry_run"), "real run must omit dry_run query param")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.CleanupResult{
+			{InstanceID: "i1", Action: "stop", Status: "success"},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	results, err := c.RunCleanupPolicy("1", false)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "success", results[0].Status)
+}
+
+func TestRunCleanupPolicy_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	results, err := c.RunCleanupPolicy("1", false)
+	require.Error(t, err)
+	assert.Nil(t, results)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
 func TestDeleteCleanupPolicy_NotFound(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -745,6 +745,9 @@ type CreateCleanupPolicyRequest struct {
 // POST /api/v1/admin/cleanup-policies/:id/run. Mirrors backend
 // scheduler.CleanupResult.
 //
+// Population: only returned on HTTP 200. On non-2xx the client surfaces an
+// APIError and the result slice is left nil by the caller.
+//
 // Field semantics:
 //   - Status — "success" (action applied), "error" (action attempted and
 //     failed), or "dry_run" (matched, no action taken). Callers should treat

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -741,6 +741,26 @@ type CreateCleanupPolicyRequest struct {
 	DryRun    bool   `json:"dry_run" yaml:"dry_run"`
 }
 
+// CleanupResult is one entry in the response of
+// POST /api/v1/admin/cleanup-policies/:id/run. Mirrors backend
+// scheduler.CleanupResult.
+//
+// Field semantics:
+//   - Status — "success" (action applied), "error" (action attempted and
+//     failed), or "dry_run" (matched, no action taken). Callers should treat
+//     "dry_run" as informational and "error" as the partial-failure signal.
+//   - Error — populated only when Status == "error"; carries the per-instance
+//     failure reason.
+type CleanupResult struct {
+	InstanceID   string `json:"instance_id" yaml:"instance_id"`
+	InstanceName string `json:"instance_name" yaml:"instance_name"`
+	Namespace    string `json:"namespace" yaml:"namespace"`
+	OwnerID      string `json:"owner_id" yaml:"owner_id"`
+	Action       string `json:"action" yaml:"action"`
+	Status       string `json:"status" yaml:"status"`
+	Error        string `json:"error,omitempty" yaml:"error,omitempty"`
+}
+
 // UpdateCleanupPolicyRequest is the body for PUT /api/v1/admin/cleanup-policies/:id
 // (admin-only). Same shape as CreateCleanupPolicyRequest: PUT is a full
 // upsert, so all fields must be provided.

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2116,6 +2116,16 @@ func startE2ECleanupPolicyMockServer(t *testing.T) *httptest.Server {
 				return
 			}
 
+			// If the path carried an action segment we didn't explicitly handle
+			// (e.g. /:id/unknown), reject before falling through to PUT/DELETE
+			// on the base policy — otherwise the mock would silently mutate
+			// /:id when the caller asked for /:id/<something-else>.
+			if action != "" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "unknown action: " + action})
+				return
+			}
+
 			switch r.Method {
 			case http.MethodPut:
 				if !exists {

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2089,9 +2089,32 @@ func startE2ECleanupPolicyMockServer(t *testing.T) *httptest.Server {
 				return
 			}
 			id := trimmed
+			action := ""
+			if i := strings.Index(id, "/"); i >= 0 {
+				id, action = id[:i], id[i+1:]
+			}
 			mu.Lock()
 			existing, exists := policies[id]
 			mu.Unlock()
+
+			// POST /api/v1/admin/cleanup-policies/:id/run
+			if action == "run" && r.Method == http.MethodPost {
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "cleanup policy not found"})
+					return
+				}
+				dryRun := r.URL.Query().Get("dry_run") == "true"
+				status := "success"
+				if dryRun {
+					status = "dry_run"
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+					{"instance_id": "i-" + id + "-1", "instance_name": "app-1", "namespace": "stack-app-1", "owner_id": "alice", "action": existing.Action, "status": status},
+				})
+				return
+			}
 
 			switch r.Method {
 			case http.MethodPut:
@@ -2198,4 +2221,41 @@ func TestE2ECleanupPolicyCRUDRoundTrip(t *testing.T) {
 	// delete
 	_, _, err = runStackctl(t, dir, "cleanup-policy", "delete", got.ID, "--yes")
 	require.NoError(t, err)
+}
+
+func TestE2ECleanupPolicyRunDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2ECleanupPolicyMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	// Seed a policy first.
+	policyFile := filepath.Join(dir, "policy.json")
+	require.NoError(t, os.WriteFile(policyFile, []byte(`{
+		"name": "nightly-stop",
+		"cluster_id": "all",
+		"action": "stop",
+		"condition": "idle_days:7",
+		"schedule": "0 2 * * *",
+		"enabled": true
+	}`), 0o600))
+	_, _, err := runStackctl(t, dir, "cleanup-policy", "create", "--from-file", policyFile)
+	require.NoError(t, err)
+
+	// run --dry-run — exit 0, output shows the dry-run status.
+	stdout, _, err := runStackctl(t, dir, "cleanup-policy", "run", "1", "--dry-run")
+	require.NoError(t, err, "dry-run must exit 0")
+	assert.Contains(t, stdout, "dry_run")
+	assert.Contains(t, stdout, "1 dry-run")
+
+	// Real run also exits 0 when every instance reports success.
+	stdout, _, err = runStackctl(t, dir, "cleanup-policy", "run", "1")
+	require.NoError(t, err, "all-success real run must exit 0")
+	assert.Contains(t, stdout, "success")
+	assert.Contains(t, stdout, "1 success")
 }

--- a/cli/test/integration/cleanup_policy_integration_test.go
+++ b/cli/test/integration/cleanup_policy_integration_test.go
@@ -117,6 +117,14 @@ func startCleanupPolicyMockServer(t *testing.T, state *cleanupPolicyMockState) *
 				return
 			}
 
+			// Reject any other action segment so /:id/<unknown> doesn't fall
+			// through to PUT/DELETE on the base policy.
+			if action != "" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "unknown action: " + action})
+				return
+			}
+
 			switch r.Method {
 			case http.MethodPut:
 				if !exists {

--- a/cli/test/integration/cleanup_policy_integration_test.go
+++ b/cli/test/integration/cleanup_policy_integration_test.go
@@ -86,9 +86,36 @@ func startCleanupPolicyMockServer(t *testing.T, state *cleanupPolicyMockState) *
 				return
 			}
 			id := trimmed
+			action := ""
+			if i := strings.Index(id, "/"); i >= 0 {
+				id, action = id[:i], id[i+1:]
+			}
 			state.mu.Lock()
 			existing, exists := state.policies[id]
 			state.mu.Unlock()
+
+			// POST /api/v1/admin/cleanup-policies/:id/run — execute the policy.
+			if action == "run" && r.Method == http.MethodPost {
+				if !exists {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "cleanup policy not found"})
+					return
+				}
+				dryRun := r.URL.Query().Get("dry_run") == "true"
+				status := "success"
+				if dryRun {
+					status = "dry_run"
+				}
+				results := []types.CleanupResult{
+					{InstanceID: "i-" + id + "-1", InstanceName: "app-1", Namespace: "stack-app-1", OwnerID: "alice", Action: existing.Action, Status: status},
+				}
+				state.mu.Lock()
+				existing.LastRunAt = func() *time.Time { t := time.Now(); return &t }()
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(results)
+				return
+			}
 
 			switch r.Method {
 			case http.MethodPut:
@@ -283,4 +310,80 @@ func TestCleanupPolicyCobra_CRUDViaFile(t *testing.T) {
 	_, exists := state.policies[createdID]
 	state.mu.Unlock()
 	assert.False(t, exists)
+}
+
+func TestCleanupPolicyWorkflow_RunDryRunThenReal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := newCleanupPolicyMockState()
+	server := startCleanupPolicyMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	created, err := c.CreateCleanupPolicy(&types.CreateCleanupPolicyRequest{
+		Name: "nightly-stop", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:7", Schedule: "0 2 * * *", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	// dry-run first
+	results, err := c.RunCleanupPolicy(created.ID, true)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "dry_run", results[0].Status)
+	assert.Equal(t, "stop", results[0].Action)
+
+	// real run
+	results, err = c.RunCleanupPolicy(created.ID, false)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "success", results[0].Status)
+}
+
+func TestCleanupPolicyCobra_Run(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	state := newCleanupPolicyMockState()
+	server := startCleanupPolicyMockServer(t, state)
+	defer server.Close()
+
+	dir := t.TempDir()
+	t.Setenv("STACKCTL_CONFIG_DIR", dir)
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	// Seed a policy via the client so we have an ID to run.
+	c := client.New(server.URL)
+	created, err := c.CreateCleanupPolicy(&types.CreateCleanupPolicyRequest{
+		Name: "p1", ClusterID: "all", Action: "stop",
+		Condition: "idle_days:7", Schedule: "0 2 * * *", Enabled: true,
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+
+	// Real run first — the --dry-run flag is sticky across cmd.Execute() calls
+	// when reused in this in-process test loop, so do the explicit-false case
+	// before the explicit-true case to avoid bleed-over.
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cleanup-policy", "run", created.ID, "--dry-run=false"})
+	require.NoError(t, cmd.Execute())
+	realOut := buf.String()
+	assert.Contains(t, realOut, "success", "result row must show the success status")
+	assert.Contains(t, realOut, "1 success", "summary must count the success result")
+
+	// Then --dry-run
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"cleanup-policy", "run", created.ID, "--dry-run"})
+	require.NoError(t, cmd.Execute())
+	dryOut := buf.String()
+	assert.Contains(t, dryOut, "dry_run", "result row must show the dry_run status")
+	assert.Contains(t, dryOut, "1 dry-run", "summary must count the dry-run result")
 }


### PR DESCRIPTION
## Summary

Implements the `cleanup-policy run` subcommand from epic #59 phase 3 (issue #68):

- `stackctl cleanup-policy run <id-or-name> [--dry-run]` → POST `/api/v1/admin/cleanup-policies/:id/run`

Key behavior:
- `--dry-run` is sent as a **query parameter** (`?dry_run=true`), matching the backend handler that reads `c.Query("dry_run")` rather than a body field. The dry-run path reports matched instances with `Status="dry_run"` and does not apply the policy's action.
- Output: table (default), JSON, YAML, quiet (one instance ID per line). Table mode appends a `Summary: N success, N error, N dry-run.` line so the operator gets the counts without re-parsing the rows.
- **Partial-failure exit code**: returns a non-nil `RunE` error (which Cobra translates to a non-zero exit) when any result reports `Status="error"`, even if other instances succeeded. Message includes the failure count so scripts can branch on it.
- Name-or-ID resolution reuses the existing `resolveCleanupPolicyID` helper (list+filter, since the backend exposes no GET-by-ID endpoint).

## Tests

All three layers, all green (`go test ./... && go vet ./...` from `cli/`):

- **Unit (cmd):** 10 tests in `cli/cmd/cleanup_policy_test.go` — dry-run wire format, real run, partial-failure exit, all-success, empty-result, JSON/YAML/quiet output, name resolution, 403.
- **Unit (client):** 3 tests in `cli/pkg/client/client_test.go` — asserts `dry_run` query param is present on dry-run and absent on real run, plus 403 mapping.
- **Integration:** in-process client round-trip (dry-run + real run) and Cobra-via-env test in `cli/test/integration/cleanup_policy_integration_test.go`.
- **E2E:** binary exec'd against a stub server in `cli/test/e2e/cli_e2e_test.go`, asserts exit 0 for both dry-run and all-success real run.

Independent code review found no blockers. Three small suggestions applied: folded duplicate error-count loop, fixed "no matches" message to echo the user's original argument (not the resolved ID), and expanded the client doc comment to flag the partial-failure return semantics.

## Test plan

- [x] `go test ./... -v` passes
- [x] `go vet ./...` clean
- [x] Coverage on new code ≥80%
- [ ] Manually exercise `run --dry-run` against a dev backend once merged

Closes #68
Tracks #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to run cleanup policies on-demand (by ID or name) with a --dry-run preview.
  * Multiple output formats: table (default), JSON, YAML, and quiet mode (one ID per line).
  * Non-zero exit when any instance reports an error.

* **Tests**
  * Added unit, integration, and e2e coverage for dry-run, real runs, partial failures, output formats, name resolution, and permission errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->