### PR TITLE
feat(user,auth): admin user lifecycle + auth register

### DIFF
--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -68,10 +68,15 @@ Environment variables:
 		}
 
 		if password == "" {
+			// loginCmd intentionally tolerates non-TTY stdin without a flag
+			// for backward compatibility — scripts have been piping passwords
+			// to `stackctl login` since day one. New destructive commands
+			// (auth register, user reset-password) use the stricter
+			// readPassword helper which requires --password-stdin.
 			fmt.Fprint(cmd.ErrOrStderr(), "Password: ")
 			if f, ok := cmd.InOrStdin().(*os.File); ok && term.IsTerminal(int(f.Fd())) {
 				raw, err := term.ReadPassword(int(f.Fd()))
-				fmt.Fprintln(cmd.ErrOrStderr()) // newline after hidden input
+				fmt.Fprintln(cmd.ErrOrStderr())
 				if err != nil {
 					return fmt.Errorf("reading password: %w", err)
 				}
@@ -320,12 +325,124 @@ func parseJWTExpiry(token string) (time.Time, error) {
 	return time.Unix(claims.Exp, 0), nil
 }
 
+// readPassword reads a password from stdin. When fromStdin is true the
+// caller is opting into pipe-based input — read the full piped line(s) and
+// strip the trailing newline. Otherwise, prompt on stderr and read silently
+// from the terminal.
+//
+// If stdin is NOT a TTY and the caller didn't pass --password-stdin, this
+// returns an error rather than silently slurping inherited/redirected stdin
+// (which would proceed past the visible prompt with arbitrary content).
+// Mirrors the `docker login --password-stdin` contract.
+//
+// Tests inject input via cmd.SetIn(strings.NewReader(...)); they must pass
+// fromStdin=true to opt into the line-mode path.
+func readPassword(cmd *cobra.Command, prompt string, fromStdin bool) (string, error) {
+	if !fromStdin {
+		f, ok := cmd.InOrStdin().(*os.File)
+		if !ok || !term.IsTerminal(int(f.Fd())) {
+			return "", fmt.Errorf("stdin is not a terminal; use --password-stdin to read the password from a pipe or file")
+		}
+		fmt.Fprint(cmd.ErrOrStderr(), prompt)
+		raw, err := term.ReadPassword(int(f.Fd()))
+		fmt.Fprintln(cmd.ErrOrStderr()) // newline after hidden input
+		if err != nil {
+			return "", fmt.Errorf("reading password: %w", err)
+		}
+		return string(raw), nil
+	}
+	reader := bufio.NewReader(cmd.InOrStdin())
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf("reading password: %w", err)
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Authentication commands",
+	Long: `Authentication commands.
+
+Note: the day-to-day verbs login/logout/whoami live at the top level
+(stackctl login, stackctl logout, stackctl whoami) for ergonomics. The
+'auth' group hosts the less-frequent admin-only register flow.`,
+}
+
+var authRegisterCmd = &cobra.Command{
+	Use:   "register",
+	Short: "Register a new user account (admin only unless self-registration is enabled)",
+	Long: `Create a new user account on the server.
+
+The endpoint requires an authenticated caller. Non-admin callers can only
+register if the server has self-registration enabled. Only admin callers can
+set --role or --service-account (the server silently overrides them for
+non-admin callers).
+
+The password is read interactively by default. Use --password-stdin to read
+the password from stdin (recommended for scripting); the entire piped
+content is treated as the password with the trailing newline stripped.
+
+Note: the backend's register endpoint does not accept an email address.
+Email-on-create is not supported at this time.
+
+Examples:
+  stackctl auth register --username alice
+  stackctl auth register --username svc-ci --service-account --role user \
+      --password-stdin < /run/secrets/svc-ci.password`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		username, _ := cmd.Flags().GetString("username")
+		if username == "" {
+			return fmt.Errorf("--username is required")
+		}
+		displayName, _ := cmd.Flags().GetString("display-name")
+		role, _ := cmd.Flags().GetString("role")
+		serviceAccount, _ := cmd.Flags().GetBool("service-account")
+		fromStdin, _ := cmd.Flags().GetBool("password-stdin")
+
+		password, err := readPassword(cmd, "Password: ", fromStdin)
+		if err != nil {
+			return err
+		}
+		if len(password) < 8 {
+			return fmt.Errorf("password must be at least 8 characters")
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		user, err := c.Register(&types.RegisterRequest{
+			Username:       username,
+			Password:       password,
+			DisplayName:    displayName,
+			Role:           role,
+			ServiceAccount: serviceAccount,
+		})
+		if err != nil {
+			return err
+		}
+		return printUser(user)
+	},
+}
+
 func init() {
 	loginCmd.Flags().String("username", "", "Username for authentication")
 	loginCmd.Flags().String("password", "", "Password for authentication")
 	loginCmd.Flags().Bool("sso", false, "Authenticate via SSO (opens browser)")
 
+	authRegisterCmd.Flags().String("username", "", "Username for the new account (required)")
+	authRegisterCmd.Flags().String("display-name", "", "Optional display name; defaults to username on the server")
+	authRegisterCmd.Flags().String("role", "", "Role to assign (admin only; ignored from non-admin callers)")
+	authRegisterCmd.Flags().Bool("service-account", false, "Create a service account (admin only)")
+	authRegisterCmd.Flags().Bool("password-stdin", false, "Read the password from stdin (one line, trailing newline stripped)")
+	_ = authRegisterCmd.MarkFlagRequired("username")
+
+	authCmd.AddCommand(authRegisterCmd)
+
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(logoutCmd)
 	rootCmd.AddCommand(whoamiCmd)
+	rootCmd.AddCommand(authCmd)
 }

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -326,9 +326,10 @@ func parseJWTExpiry(token string) (time.Time, error) {
 }
 
 // readPassword reads a password from stdin. When fromStdin is true the
-// caller is opting into pipe-based input — read the full piped line(s) and
-// strip the trailing newline. Otherwise, prompt on stderr and read silently
-// from the terminal.
+// caller is opting into pipe-based input — read one line from stdin (up to
+// the first newline, or EOF) and strip the trailing CR/LF. Embedded newlines
+// are not supported. Otherwise, prompt on stderr and read silently from the
+// terminal.
 //
 // If stdin is NOT a TTY and the caller didn't pass --password-stdin, this
 // returns an error rather than silently slurping inherited/redirected stdin
@@ -380,8 +381,9 @@ set --role or --service-account (the server silently overrides them for
 non-admin callers).
 
 The password is read interactively by default. Use --password-stdin to read
-the password from stdin (recommended for scripting); the entire piped
-content is treated as the password with the trailing newline stripped.
+the password from stdin (recommended for scripting); one line is read (up to
+the first newline, or EOF) and the trailing CR/LF is stripped. Embedded
+newlines in the password are not supported.
 
 Note: the backend's register endpoint does not accept an email address.
 Email-on-create is not supported at this time.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -109,6 +109,13 @@ func SetOut(w io.Writer) {
 	rootCmd.SetOut(w)
 }
 
+// SetIn redirects the root command input reader. Subcommands that read
+// passwords or confirmation responses use cmd.InOrStdin(), which inherits
+// the root setting. Intended for integration tests.
+func SetIn(r io.Reader) {
+	rootCmd.SetIn(r)
+}
+
 // ResetFlagsForTest resets all persistent flag variables to their default
 // values. Cobra does not reset flags between in-process Execute calls, so
 // integration tests that mix flag values across subtests must call this

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -139,8 +139,9 @@ The new password must be at least 8 characters. The backend rejects users
 whose AuthProvider is not "local" (e.g. OIDC-federated users).
 
 The password is read interactively by default. Use --password-stdin to read
-the password from stdin (recommended for scripting); the entire piped
-content is treated as the password with the trailing newline stripped.
+the password from stdin (recommended for scripting); one line is read (up to
+the first newline, or EOF) and the trailing CR/LF is stripped. Embedded
+newlines in the password are not supported.
 
 Examples:
   stackctl user reset-password <uuid>

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+var userCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Manage user accounts (admin only)",
+	Long: `Manage user accounts on the stack manager API.
+
+All user-management commands require admin role. The CLI surface intentionally
+omits a generic 'update' verb because the backend only exposes the
+disable/enable/reset-password operations rather than a full PUT.`,
+}
+
+var userListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all user accounts (admin only)",
+	Long: `List every user account on the server.
+
+Examples:
+  stackctl user list
+  stackctl user list -o json
+  stackctl user list --quiet`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		users, err := c.ListUsers()
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, u := range users {
+				fmt.Fprintln(printer.Writer, u.ID)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(users)
+		case output.FormatYAML:
+			return printer.PrintYAML(users)
+		default:
+			if len(users) == 0 {
+				printer.PrintMessage("No users found.")
+				return nil
+			}
+			headers := []string{"ID", "USERNAME", "DISPLAY NAME", "ROLE", "PROVIDER", "DISABLED", "SERVICE ACCOUNT"}
+			rows := make([][]string, len(users))
+			for i, u := range users {
+				rows[i] = []string{
+					u.ID,
+					u.Username,
+					u.DisplayName,
+					u.Role,
+					u.AuthProvider,
+					strconv.FormatBool(u.Disabled),
+					strconv.FormatBool(u.ServiceAccount),
+				}
+			}
+			return printer.PrintTable(headers, rows)
+		}
+	},
+}
+
+var userDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete a user account (admin only)",
+	Long: `Permanently delete a user account.
+
+This is a destructive operation. You will be prompted for confirmation
+unless --yes is specified. The backend rejects an attempt to delete the
+caller's own account.
+
+Examples:
+  stackctl user delete <uuid>
+  stackctl user delete <uuid> --yes`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return deleteByID(cmd, args,
+			"This will permanently delete user %s. Continue? (y/n): ",
+			passthroughID,
+			func(c *client.Client, id string) error { return c.DeleteUser(id) },
+			"Deleted user %s",
+		)
+	},
+}
+
+var userDisableCmd = &cobra.Command{
+	Use:   "disable <id>",
+	Short: "Disable a user account (admin only)",
+	Long: `Disable a user account. All active sessions and API keys are revoked
+server-side; the user can no longer authenticate until re-enabled.
+
+The backend rejects an attempt to disable the caller's own account.
+
+Examples:
+  stackctl user disable <uuid>`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return userToggle(cmd, args, "Disabled", (*client.Client).DisableUser)
+	},
+}
+
+var userEnableCmd = &cobra.Command{
+	Use:   "enable <id>",
+	Short: "Re-enable a previously disabled user account (admin only)",
+	Long: `Re-enable a previously disabled user account.
+
+Examples:
+  stackctl user enable <uuid>`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return userToggle(cmd, args, "Enabled", (*client.Client).EnableUser)
+	},
+}
+
+var userResetPasswordCmd = &cobra.Command{
+	Use:   "reset-password <id>",
+	Short: "Reset a user's password (admin only)",
+	Long: `Reset the password for a local user account.
+
+The new password must be at least 8 characters. The backend rejects users
+whose AuthProvider is not "local" (e.g. OIDC-federated users).
+
+The password is read interactively by default. Use --password-stdin to read
+the password from stdin (recommended for scripting); the entire piped
+content is treated as the password with the trailing newline stripped.
+
+Examples:
+  stackctl user reset-password <uuid>
+  echo 'hunter2!!' | stackctl user reset-password <uuid> --password-stdin`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+
+		fromStdin, _ := cmd.Flags().GetBool("password-stdin")
+		password, err := readPassword(cmd, "New password: ", fromStdin)
+		if err != nil {
+			return err
+		}
+		if len(password) < 8 {
+			return fmt.Errorf("password must be at least 8 characters")
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		if err := c.ResetUserPassword(id, password); err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, id)
+			return nil
+		}
+		printer.PrintMessage("Reset password for user %s", id)
+		return nil
+	},
+}
+
+// userToggle backs the user disable/enable commands. label is "Disabled"
+// or "Enabled" (used verbatim in the success message); apply is the client
+// method to invoke.
+func userToggle(cmd *cobra.Command, args []string, label string, apply func(*client.Client, string) error) error {
+	id, err := parseID(args[0])
+	if err != nil {
+		return err
+	}
+	c, err := newClient()
+	if err != nil {
+		return err
+	}
+	if err := apply(c, id); err != nil {
+		return err
+	}
+
+	if printer.Quiet {
+		fmt.Fprintln(printer.Writer, id)
+		return nil
+	}
+	printer.PrintMessage("%s user %s", label, id)
+	return nil
+}
+
+// printUser renders a single User in the configured output format. Shared
+// by `auth register` to display the just-created account.
+func printUser(u *types.User) error {
+	if printer.Quiet {
+		fmt.Fprintln(printer.Writer, u.ID)
+		return nil
+	}
+	switch printer.Format {
+	case output.FormatJSON:
+		return printer.PrintJSON(u)
+	case output.FormatYAML:
+		return printer.PrintYAML(u)
+	default:
+		return printer.PrintSingle(u, []output.KeyValue{
+			{Key: "ID", Value: u.ID},
+			{Key: "Username", Value: u.Username},
+			{Key: "Display Name", Value: u.DisplayName},
+			{Key: "Email", Value: u.Email},
+			{Key: "Role", Value: u.Role},
+			{Key: "Provider", Value: u.AuthProvider},
+			{Key: "Disabled", Value: strconv.FormatBool(u.Disabled)},
+			{Key: "Service Account", Value: strconv.FormatBool(u.ServiceAccount)},
+		})
+	}
+}
+
+func init() {
+	userDeleteCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	userDeleteCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+	userResetPasswordCmd.Flags().Bool("password-stdin", false, "Read the new password from stdin (one line, trailing newline stripped)")
+
+	userCmd.AddCommand(userListCmd)
+	userCmd.AddCommand(userDeleteCmd)
+	userCmd.AddCommand(userDisableCmd)
+	userCmd.AddCommand(userEnableCmd)
+	userCmd.AddCommand(userResetPasswordCmd)
+
+	rootCmd.AddCommand(userCmd)
+}

--- a/cli/cmd/user_test.go
+++ b/cli/cmd/user_test.go
@@ -410,3 +410,102 @@ func TestAuthRegisterCmd_QuietOutput(t *testing.T) {
 	require.NoError(t, authRegisterCmd.RunE(authRegisterCmd, []string{}))
 	assert.Equal(t, "new-id\n", buf.String())
 }
+
+// ---------- API error matrix (401/404/500) ----------
+//
+// Every new user/auth command must surface the documented APIError statuses
+// (401/404/500) as a non-nil error from RunE so the cobra harness exits
+// non-zero. The cases below are genuinely homogeneous — same setup, same
+// assertion shape, only the command and status differ — so table-driven is
+// the right fit per tests.instructions.md.
+
+func TestUserAuthCmd_APIErrorMatrix(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   map[string]string
+		want   string // substring expected in the surfaced error
+	}{
+		{"Unauthorized", http.StatusUnauthorized, map[string]string{"error": "unauthorized"}, "authenticated"},
+		{"NotFound", http.StatusNotFound, map[string]string{"error": "user not found"}, "not found"},
+		{"InternalServerError", http.StatusInternalServerError, map[string]string{"error": "boom"}, "boom"},
+	}
+
+	// Each invocation pairs a command with the arguments + per-test setup
+	// needed to reach the API call. Run helpers return the error from RunE.
+	invocations := []struct {
+		name string
+		run  func(t *testing.T) error
+	}{
+		{
+			name: "userList",
+			run: func(t *testing.T) error {
+				return userListCmd.RunE(userListCmd, []string{})
+			},
+		},
+		{
+			name: "userDelete",
+			run: func(t *testing.T) error {
+				require.NoError(t, userDeleteCmd.Flags().Set("yes", "true"))
+				t.Cleanup(func() { resetFlag(t, userDeleteCmd.Flags(), "yes", "false") })
+				return userDeleteCmd.RunE(userDeleteCmd, []string{"u1"})
+			},
+		},
+		{
+			name: "userDisable",
+			run: func(t *testing.T) error {
+				return userDisableCmd.RunE(userDisableCmd, []string{"u1"})
+			},
+		},
+		{
+			name: "userEnable",
+			run: func(t *testing.T) error {
+				return userEnableCmd.RunE(userEnableCmd, []string{"u1"})
+			},
+		},
+		{
+			name: "userResetPassword",
+			run: func(t *testing.T) error {
+				require.NoError(t, userResetPasswordCmd.Flags().Set("password-stdin", "true"))
+				t.Cleanup(func() { resetFlag(t, userResetPasswordCmd.Flags(), "password-stdin", "false") })
+				userResetPasswordCmd.SetIn(strings.NewReader("new-password-strong-enough\n"))
+				t.Cleanup(func() { userResetPasswordCmd.SetIn(nil) })
+				return userResetPasswordCmd.RunE(userResetPasswordCmd, []string{"u1"})
+			},
+		},
+		{
+			name: "authRegister",
+			run: func(t *testing.T) error {
+				require.NoError(t, authRegisterCmd.Flags().Set("username", "alice"))
+				require.NoError(t, authRegisterCmd.Flags().Set("password-stdin", "true"))
+				t.Cleanup(func() {
+					resetFlag(t, authRegisterCmd.Flags(), "username", "")
+					resetFlag(t, authRegisterCmd.Flags(), "password-stdin", "false")
+				})
+				authRegisterCmd.SetIn(strings.NewReader("strongpass!\n"))
+				t.Cleanup(func() { authRegisterCmd.SetIn(nil) })
+				return authRegisterCmd.RunE(authRegisterCmd, []string{})
+			},
+		},
+	}
+
+	for _, inv := range invocations {
+		for _, tc := range cases {
+			name := inv.name + "_" + tc.name
+			t.Run(name, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(tc.status)
+					_ = json.NewEncoder(w).Encode(tc.body)
+				}))
+				defer server.Close()
+
+				_ = setupStackTestCmd(t, server.URL)
+				err := inv.run(t)
+				require.Error(t, err, "%s: expected non-nil error for status %d", name, tc.status)
+				assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tc.want),
+					"%s: error %q should contain %q", name, err.Error(), tc.want)
+			})
+		}
+	}
+}

--- a/cli/cmd/user_test.go
+++ b/cli/cmd/user_test.go
@@ -415,97 +415,140 @@ func TestAuthRegisterCmd_QuietOutput(t *testing.T) {
 //
 // Every new user/auth command must surface the documented APIError statuses
 // (401/404/500) as a non-nil error from RunE so the cobra harness exits
-// non-zero. The cases below are genuinely homogeneous — same setup, same
-// assertion shape, only the command and status differ — so table-driven is
-// the right fit per tests.instructions.md.
+// non-zero. Each command owns its own test function so the per-command
+// flag/stdin plumbing stays linear (per tests.instructions.md), and they all
+// reuse the same homogeneous matrix of (status, expected-error-substring).
 
-func TestUserAuthCmd_APIErrorMatrix(t *testing.T) {
-	cases := []struct {
-		name   string
-		status int
-		body   map[string]string
-		want   string // substring expected in the surfaced error
-	}{
-		{"Unauthorized", http.StatusUnauthorized, map[string]string{"error": "unauthorized"}, "authenticated"},
-		{"NotFound", http.StatusNotFound, map[string]string{"error": "user not found"}, "not found"},
-		{"InternalServerError", http.StatusInternalServerError, map[string]string{"error": "boom"}, "boom"},
-	}
+// apiErrorMatrixCase is a single (status, body) the backend may emit; want
+// is a lowercased substring expected in the surfaced error.
+type apiErrorMatrixCase struct {
+	name   string
+	status int
+	body   map[string]string
+	want   string
+}
 
-	// Each invocation pairs a command with the arguments + per-test setup
-	// needed to reach the API call. Run helpers return the error from RunE.
-	invocations := []struct {
-		name string
-		run  func(t *testing.T) error
-	}{
-		{
-			name: "userList",
-			run: func(t *testing.T) error {
+var apiErrorMatrixCases = []apiErrorMatrixCase{
+	{"Unauthorized", http.StatusUnauthorized, map[string]string{"error": "unauthorized"}, "authenticated"},
+	{"NotFound", http.StatusNotFound, map[string]string{"error": "user not found"}, "not found"},
+	{"InternalServerError", http.StatusInternalServerError, map[string]string{"error": "boom"}, "boom"},
+}
+
+// startAPIErrorServer returns an httptest server that always responds with
+// the given status and body. Caller is responsible for Close().
+func startAPIErrorServer(t *testing.T, tc apiErrorMatrixCase) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(tc.status)
+		_ = json.NewEncoder(w).Encode(tc.body)
+	}))
+}
+
+// assertAPIError invokes run() and asserts the returned error surfaces the
+// expected error substring. Shared by every per-command matrix test below.
+func assertAPIError(t *testing.T, tc apiErrorMatrixCase, run func() error) {
+	t.Helper()
+	err := run()
+	require.Error(t, err, "expected non-nil error for status %d", tc.status)
+	assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tc.want),
+		"error %q should contain %q", err.Error(), tc.want)
+}
+
+func TestUserListCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			assertAPIError(t, tc, func() error {
 				return userListCmd.RunE(userListCmd, []string{})
-			},
-		},
-		{
-			name: "userDelete",
-			run: func(t *testing.T) error {
-				require.NoError(t, userDeleteCmd.Flags().Set("yes", "true"))
-				t.Cleanup(func() { resetFlag(t, userDeleteCmd.Flags(), "yes", "false") })
-				return userDeleteCmd.RunE(userDeleteCmd, []string{"u1"})
-			},
-		},
-		{
-			name: "userDisable",
-			run: func(t *testing.T) error {
-				return userDisableCmd.RunE(userDisableCmd, []string{"u1"})
-			},
-		},
-		{
-			name: "userEnable",
-			run: func(t *testing.T) error {
-				return userEnableCmd.RunE(userEnableCmd, []string{"u1"})
-			},
-		},
-		{
-			name: "userResetPassword",
-			run: func(t *testing.T) error {
-				require.NoError(t, userResetPasswordCmd.Flags().Set("password-stdin", "true"))
-				t.Cleanup(func() { resetFlag(t, userResetPasswordCmd.Flags(), "password-stdin", "false") })
-				userResetPasswordCmd.SetIn(strings.NewReader("new-password-strong-enough\n"))
-				t.Cleanup(func() { userResetPasswordCmd.SetIn(nil) })
-				return userResetPasswordCmd.RunE(userResetPasswordCmd, []string{"u1"})
-			},
-		},
-		{
-			name: "authRegister",
-			run: func(t *testing.T) error {
-				require.NoError(t, authRegisterCmd.Flags().Set("username", "alice"))
-				require.NoError(t, authRegisterCmd.Flags().Set("password-stdin", "true"))
-				t.Cleanup(func() {
-					resetFlag(t, authRegisterCmd.Flags(), "username", "")
-					resetFlag(t, authRegisterCmd.Flags(), "password-stdin", "false")
-				})
-				authRegisterCmd.SetIn(strings.NewReader("strongpass!\n"))
-				t.Cleanup(func() { authRegisterCmd.SetIn(nil) })
-				return authRegisterCmd.RunE(authRegisterCmd, []string{})
-			},
-		},
-	}
-
-	for _, inv := range invocations {
-		for _, tc := range cases {
-			name := inv.name + "_" + tc.name
-			t.Run(name, func(t *testing.T) {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(tc.status)
-					_ = json.NewEncoder(w).Encode(tc.body)
-				}))
-				defer server.Close()
-
-				_ = setupStackTestCmd(t, server.URL)
-				err := inv.run(t)
-				require.Error(t, err, "%s: expected non-nil error for status %d", name, tc.status)
-				assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tc.want),
-					"%s: error %q should contain %q", name, err.Error(), tc.want)
 			})
-		}
+		})
+	}
+}
+
+func TestUserDeleteCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			require.NoError(t, userDeleteCmd.Flags().Set("yes", "true"))
+			t.Cleanup(func() { resetFlag(t, userDeleteCmd.Flags(), "yes", "false") })
+			assertAPIError(t, tc, func() error {
+				return userDeleteCmd.RunE(userDeleteCmd, []string{"u1"})
+			})
+		})
+	}
+}
+
+func TestUserDisableCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			assertAPIError(t, tc, func() error {
+				return userDisableCmd.RunE(userDisableCmd, []string{"u1"})
+			})
+		})
+	}
+}
+
+func TestUserEnableCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			assertAPIError(t, tc, func() error {
+				return userEnableCmd.RunE(userEnableCmd, []string{"u1"})
+			})
+		})
+	}
+}
+
+func TestUserResetPasswordCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			require.NoError(t, userResetPasswordCmd.Flags().Set("password-stdin", "true"))
+			t.Cleanup(func() { resetFlag(t, userResetPasswordCmd.Flags(), "password-stdin", "false") })
+			userResetPasswordCmd.SetIn(strings.NewReader("new-password-strong-enough\n"))
+			t.Cleanup(func() { userResetPasswordCmd.SetIn(nil) })
+			assertAPIError(t, tc, func() error {
+				return userResetPasswordCmd.RunE(userResetPasswordCmd, []string{"u1"})
+			})
+		})
+	}
+}
+
+func TestAuthRegisterCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			require.NoError(t, authRegisterCmd.Flags().Set("username", "alice"))
+			require.NoError(t, authRegisterCmd.Flags().Set("password-stdin", "true"))
+			t.Cleanup(func() {
+				resetFlag(t, authRegisterCmd.Flags(), "username", "")
+				resetFlag(t, authRegisterCmd.Flags(), "password-stdin", "false")
+			})
+			authRegisterCmd.SetIn(strings.NewReader("strongpass!\n"))
+			t.Cleanup(func() { authRegisterCmd.SetIn(nil) })
+			assertAPIError(t, tc, func() error {
+				return authRegisterCmd.RunE(authRegisterCmd, []string{})
+			})
+		})
 	}
 }

--- a/cli/cmd/user_test.go
+++ b/cli/cmd/user_test.go
@@ -1,0 +1,412 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// Tests in this file are NOT parallelized because they mutate package-level
+// globals (cfg, printer, flagAPIURL) via setupStackTestCmd. Do not add t.Parallel().
+
+func sampleUsers() []types.User {
+	return []types.User{
+		{
+			Base:     types.Base{ID: "u1"},
+			Username: "alice",
+			Role:     "admin",
+			Email:    "alice@example.com",
+		},
+		{
+			Base:           types.Base{ID: "u2"},
+			Username:       "svc-ci",
+			Role:           "user",
+			ServiceAccount: true,
+			AuthProvider:   "local",
+		},
+	}
+}
+
+// ---------- user list ----------
+
+func TestUserListCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/users", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(sampleUsers()))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	require.NoError(t, userListCmd.RunE(userListCmd, []string{}))
+	out := buf.String()
+	assert.Contains(t, out, "USERNAME")
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "svc-ci")
+	assert.Contains(t, out, "admin")
+}
+
+func TestUserListCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(sampleUsers()))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	require.NoError(t, userListCmd.RunE(userListCmd, []string{}))
+
+	var got []types.User
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+	assert.Equal(t, "alice", got[0].Username)
+}
+
+func TestUserListCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(sampleUsers()))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	require.NoError(t, userListCmd.RunE(userListCmd, []string{}))
+
+	var got []types.User
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestUserListCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(sampleUsers()))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	require.NoError(t, userListCmd.RunE(userListCmd, []string{}))
+	assert.Equal(t, "u1\nu2\n", buf.String(), "quiet mode must emit one user ID per line")
+}
+
+func TestUserListCmd_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode([]types.User{}))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, userListCmd.RunE(userListCmd, []string{}))
+	assert.Contains(t, buf.String(), "No users found")
+}
+
+func TestUserListCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "admin role required"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := userListCmd.RunE(userListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "admin role required")
+}
+
+// ---------- user delete ----------
+
+func TestUserDeleteCmd_WithYesFlag(t *testing.T) {
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/api/v1/users/u1", r.URL.Path)
+		deleted = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, userDeleteCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { resetFlag(t, userDeleteCmd.Flags(), "yes", "false") })
+
+	require.NoError(t, userDeleteCmd.RunE(userDeleteCmd, []string{"u1"}))
+	assert.True(t, deleted)
+	assert.Contains(t, buf.String(), "Deleted user u1")
+}
+
+func TestUserDeleteCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, userDeleteCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { resetFlag(t, userDeleteCmd.Flags(), "yes", "false") })
+
+	require.NoError(t, userDeleteCmd.RunE(userDeleteCmd, []string{"u1"}))
+	assert.Equal(t, "u1\n", buf.String())
+}
+
+func TestUserDeleteCmd_SelfDeleteRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Cannot delete your own account"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, userDeleteCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { resetFlag(t, userDeleteCmd.Flags(), "yes", "false") })
+
+	err := userDeleteCmd.RunE(userDeleteCmd, []string{"self-id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot delete your own account")
+}
+
+// ---------- user disable / enable ----------
+
+func TestUserDisableCmd_HappyPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		require.Equal(t, "/api/v1/users/u1/disable", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "User disabled successfully"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, userDisableCmd.RunE(userDisableCmd, []string{"u1"}))
+	assert.Contains(t, buf.String(), "Disabled user u1")
+}
+
+func TestUserEnableCmd_HappyPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		require.Equal(t, "/api/v1/users/u1/enable", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "User enabled successfully"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, userEnableCmd.RunE(userEnableCmd, []string{"u1"}))
+	assert.Contains(t, buf.String(), "Enabled user u1")
+}
+
+func TestUserDisableCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "ok"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, userDisableCmd.RunE(userDisableCmd, []string{"u1"}))
+	assert.Equal(t, "u1\n", buf.String())
+}
+
+func TestUserDisableCmd_SelfDisableRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Cannot change your own account status"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := userDisableCmd.RunE(userDisableCmd, []string{"self-id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot change your own account status")
+}
+
+// ---------- user reset-password ----------
+
+func TestUserResetPasswordCmd_FromStdin(t *testing.T) {
+	var capturedBody types.ResetPasswordRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		require.Equal(t, "/api/v1/users/u1/password", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "ok"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, userResetPasswordCmd.Flags().Set("password-stdin", "true"))
+	t.Cleanup(func() { resetFlag(t, userResetPasswordCmd.Flags(), "password-stdin", "false") })
+
+	userResetPasswordCmd.SetIn(strings.NewReader("new-password-strong-enough\n"))
+	t.Cleanup(func() { userResetPasswordCmd.SetIn(nil) })
+
+	require.NoError(t, userResetPasswordCmd.RunE(userResetPasswordCmd, []string{"u1"}))
+	assert.Equal(t, "new-password-strong-enough", capturedBody.Password)
+	assert.Contains(t, buf.String(), "Reset password for user u1")
+}
+
+func TestUserResetPasswordCmd_TooShort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("backend must NOT be called when password is too short: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, userResetPasswordCmd.Flags().Set("password-stdin", "true"))
+	t.Cleanup(func() { resetFlag(t, userResetPasswordCmd.Flags(), "password-stdin", "false") })
+
+	userResetPasswordCmd.SetIn(strings.NewReader("short\n"))
+	t.Cleanup(func() { userResetPasswordCmd.SetIn(nil) })
+
+	err := userResetPasswordCmd.RunE(userResetPasswordCmd, []string{"u1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 8")
+}
+
+func TestUserResetPasswordCmd_NonLocalRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Cannot reset password for non-local user"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, userResetPasswordCmd.Flags().Set("password-stdin", "true"))
+	t.Cleanup(func() { resetFlag(t, userResetPasswordCmd.Flags(), "password-stdin", "false") })
+
+	userResetPasswordCmd.SetIn(strings.NewReader("new-password-strong-enough\n"))
+	t.Cleanup(func() { userResetPasswordCmd.SetIn(nil) })
+
+	err := userResetPasswordCmd.RunE(userResetPasswordCmd, []string{"u1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-local")
+}
+
+// ---------- auth register ----------
+
+func TestAuthRegisterCmd_HappyPath(t *testing.T) {
+	var captured types.RegisterRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/auth/register", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.User{
+			Base: types.Base{ID: "new-id"}, Username: captured.Username,
+			DisplayName: captured.DisplayName, Role: "user", AuthProvider: "local",
+		})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, authRegisterCmd.Flags().Set("username", "alice"))
+	require.NoError(t, authRegisterCmd.Flags().Set("display-name", "Alice"))
+	require.NoError(t, authRegisterCmd.Flags().Set("password-stdin", "true"))
+	t.Cleanup(func() {
+		resetFlag(t, authRegisterCmd.Flags(), "username", "")
+		resetFlag(t, authRegisterCmd.Flags(), "display-name", "")
+		resetFlag(t, authRegisterCmd.Flags(), "password-stdin", "false")
+	})
+
+	authRegisterCmd.SetIn(strings.NewReader("strongpass!\n"))
+	t.Cleanup(func() { authRegisterCmd.SetIn(nil) })
+
+	require.NoError(t, authRegisterCmd.RunE(authRegisterCmd, []string{}))
+	assert.Equal(t, "alice", captured.Username)
+	assert.Equal(t, "strongpass!", captured.Password)
+	assert.Equal(t, "Alice", captured.DisplayName)
+	assert.Contains(t, buf.String(), "alice")
+}
+
+func TestAuthRegisterCmd_ShortPasswordRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server must NOT be called when password is too short")
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, authRegisterCmd.Flags().Set("username", "alice"))
+	require.NoError(t, authRegisterCmd.Flags().Set("password-stdin", "true"))
+	t.Cleanup(func() {
+		resetFlag(t, authRegisterCmd.Flags(), "username", "")
+		resetFlag(t, authRegisterCmd.Flags(), "password-stdin", "false")
+	})
+
+	authRegisterCmd.SetIn(strings.NewReader("short\n"))
+	t.Cleanup(func() { authRegisterCmd.SetIn(nil) })
+
+	err := authRegisterCmd.RunE(authRegisterCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 8")
+}
+
+func TestAuthRegisterCmd_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "Registration is disabled"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, authRegisterCmd.Flags().Set("username", "alice"))
+	require.NoError(t, authRegisterCmd.Flags().Set("password-stdin", "true"))
+	t.Cleanup(func() {
+		resetFlag(t, authRegisterCmd.Flags(), "username", "")
+		resetFlag(t, authRegisterCmd.Flags(), "password-stdin", "false")
+	})
+
+	authRegisterCmd.SetIn(strings.NewReader("strongpass!\n"))
+	t.Cleanup(func() { authRegisterCmd.SetIn(nil) })
+
+	err := authRegisterCmd.RunE(authRegisterCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "registration is disabled")
+}
+
+func TestAuthRegisterCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: "new-id"}, Username: "alice"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, authRegisterCmd.Flags().Set("username", "alice"))
+	require.NoError(t, authRegisterCmd.Flags().Set("password-stdin", "true"))
+	t.Cleanup(func() {
+		resetFlag(t, authRegisterCmd.Flags(), "username", "")
+		resetFlag(t, authRegisterCmd.Flags(), "password-stdin", "false")
+	})
+
+	authRegisterCmd.SetIn(strings.NewReader("strongpass!\n"))
+	t.Cleanup(func() { authRegisterCmd.SetIn(nil) })
+
+	require.NoError(t, authRegisterCmd.RunE(authRegisterCmd, []string{}))
+	assert.Equal(t, "new-id\n", buf.String())
+}

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1270,3 +1270,61 @@ func (c *Client) RunCleanupPolicy(id string, dryRun bool) ([]types.CleanupResult
 	}
 	return results, nil
 }
+
+// Register creates a new user account. Requires an authenticated caller —
+// the backend rejects with 403 when self-registration is disabled and the
+// caller is not an admin. The Role and ServiceAccount fields on the request
+// are silently overridden by the server unless the caller is admin.
+//
+// @see POST /api/v1/auth/register
+func (c *Client) Register(req *types.RegisterRequest) (*types.User, error) {
+	var user types.User
+	if err := c.Post("/api/v1/auth/register", req, &user); err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+// ListUsers returns every user account on the server. Admin-only.
+//
+// @see GET /api/v1/users
+func (c *Client) ListUsers() ([]types.User, error) {
+	var users []types.User
+	if err := c.Get("/api/v1/users", &users); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// DeleteUser permanently removes a user account by ID. Admin-only. The
+// backend rejects with 400 when the caller tries to delete its own account.
+//
+// @see DELETE /api/v1/users/:id
+func (c *Client) DeleteUser(id string) error {
+	return c.Delete(fmt.Sprintf("/api/v1/users/%s", id))
+}
+
+// DisableUser marks a user account as disabled. All active sessions and API
+// keys are revoked server-side. Admin-only. The backend rejects with 400
+// when the caller tries to disable its own account.
+//
+// @see PUT /api/v1/users/:id/disable
+func (c *Client) DisableUser(id string) error {
+	return c.Put(fmt.Sprintf("/api/v1/users/%s/disable", id), nil, nil)
+}
+
+// EnableUser re-enables a previously disabled user account. Admin-only.
+//
+// @see PUT /api/v1/users/:id/enable
+func (c *Client) EnableUser(id string) error {
+	return c.Put(fmt.Sprintf("/api/v1/users/%s/enable", id), nil, nil)
+}
+
+// ResetUserPassword sets a new password for a local user account. Admin-only.
+// The backend rejects with 400 for passwords shorter than 8 characters and
+// for users with a non-local AuthProvider.
+//
+// @see PUT /api/v1/users/:id/password
+func (c *Client) ResetUserPassword(id, password string) error {
+	return c.Put(fmt.Sprintf("/api/v1/users/%s/password", id), &types.ResetPasswordRequest{Password: password}, nil)
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -2751,6 +2752,56 @@ func TestResetUserPassword_NonLocalRejected(t *testing.T) {
 	var apiErr *APIError
 	require.ErrorAs(t, err, &apiErr)
 	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+}
+
+// TestUserAuthClient_APIErrorMatrix asserts every new user/auth client
+// method surfaces 401/404/500 as a *APIError with the right StatusCode.
+// Genuinely homogeneous error-mapping cases — table-driven is the right
+// fit per tests.instructions.md.
+func TestUserAuthClient_APIErrorMatrix(t *testing.T) {
+	t.Parallel()
+	statuses := []int{http.StatusUnauthorized, http.StatusNotFound, http.StatusInternalServerError}
+	calls := []struct {
+		name string
+		call func(c *Client) error
+	}{
+		{"Register", func(c *Client) error {
+			_, err := c.Register(&types.RegisterRequest{Username: "x", Password: "strongpass!"})
+			return err
+		}},
+		{"ListUsers", func(c *Client) error {
+			_, err := c.ListUsers()
+			return err
+		}},
+		{"DeleteUser", func(c *Client) error { return c.DeleteUser("u1") }},
+		{"DisableUser", func(c *Client) error { return c.DisableUser("u1") }},
+		{"EnableUser", func(c *Client) error { return c.EnableUser("u1") }},
+		{"ResetUserPassword", func(c *Client) error { return c.ResetUserPassword("u1", "strongpass!") }},
+	}
+
+	for _, call := range calls {
+		call := call
+		for _, status := range statuses {
+			status := status
+			name := fmt.Sprintf("%s_%d", call.name, status)
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(status)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "x"})
+				}))
+				defer server.Close()
+
+				c := New(server.URL)
+				err := call.call(c)
+				require.Error(t, err, "%s: expected non-nil error for status %d", name, status)
+				var apiErr *APIError
+				require.ErrorAs(t, err, &apiErr, "%s: error must wrap *APIError", name)
+				assert.Equal(t, status, apiErr.StatusCode, "%s: status code mismatch", name)
+			})
+		}
+	}
 }
 
 // ---------- shared values ----------

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2581,6 +2581,178 @@ func TestDeleteCleanupPolicy_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
 }
 
+// ---------- users + auth register ----------
+
+func TestRegister_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/auth/register", r.URL.Path)
+		var got types.RegisterRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "alice", got.Username)
+		assert.Equal(t, "strongpass!", got.Password)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.User{
+			Base: types.Base{ID: "new-id"}, Username: got.Username, Role: "user",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	user, err := c.Register(&types.RegisterRequest{Username: "alice", Password: "strongpass!"})
+	require.NoError(t, err)
+	assert.Equal(t, "new-id", user.ID)
+}
+
+func TestRegister_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Registration is disabled"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	user, err := c.Register(&types.RegisterRequest{Username: "alice", Password: "strongpass!"})
+	require.Error(t, err)
+	assert.Nil(t, user)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
+func TestListUsers_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.User{
+			{Base: types.Base{ID: "u1"}, Username: "alice", Role: "admin"},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	users, err := c.ListUsers()
+	require.NoError(t, err)
+	require.Len(t, users, 1)
+	assert.Equal(t, "alice", users[0].Username)
+}
+
+func TestListUsers_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	users, err := c.ListUsers()
+	require.Error(t, err)
+	assert.Nil(t, users)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
+func TestDeleteUser_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/users/u1", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.DeleteUser("u1"))
+}
+
+func TestDeleteUser_SelfRejected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Cannot delete your own account"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.DeleteUser("self-id")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+}
+
+func TestDisableUser_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/users/u1/disable", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "ok"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.DisableUser("u1"))
+}
+
+func TestEnableUser_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/users/u1/enable", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "ok"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.EnableUser("u1"))
+}
+
+func TestResetUserPassword_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/users/u1/password", r.URL.Path)
+		var got types.ResetPasswordRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "strongpass!", got.Password)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "ok"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.ResetUserPassword("u1", "strongpass!"))
+}
+
+func TestResetUserPassword_NonLocalRejected(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Cannot reset password for non-local user"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.ResetUserPassword("u1", "strongpass!")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+}
+
 // ---------- shared values ----------
 
 func TestListSharedValues_Success(t *testing.T) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -109,13 +109,13 @@ type UpdateClusterRequest struct {
 	ImagePullSecretName *string `json:"image_pull_secret_name,omitempty" yaml:"image_pull_secret_name,omitempty"`
 }
 
-// User represents a user account.
 // User represents a user account on the server. Returned by
-// GET /api/v1/auth/me (single) and GET /api/v1/users (list, admin-only).
+// GET /api/v1/auth/me (200, single), GET /api/v1/users (200, list,
+// admin-only), and POST /api/v1/auth/register (201, single).
 //
-// Population: only returned on HTTP 200. On non-2xx the client surfaces an
-// APIError and the struct is left zero-valued by the caller. Backend never
-// serialises the password hash (json:"-" on the server side).
+// Population: only returned on a 2xx response. On non-2xx the client
+// surfaces an APIError and the struct is left zero-valued by the caller.
+// Backend never serialises the password hash (json:"-" on the server side).
 //
 // Field semantics:
 //   - AuthProvider — "local" (password) or an external IdP name (e.g. "oidc").

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -110,10 +110,56 @@ type UpdateClusterRequest struct {
 }
 
 // User represents a user account.
+// User represents a user account on the server. Returned by
+// GET /api/v1/auth/me (single) and GET /api/v1/users (list, admin-only).
+//
+// Population: only returned on HTTP 200. On non-2xx the client surfaces an
+// APIError and the struct is left zero-valued by the caller. Backend never
+// serialises the password hash (json:"-" on the server side).
+//
+// Field semantics:
+//   - AuthProvider — "local" (password) or an external IdP name (e.g. "oidc").
+//     Reset-password only applies when AuthProvider == "local".
+//   - ExternalID — set only for federated users; nil for local accounts.
+//   - Disabled — when true, all sessions and API keys for this user have
+//     been revoked and any new authentication attempt is rejected.
+//   - ServiceAccount — when true, this is a non-interactive identity used
+//     by CI/automation; only admins can create these.
 type User struct {
 	Base
-	Username string `json:"username" yaml:"username"`
-	Role     string `json:"role" yaml:"role"`
+	Username       string  `json:"username" yaml:"username"`
+	DisplayName    string  `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Email          string  `json:"email,omitempty" yaml:"email,omitempty"`
+	Role           string  `json:"role" yaml:"role"`
+	AuthProvider   string  `json:"auth_provider,omitempty" yaml:"auth_provider,omitempty"`
+	ExternalID     *string `json:"external_id,omitempty" yaml:"external_id,omitempty"`
+	Disabled       bool    `json:"disabled" yaml:"disabled"`
+	ServiceAccount bool    `json:"service_account" yaml:"service_account"`
+}
+
+// RegisterRequest is the body for POST /api/v1/auth/register.
+//
+// The endpoint requires an authenticated caller. Non-admin callers can only
+// register if self-registration is enabled server-side; admins can always
+// register and are the only callers permitted to set Role or ServiceAccount.
+//
+// Field semantics:
+//   - Username, Password — required.
+//   - DisplayName — optional; defaults to Username server-side when empty.
+//   - Role — admin-only; ignored from non-admin callers (server forces "user").
+//   - ServiceAccount — admin-only; ignored from non-admin callers.
+type RegisterRequest struct {
+	Username       string `json:"username" yaml:"username"`
+	Password       string `json:"password" yaml:"password"`
+	DisplayName    string `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Role           string `json:"role,omitempty" yaml:"role,omitempty"`
+	ServiceAccount bool   `json:"service_account,omitempty" yaml:"service_account,omitempty"`
+}
+
+// ResetPasswordRequest is the body for PUT /api/v1/users/:id/password.
+// Backend rejects passwords shorter than 8 characters.
+type ResetPasswordRequest struct {
+	Password string `json:"password" yaml:"password"`
 }
 
 // CreateStackRequest is the request body for POST /api/v1/stack-instances.

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2269,3 +2269,148 @@ func TestE2ECleanupPolicyRunDryRun(t *testing.T) {
 	assert.Contains(t, stdout, "success")
 	assert.Contains(t, stdout, "1 success")
 }
+
+// startE2EUserMockServer is an in-memory backend for the auth-register / user
+// admin e2e tests. Implements POST /api/v1/auth/register + GET /api/v1/users
+// + DELETE /:id + PUT /:id/{disable,enable}.
+func startE2EUserMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	type user struct {
+		ID             string `json:"id"`
+		Username       string `json:"username"`
+		DisplayName    string `json:"display_name,omitempty"`
+		Role           string `json:"role"`
+		AuthProvider   string `json:"auth_provider,omitempty"`
+		Disabled       bool   `json:"disabled"`
+		ServiceAccount bool   `json:"service_account"`
+	}
+	var (
+		mu     sync.Mutex
+		nextID = 1
+		users  = map[string]*user{}
+	)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v1/auth/register" && r.Method == http.MethodPost:
+			var body struct {
+				Username       string `json:"username"`
+				Password       string `json:"password"`
+				DisplayName    string `json:"display_name"`
+				Role           string `json:"role"`
+				ServiceAccount bool   `json:"service_account"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+				return
+			}
+			if body.Username == "" || body.Password == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "username and password required"})
+				return
+			}
+			mu.Lock()
+			id := fmt.Sprintf("u-%d", nextID)
+			nextID++
+			u := &user{
+				ID: id, Username: body.Username, DisplayName: body.DisplayName,
+				Role: "user", AuthProvider: "local", ServiceAccount: body.ServiceAccount,
+			}
+			users[id] = u
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(u)
+
+		case r.URL.Path == "/api/v1/users" && r.Method == http.MethodGet:
+			mu.Lock()
+			out := make([]user, 0, len(users))
+			for _, u := range users {
+				out = append(out, *u)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+
+		default:
+			trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/users/")
+			if trimmed == r.URL.Path || trimmed == "" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+				return
+			}
+			id := trimmed
+			action := ""
+			if i := strings.Index(id, "/"); i >= 0 {
+				id, action = id[:i], id[i+1:]
+			}
+			mu.Lock()
+			u, exists := users[id]
+			mu.Unlock()
+			if !exists {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "user not found"})
+				return
+			}
+
+			switch action {
+			case "":
+				if r.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				mu.Lock()
+				delete(users, id)
+				mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
+			case "disable":
+				if r.Method != http.MethodPut {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				mu.Lock()
+				u.Disabled = true
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"message": "User disabled successfully"})
+			case "enable":
+				if r.Method != http.MethodPut {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				mu.Lock()
+				u.Disabled = false
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"message": "User enabled successfully"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "unknown action: " + action})
+			}
+		}
+	}))
+}
+
+func TestE2EAuthRegisterAndUserList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EUserMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	// auth register --username alice --password-stdin
+	stdout, _, err := runStackctlWithStdin(t, dir, "strongpass!\n",
+		"auth", "register", "--username", "alice", "--password-stdin")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "alice")
+
+	// user list now contains alice
+	stdout, _, err = runStackctl(t, dir, "user", "list")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "alice")
+}

--- a/cli/test/integration/user_integration_test.go
+++ b/cli/test/integration/user_integration_test.go
@@ -1,0 +1,231 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/cmd"
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// userMockState backs the user/auth admin integration tests.
+type userMockState struct {
+	mu     sync.Mutex
+	nextID int
+	users  map[string]*types.User
+}
+
+func newUserMockState() *userMockState {
+	return &userMockState{nextID: 1, users: map[string]*types.User{}}
+}
+
+func startUserMockServer(t *testing.T, state *userMockState) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v1/auth/register" && r.Method == http.MethodPost:
+			var req types.RegisterRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+				return
+			}
+			if req.Username == "" || req.Password == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "username/password required"})
+				return
+			}
+			state.mu.Lock()
+			id := fmt.Sprintf("user-%d", state.nextID)
+			state.nextID++
+			user := &types.User{
+				Base:           types.Base{ID: id},
+				Username:       req.Username,
+				DisplayName:    req.DisplayName,
+				Role:           "user",
+				AuthProvider:   "local",
+				ServiceAccount: req.ServiceAccount,
+			}
+			if req.Role != "" {
+				user.Role = req.Role
+			}
+			state.users[id] = user
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(user)
+
+		case r.URL.Path == "/api/v1/users" && r.Method == http.MethodGet:
+			state.mu.Lock()
+			out := make([]types.User, 0, len(state.users))
+			for _, u := range state.users {
+				out = append(out, *u)
+			}
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+
+		default:
+			trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/users/")
+			if trimmed == r.URL.Path || trimmed == "" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+				return
+			}
+			id := trimmed
+			action := ""
+			if i := strings.Index(id, "/"); i >= 0 {
+				id, action = id[:i], id[i+1:]
+			}
+			state.mu.Lock()
+			user, exists := state.users[id]
+			state.mu.Unlock()
+			if !exists {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "user not found"})
+				return
+			}
+
+			switch action {
+			case "":
+				if r.Method != http.MethodDelete {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				state.mu.Lock()
+				delete(state.users, id)
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
+
+			case "disable":
+				if r.Method != http.MethodPut {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				state.mu.Lock()
+				user.Disabled = true
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"message": "User disabled successfully"})
+
+			case "enable":
+				if r.Method != http.MethodPut {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				state.mu.Lock()
+				user.Disabled = false
+				state.mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"message": "User enabled successfully"})
+
+			case "password":
+				if r.Method != http.MethodPut {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				var req types.ResetPasswordRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+					return
+				}
+				if len(req.Password) < 8 {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Password must be at least 8 characters"})
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"message": "Password reset"})
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "unknown action: " + action})
+			}
+		}
+	}))
+}
+
+func TestUserWorkflow_RegisterListDisableEnableDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := newUserMockState()
+	server := startUserMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	// register
+	user, err := c.Register(&types.RegisterRequest{Username: "alice", Password: "strongpass!"})
+	require.NoError(t, err)
+	require.NotEmpty(t, user.ID)
+
+	// list — caller sees the new user
+	users, err := c.ListUsers()
+	require.NoError(t, err)
+	require.Len(t, users, 1)
+	assert.Equal(t, "alice", users[0].Username)
+
+	// disable → enable round-trip
+	require.NoError(t, c.DisableUser(user.ID))
+	state.mu.Lock()
+	assert.True(t, state.users[user.ID].Disabled)
+	state.mu.Unlock()
+
+	require.NoError(t, c.EnableUser(user.ID))
+	state.mu.Lock()
+	assert.False(t, state.users[user.ID].Disabled)
+	state.mu.Unlock()
+
+	// reset-password
+	require.NoError(t, c.ResetUserPassword(user.ID, "newstrongpass!"))
+
+	// delete
+	require.NoError(t, c.DeleteUser(user.ID))
+	users, err = c.ListUsers()
+	require.NoError(t, err)
+	assert.Empty(t, users)
+}
+
+func TestUserCobra_AuthRegisterThenUserList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	state := newUserMockState()
+	server := startUserMockServer(t, state)
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+
+	// auth register --username alice --password-stdin
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetIn(strings.NewReader("strongpass!\n"))
+	cmd.SetArgs([]string{"auth", "register", "--username", "alice", "--password-stdin"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "alice")
+
+	// user list — should now include alice
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"user", "list"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "alice")
+}


### PR DESCRIPTION
## Summary

Implements the user-admin + auth-register CLI surface from epic #59 phase 4 (issue #69):

- `stackctl auth register --username --password-stdin [--display-name --role --service-account]`
- `stackctl user list`
- `stackctl user delete <id> [--yes]`
- `stackctl user disable <id>`
- `stackctl user enable <id>`
- `stackctl user reset-password <id> [--password-stdin]`

All `user-*` commands are admin-only (backend gates with `RequireAdmin` middleware). `auth register` requires an authenticated caller; non-admins are rejected unless the server has self-registration enabled. Only admin callers can set `--role` or `--service-account` (the server silently overrides them for non-admin callers).

## Design notes

- **No email field**: the issue title says `--email` but the backend `RegisterRequest` has no email field. The CLI matches the actual wire contract and documents this in the `auth register` Long text.
- **Password input**: shared `readPassword` helper. The new commands (`auth register`, `user reset-password`) error out when stdin is not a TTY and `--password-stdin` is not set — prevents silent slurping of inherited stdin in CI/cron contexts. Mirrors the `docker login --password-stdin` model. `loginCmd` intentionally keeps the older permissive behavior for backward compatibility.
- **Self-action rejection**: backend rejects self-delete/disable with HTTP 400; the CLI surfaces this via the standard APIError path with the backend message. No client-side caller-ID detection (would double the request count).
- **Nil-body PUT**: DisableUser/EnableUser send `Put(path, nil, nil)`; the client's `do()` correctly elides Content-Type when body == nil.
- **`@see` godoc**: all 6 new client methods carry HTTP-verb + route tags, matching the convention from PRs #83/#84.
- `cli/cmd/root.go` gains a `SetIn(io.Reader)` export mirroring `SetOut` so integration tests can pipe stdin to in-process `Execute()` calls.

## Tests

All three layers, all green (`go test ./... && go vet ./...` from `cli/`):

- **Unit (cmd):** 20 tests in `cli/cmd/user_test.go` — all 6 verbs × output modes, short-password rejection, non-local-user password-reset rejection, self-action 400 surfacing, 403 mapping, interactive register flow.
- **Unit (client):** 10 tests in `cli/pkg/client/client_test.go`.
- **Integration:** full client round-trip (register → list → disable → enable → reset-password → delete → list-empty) plus a Cobra-in-process exec test in `cli/test/integration/user_integration_test.go`.
- **E2E:** binary exec'd against a stub server in `cli/test/e2e/cli_e2e_test.go` — `auth register --password-stdin` then `user list`.

Independent code review found no blockers. Two small refinements applied: TTY-check tightening in `readPassword` (the "Important" finding) and `userToggle` refactored from string dispatch to function passing.

## Test plan

- [x] `go test ./... -v` passes
- [x] `go vet ./...` clean
- [x] Coverage on new code ≥80%
- [ ] Manually exercise `auth register` + `user disable` flow against a dev backend once merged

Closes #69
Tracks #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only user management: stackctl user list, delete, disable, enable, reset-password.
  * New registration: stackctl auth register.
  * Password handling: interactive or piped/file input via --password-stdin, enforces minimum length.
  * Output formats: table, JSON, YAML, and quiet mode.

* **Tests**
  * New unit, integration, and end-to-end tests covering auth/register and full user workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->