### PR TITLE
feat(apikey): list/create/revoke per user

### DIFF
--- a/cli/cmd/apikey.go
+++ b/cli/cmd/apikey.go
@@ -247,9 +247,12 @@ Examples:
 // the --user flag value when set, otherwise the caller's own user ID
 // resolved via GET /api/v1/auth/me. The latter is cached for the duration
 // of a single command invocation but not across invocations.
+//
+// When --user is set, it's run through parseID() to trim whitespace and
+// reject empty values before going into a /users/:id/... path.
 func resolveAPIKeyUserID(cmd *cobra.Command, c *client.Client) (string, error) {
 	if u, _ := cmd.Flags().GetString("user"); strings.TrimSpace(u) != "" {
-		return u, nil
+		return parseID(u)
 	}
 	me, err := c.Whoami()
 	if err != nil {

--- a/cli/cmd/apikey.go
+++ b/cli/cmd/apikey.go
@@ -244,14 +244,17 @@ Examples:
 }
 
 // resolveAPIKeyUserID returns the user ID to use for the api-keys/* request:
-// the --user flag value when set, otherwise the caller's own user ID
-// resolved via GET /api/v1/auth/me. The latter is cached for the duration
-// of a single command invocation but not across invocations.
+// the --user flag value when explicitly set, otherwise the caller's own
+// user ID resolved via GET /api/v1/auth/me. The latter is cached for the
+// duration of a single command invocation but not across invocations.
 //
-// When --user is set, it's run through parseID() to trim whitespace and
-// reject empty values before going into a /users/:id/... path.
+// "Explicitly set" is detected with cmd.Flags().Changed("user"); passing
+// --user with a whitespace-only value (e.g. --user "   ") routes through
+// parseID() which returns a clear empty-ID error rather than silently
+// falling back to /auth/me.
 func resolveAPIKeyUserID(cmd *cobra.Command, c *client.Client) (string, error) {
-	if u, _ := cmd.Flags().GetString("user"); strings.TrimSpace(u) != "" {
+	if cmd.Flags().Changed("user") {
+		u, _ := cmd.Flags().GetString("user")
 		return parseID(u)
 	}
 	me, err := c.Whoami()

--- a/cli/cmd/apikey.go
+++ b/cli/cmd/apikey.go
@@ -1,0 +1,281 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+var apikeyCmd = &cobra.Command{
+	Use:   "apikey",
+	Short: "Manage user API keys",
+	Long: `Manage API keys used for non-interactive (CI / service account)
+authentication against the stack manager API.
+
+By default every subcommand operates on the caller's own API keys. Admins can
+manage any user's keys by passing --user <id>. The backend gates non-admin
+callers to their own user-id; --user pointing at another user returns 403.
+
+Created keys are returned ONCE in plaintext and cannot be retrieved again —
+treat the create-step output as a secret. The CLI never writes the raw key
+to config or debug logs.`,
+}
+
+var apikeyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List API keys for the current user (or --user)",
+	Long: `List API keys configured for the caller (default) or for another
+user when --user is supplied.
+
+The raw key value is NEVER returned by this endpoint — only the prefix
+(first 16 chars) is shown for visual identification, plus name, creation
+time, last-used time, and expiry.
+
+Examples:
+  stackctl apikey list
+  stackctl apikey list --user <uuid>
+  stackctl apikey list -o json`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		userID, err := resolveAPIKeyUserID(cmd, c)
+		if err != nil {
+			return err
+		}
+		keys, err := c.ListAPIKeys(userID)
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, k := range keys {
+				fmt.Fprintln(printer.Writer, k.ID)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(keys)
+		case output.FormatYAML:
+			return printer.PrintYAML(keys)
+		default:
+			if len(keys) == 0 {
+				printer.PrintMessage("No API keys configured for user %s.", userID)
+				return nil
+			}
+			headers := []string{"ID", "NAME", "PREFIX", "CREATED", "LAST USED", "EXPIRES"}
+			rows := make([][]string, len(keys))
+			for i, k := range keys {
+				rows[i] = []string{
+					k.ID,
+					k.Name,
+					k.Prefix,
+					k.CreatedAt.Format("2006-01-02"),
+					formatTime(k.LastUsedAt),
+					formatTime(k.ExpiresAt),
+				}
+			}
+			return printer.PrintTable(headers, rows)
+		}
+	},
+}
+
+var apikeyCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new API key (returned once, in plaintext)",
+	Long: `Create a new API key for the caller (default) or for --user.
+
+The backend REQUIRES an expiry — pass exactly one of --expires-at
+(YYYY-MM-DD or RFC3339) or --expires-in-days (positive integer). Passing
+both returns 400. The expiry must be strictly in the future and may be
+capped by the server's API_KEY_MAX_LIFETIME_DAYS setting.
+
+The raw key is returned ONCE in the response and CANNOT be retrieved again.
+In quiet mode the command prints only the raw key on stdout (one line),
+making it pipeable into a token file for CI/service-account bootstrap:
+
+  stackctl apikey create --name ci --expires-in-days 365 --quiet > /run/secrets/stackctl-token
+
+Default and JSON/YAML modes print the full response including ID, name,
+prefix, created/expires timestamps, and the raw key — store the raw key
+immediately.
+
+Examples:
+  stackctl apikey create --name ci --expires-in-days 365
+  stackctl apikey create --name release --expires-at 2027-01-01
+  stackctl apikey create --name svc-ci --user <uuid> --expires-in-days 90 --quiet`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name, _ := cmd.Flags().GetString("name")
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("--name is required")
+		}
+		expiresAt, _ := cmd.Flags().GetString("expires-at")
+		expiresInDays, _ := cmd.Flags().GetInt("expires-in-days")
+		expiresAtChanged := cmd.Flags().Changed("expires-at")
+		expiresInDaysChanged := cmd.Flags().Changed("expires-in-days")
+
+		if !expiresAtChanged && !expiresInDaysChanged {
+			return fmt.Errorf("an expiry is required: pass --expires-at <YYYY-MM-DD|RFC3339> or --expires-in-days <int>")
+		}
+		if expiresAtChanged && expiresInDaysChanged {
+			return fmt.Errorf("--expires-at and --expires-in-days are mutually exclusive; pass exactly one")
+		}
+
+		req := types.CreateAPIKeyRequest{Name: name}
+		if expiresAtChanged {
+			s := strings.TrimSpace(expiresAt)
+			if s == "" {
+				return fmt.Errorf("--expires-at must not be empty")
+			}
+			req.ExpiresAt = &s
+		}
+		if expiresInDaysChanged {
+			if expiresInDays <= 0 {
+				return fmt.Errorf("--expires-in-days must be a positive integer")
+			}
+			d := expiresInDays
+			req.ExpiresInDays = &d
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		userID, err := resolveAPIKeyUserID(cmd, c)
+		if err != nil {
+			return err
+		}
+
+		resp, err := c.CreateAPIKey(userID, &req)
+		if err != nil {
+			return err
+		}
+
+		// Quiet mode is the script-bootstrap path: ONLY the raw key on stdout,
+		// nothing else, no trailing whitespace beyond the single newline that
+		// Fprintln adds. This is the documented contract for piping into a
+		// token file.
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, resp.RawKey)
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(resp)
+		case output.FormatYAML:
+			return printer.PrintYAML(resp)
+		default:
+			return printer.PrintSingle(resp, []output.KeyValue{
+				{Key: "ID", Value: resp.ID},
+				{Key: "Name", Value: resp.Name},
+				{Key: "Prefix", Value: resp.Prefix},
+				{Key: "Created", Value: resp.CreatedAt.Format("2006-01-02T15:04:05Z07:00")},
+				{Key: "Expires", Value: formatTime(resp.ExpiresAt)},
+				{Key: "Raw Key (store now — non-retrievable)", Value: resp.RawKey},
+			})
+		}
+	},
+}
+
+var apikeyRevokeCmd = &cobra.Command{
+	Use:   "revoke <key-id>",
+	Short: "Revoke an API key by ID",
+	Long: `Revoke (delete) an API key. The key stops authenticating new
+requests immediately.
+
+This is a destructive operation. You will be prompted for confirmation
+unless --yes is specified.
+
+Examples:
+  stackctl apikey revoke <key-uuid>
+  stackctl apikey revoke <key-uuid> --yes
+  stackctl apikey revoke <key-uuid> --user <user-uuid> --yes`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		keyID, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+
+		if isDryRun(cmd, "Would revoke API key %s", keyID) {
+			return nil
+		}
+
+		confirmed, err := confirmAction(cmd, fmt.Sprintf("This will revoke API key %s. Continue? (y/n): ", keyID))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			printer.PrintMessage("Aborted.")
+			return nil
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		userID, err := resolveAPIKeyUserID(cmd, c)
+		if err != nil {
+			return err
+		}
+
+		if err := c.DeleteAPIKey(userID, keyID); err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, keyID)
+			return nil
+		}
+		printer.PrintMessage("Revoked API key %s", keyID)
+		return nil
+	},
+}
+
+// resolveAPIKeyUserID returns the user ID to use for the api-keys/* request:
+// the --user flag value when set, otherwise the caller's own user ID
+// resolved via GET /api/v1/auth/me. The latter is cached for the duration
+// of a single command invocation but not across invocations.
+func resolveAPIKeyUserID(cmd *cobra.Command, c *client.Client) (string, error) {
+	if u, _ := cmd.Flags().GetString("user"); strings.TrimSpace(u) != "" {
+		return u, nil
+	}
+	me, err := c.Whoami()
+	if err != nil {
+		return "", fmt.Errorf("resolving caller user ID via /auth/me: %w", err)
+	}
+	if me.ID == "" {
+		return "", fmt.Errorf("server returned empty user ID from /auth/me")
+	}
+	return me.ID, nil
+}
+
+func init() {
+	apikeyListCmd.Flags().String("user", "", "Target user ID (defaults to the caller's own user via /auth/me)")
+
+	apikeyCreateCmd.Flags().String("name", "", "Human-readable name for the new key (required)")
+	apikeyCreateCmd.Flags().String("user", "", "Target user ID (defaults to the caller's own user via /auth/me)")
+	apikeyCreateCmd.Flags().String("expires-at", "", "Expiry as YYYY-MM-DD or RFC3339 (mutually exclusive with --expires-in-days)")
+	apikeyCreateCmd.Flags().Int("expires-in-days", 0, "Expiry in days from now (mutually exclusive with --expires-at)")
+	_ = apikeyCreateCmd.MarkFlagRequired("name")
+
+	apikeyRevokeCmd.Flags().String("user", "", "Target user ID (defaults to the caller's own user via /auth/me)")
+	apikeyRevokeCmd.Flags().BoolP("yes", "y", false, flagDescSkipConfirm)
+	apikeyRevokeCmd.Flags().Bool("dry-run", false, "Show what would happen without executing")
+
+	apikeyCmd.AddCommand(apikeyListCmd)
+	apikeyCmd.AddCommand(apikeyCreateCmd)
+	apikeyCmd.AddCommand(apikeyRevokeCmd)
+	rootCmd.AddCommand(apikeyCmd)
+}

--- a/cli/cmd/apikey_test.go
+++ b/cli/cmd/apikey_test.go
@@ -269,6 +269,36 @@ func TestAPIKeyCreateCmd_JSONIncludesRawKey(t *testing.T) {
 	assert.Equal(t, "sk_json", got.RawKey)
 }
 
+func TestAPIKeyCreateCmd_YAMLIncludesRawKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me":
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}})
+		case strings.Contains(r.URL.Path, "/api-keys") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{ID: "id", Name: "ci", RawKey: "sk_yaml"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-in-days", "30"))
+	t.Cleanup(func() {
+		resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-in-days", "0")
+	})
+
+	require.NoError(t, apikeyCreateCmd.RunE(apikeyCreateCmd, []string{}))
+	var got types.CreateAPIKeyResponse
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "sk_yaml", got.RawKey)
+}
+
 func TestAPIKeyCreateCmd_RequiresExpiry(t *testing.T) {
 	// Backend must NOT be called when no expiry is provided.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/cmd/apikey_test.go
+++ b/cli/cmd/apikey_test.go
@@ -1,0 +1,474 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// Tests in this file are NOT parallelized because they mutate package-level
+// globals (cfg, printer, flagAPIURL) via setupStackTestCmd. Do not add t.Parallel().
+
+const callerID = "me-uuid"
+
+func sampleAPIKeys() []types.APIKey {
+	created := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	exp := time.Date(2027, 5, 1, 23, 59, 59, 0, time.UTC)
+	return []types.APIKey{
+		{ID: "k1", UserID: callerID, Name: "ci", Prefix: "0123456789abcdef", CreatedAt: created, ExpiresAt: &exp},
+		{ID: "k2", UserID: callerID, Name: "release", Prefix: "fedcba9876543210", CreatedAt: created, ExpiresAt: &exp},
+	}
+}
+
+// startAPIKeyServer returns a mock that handles /auth/me + the api-keys
+// surface for the test-supplied userID. The user can override individual
+// handlers by passing a non-nil override.
+func startAPIKeyServer(t *testing.T, list []types.APIKey, override func(w http.ResponseWriter, r *http.Request) bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if override != nil && override(w, r) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}, Username: "me", Role: "user"})
+		case r.URL.Path == "/api/v1/users/"+callerID+"/api-keys" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(list)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		}
+	}))
+}
+
+// ---------- apikey list ----------
+
+func TestAPIKeyListCmd_TableOutput(t *testing.T) {
+	server := startAPIKeyServer(t, sampleAPIKeys(), nil)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+
+	require.NoError(t, apikeyListCmd.RunE(apikeyListCmd, []string{}))
+	out := buf.String()
+	assert.Contains(t, out, "PREFIX")
+	assert.Contains(t, out, "ci")
+	assert.Contains(t, out, "release")
+	assert.Contains(t, out, "0123456789abcdef")
+}
+
+func TestAPIKeyListCmd_JSONOutput(t *testing.T) {
+	server := startAPIKeyServer(t, sampleAPIKeys(), nil)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+
+	require.NoError(t, apikeyListCmd.RunE(apikeyListCmd, []string{}))
+	var got []types.APIKey
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestAPIKeyListCmd_YAMLOutput(t *testing.T) {
+	server := startAPIKeyServer(t, sampleAPIKeys(), nil)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+
+	require.NoError(t, apikeyListCmd.RunE(apikeyListCmd, []string{}))
+	var got []types.APIKey
+	require.NoError(t, yaml.Unmarshal(buf.Bytes(), &got))
+	assert.Len(t, got, 2)
+}
+
+func TestAPIKeyListCmd_QuietOutput(t *testing.T) {
+	server := startAPIKeyServer(t, sampleAPIKeys(), nil)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+
+	require.NoError(t, apikeyListCmd.RunE(apikeyListCmd, []string{}))
+	assert.Equal(t, "k1\nk2\n", buf.String(), "quiet mode must emit one key ID per line")
+}
+
+func TestAPIKeyListCmd_Empty(t *testing.T) {
+	server := startAPIKeyServer(t, []types.APIKey{}, nil)
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyListCmd.RunE(apikeyListCmd, []string{}))
+	assert.Contains(t, buf.String(), "No API keys configured")
+}
+
+func TestAPIKeyListCmd_ExplicitUserFlagSkipsAuthMe(t *testing.T) {
+	authMeCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/auth/me" {
+			authMeCalled = true
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path == "/api/v1/users/other-uuid/api-keys" && r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(sampleAPIKeys())
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyListCmd.Flags().Set("user", "other-uuid"))
+	t.Cleanup(func() { resetFlag(t, apikeyListCmd.Flags(), "user", "") })
+
+	require.NoError(t, apikeyListCmd.RunE(apikeyListCmd, []string{}))
+	assert.False(t, authMeCalled, "--user must skip the /auth/me lookup")
+}
+
+// ---------- apikey create ----------
+
+func TestAPIKeyCreateCmd_ExpiresInDays(t *testing.T) {
+	var captured types.CreateAPIKeyRequest
+	created := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	exp := created.AddDate(0, 0, 90)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me":
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}})
+		case r.URL.Path == "/api/v1/users/"+callerID+"/api-keys" && r.Method == http.MethodPost:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{
+				ID: "new-id", Name: captured.Name, Prefix: "abcdef0123456789",
+				RawKey: "sk_deadbeef", CreatedAt: created, ExpiresAt: &exp,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-in-days", "90"))
+	t.Cleanup(func() {
+		resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-in-days", "0")
+	})
+
+	require.NoError(t, apikeyCreateCmd.RunE(apikeyCreateCmd, []string{}))
+	require.NotNil(t, captured.ExpiresInDays)
+	assert.Equal(t, 90, *captured.ExpiresInDays)
+	assert.Nil(t, captured.ExpiresAt, "expires-at must not be sent when only expires-in-days was provided")
+	assert.Contains(t, buf.String(), "sk_deadbeef")
+	assert.Contains(t, buf.String(), "non-retrievable")
+}
+
+func TestAPIKeyCreateCmd_ExpiresAt(t *testing.T) {
+	var captured types.CreateAPIKeyRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me":
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}})
+		case r.URL.Path == "/api/v1/users/"+callerID+"/api-keys" && r.Method == http.MethodPost:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{ID: "id", RawKey: "sk_xyz"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "release"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-at", "2027-01-01"))
+	t.Cleanup(func() {
+		resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-at", "")
+	})
+
+	require.NoError(t, apikeyCreateCmd.RunE(apikeyCreateCmd, []string{}))
+	require.NotNil(t, captured.ExpiresAt)
+	assert.Equal(t, "2027-01-01", *captured.ExpiresAt)
+	assert.Nil(t, captured.ExpiresInDays)
+}
+
+func TestAPIKeyCreateCmd_QuietPrintsOnlyRawKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me":
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}})
+		case strings.Contains(r.URL.Path, "/api-keys") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{ID: "id", RawKey: "sk_pipeable-secret"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-in-days", "30"))
+	t.Cleanup(func() {
+		resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-in-days", "0")
+	})
+
+	require.NoError(t, apikeyCreateCmd.RunE(apikeyCreateCmd, []string{}))
+	assert.Equal(t, "sk_pipeable-secret\n", buf.String(),
+		"quiet mode must emit ONLY the raw key — pipeable into a token file")
+}
+
+func TestAPIKeyCreateCmd_JSONIncludesRawKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me":
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}})
+		case strings.Contains(r.URL.Path, "/api-keys") && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{ID: "id", Name: "ci", RawKey: "sk_json"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-in-days", "30"))
+	t.Cleanup(func() {
+		resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-in-days", "0")
+	})
+
+	require.NoError(t, apikeyCreateCmd.RunE(apikeyCreateCmd, []string{}))
+	var got types.CreateAPIKeyResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "sk_json", got.RawKey)
+}
+
+func TestAPIKeyCreateCmd_RequiresExpiry(t *testing.T) {
+	// Backend must NOT be called when no expiry is provided.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/api-keys") {
+			t.Fatalf("backend must NOT be called without an expiry: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+	t.Cleanup(func() { resetFlag(t, apikeyCreateCmd.Flags(), "name", "") })
+
+	err := apikeyCreateCmd.RunE(apikeyCreateCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expiry is required")
+}
+
+func TestAPIKeyCreateCmd_MutuallyExclusiveExpiryFlags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/api-keys") {
+			t.Fatalf("backend must NOT be called when both expiry flags are set: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-at", "2027-01-01"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-in-days", "30"))
+	t.Cleanup(func() {
+		resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-at", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-in-days", "0")
+	})
+
+	err := apikeyCreateCmd.RunE(apikeyCreateCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestAPIKeyCreateCmd_NegativeDaysRejected(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://localhost:0")
+	require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+	require.NoError(t, apikeyCreateCmd.Flags().Set("expires-in-days", "-1"))
+	t.Cleanup(func() {
+		resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+		resetFlag(t, apikeyCreateCmd.Flags(), "expires-in-days", "0")
+	})
+
+	err := apikeyCreateCmd.RunE(apikeyCreateCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "positive integer")
+}
+
+// ---------- apikey revoke ----------
+
+func TestAPIKeyRevokeCmd_WithYesFlag(t *testing.T) {
+	revoked := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me":
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}})
+		case r.URL.Path == "/api/v1/users/"+callerID+"/api-keys/k1" && r.Method == http.MethodDelete:
+			revoked = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyRevokeCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { resetFlag(t, apikeyRevokeCmd.Flags(), "yes", "false") })
+
+	require.NoError(t, apikeyRevokeCmd.RunE(apikeyRevokeCmd, []string{"k1"}))
+	assert.True(t, revoked)
+	assert.Contains(t, buf.String(), "Revoked API key k1")
+}
+
+func TestAPIKeyRevokeCmd_DryRun(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, apikeyRevokeCmd.Flags().Set("dry-run", "true"))
+	t.Cleanup(func() { resetFlag(t, apikeyRevokeCmd.Flags(), "dry-run", "false") })
+
+	require.NoError(t, apikeyRevokeCmd.RunE(apikeyRevokeCmd, []string{"k1"}))
+	assert.False(t, called)
+	assert.Contains(t, buf.String(), "Would revoke")
+}
+
+func TestAPIKeyRevokeCmd_InteractiveDecline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("API must not be called when user declines")
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	apikeyRevokeCmd.SetIn(strings.NewReader("n\n"))
+	apikeyRevokeCmd.SetErr(&bytes.Buffer{})
+	t.Cleanup(func() {
+		apikeyRevokeCmd.SetIn(nil)
+		apikeyRevokeCmd.SetErr(nil)
+	})
+
+	require.NoError(t, apikeyRevokeCmd.RunE(apikeyRevokeCmd, []string{"k1"}))
+	assert.Contains(t, buf.String(), "Aborted")
+}
+
+func TestAPIKeyRevokeCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/me":
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: callerID}})
+		case strings.HasSuffix(r.URL.Path, "/api-keys/k1") && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, apikeyRevokeCmd.Flags().Set("yes", "true"))
+	t.Cleanup(func() { resetFlag(t, apikeyRevokeCmd.Flags(), "yes", "false") })
+
+	require.NoError(t, apikeyRevokeCmd.RunE(apikeyRevokeCmd, []string{"k1"}))
+	assert.Equal(t, "k1\n", buf.String())
+}
+
+// ---------- API error matrix (401/404/500) ----------
+// Reuses the helpers defined in user_test.go (apiErrorMatrixCases,
+// startAPIErrorServer, assertAPIError). Per-command tests keep the
+// flag/stdin plumbing linear, per tests.instructions.md.
+
+func TestAPIKeyListCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			// --user set so we don't depend on /auth/me; the error server
+			// returns the same status for every path.
+			require.NoError(t, apikeyListCmd.Flags().Set("user", "x"))
+			t.Cleanup(func() { resetFlag(t, apikeyListCmd.Flags(), "user", "") })
+			assertAPIError(t, tc, func() error {
+				return apikeyListCmd.RunE(apikeyListCmd, []string{})
+			})
+		})
+	}
+}
+
+func TestAPIKeyCreateCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			require.NoError(t, apikeyCreateCmd.Flags().Set("name", "ci"))
+			require.NoError(t, apikeyCreateCmd.Flags().Set("expires-in-days", "30"))
+			require.NoError(t, apikeyCreateCmd.Flags().Set("user", "x"))
+			t.Cleanup(func() {
+				resetFlag(t, apikeyCreateCmd.Flags(), "name", "")
+				resetFlag(t, apikeyCreateCmd.Flags(), "expires-in-days", "0")
+				resetFlag(t, apikeyCreateCmd.Flags(), "user", "")
+			})
+			assertAPIError(t, tc, func() error {
+				return apikeyCreateCmd.RunE(apikeyCreateCmd, []string{})
+			})
+		})
+	}
+}
+
+func TestAPIKeyRevokeCmd_APIErrorMatrix(t *testing.T) {
+	for _, tc := range apiErrorMatrixCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := startAPIErrorServer(t, tc)
+			defer server.Close()
+			_ = setupStackTestCmd(t, server.URL)
+			require.NoError(t, apikeyRevokeCmd.Flags().Set("yes", "true"))
+			require.NoError(t, apikeyRevokeCmd.Flags().Set("user", "x"))
+			t.Cleanup(func() {
+				resetFlag(t, apikeyRevokeCmd.Flags(), "yes", "false")
+				resetFlag(t, apikeyRevokeCmd.Flags(), "user", "")
+			})
+			assertAPIError(t, tc, func() error {
+				return apikeyRevokeCmd.RunE(apikeyRevokeCmd, []string{"k1"})
+			})
+		})
+	}
+}

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1328,3 +1328,44 @@ func (c *Client) EnableUser(id string) error {
 func (c *Client) ResetUserPassword(id, password string) error {
 	return c.Put(fmt.Sprintf("/api/v1/users/%s/password", id), &types.ResetPasswordRequest{Password: password}, nil)
 }
+
+// ListAPIKeys returns every API key configured for the given user. Callers
+// must be the target user OR have the admin role; the backend returns 403
+// otherwise. The raw key value is NEVER returned by this endpoint — only
+// the prefix is available for visual identification.
+//
+// @see GET /api/v1/users/:id/api-keys
+func (c *Client) ListAPIKeys(userID string) ([]types.APIKey, error) {
+	var keys []types.APIKey
+	if err := c.Get(fmt.Sprintf("/api/v1/users/%s/api-keys", userID), &keys); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+// CreateAPIKey creates a new API key for the given user. Callers must be the
+// target user OR have the admin role.
+//
+// The returned response carries the plaintext key in RawKey (prefixed with
+// "sk_") — this is the ONLY time the raw key is available and it cannot be
+// retrieved again. Callers must surface it immediately and must not persist
+// it to config files. The client's debug logging is configured to log only
+// the request line and a small set of HEADERS (with masking), never the
+// request or response body, so debug-mode runs do not leak the key.
+//
+// @see POST /api/v1/users/:id/api-keys
+func (c *Client) CreateAPIKey(userID string, req *types.CreateAPIKeyRequest) (*types.CreateAPIKeyResponse, error) {
+	var resp types.CreateAPIKeyResponse
+	if err := c.Post(fmt.Sprintf("/api/v1/users/%s/api-keys", userID), req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeleteAPIKey revokes the given API key. Callers must be the target user OR
+// have the admin role; the backend returns 403 otherwise.
+//
+// @see DELETE /api/v1/users/:id/api-keys/:keyId
+func (c *Client) DeleteAPIKey(userID, keyID string) error {
+	return c.Delete(fmt.Sprintf("/api/v1/users/%s/api-keys/%s", userID, keyID))
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -2804,6 +2804,174 @@ func TestUserAuthClient_APIErrorMatrix(t *testing.T) {
 	}
 }
 
+// ---------- api keys ----------
+
+func TestListAPIKeys_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/users/u1/api-keys", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.APIKey{
+			{ID: "k1", UserID: "u1", Name: "ci", Prefix: "0123456789abcdef"},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	keys, err := c.ListAPIKeys("u1")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "ci", keys[0].Name)
+	assert.Equal(t, "0123456789abcdef", keys[0].Prefix)
+}
+
+func TestCreateAPIKey_ReturnsRawKeyOnce(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/users/u1/api-keys", r.URL.Path)
+		var got types.CreateAPIKeyRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.Equal(t, "ci", got.Name)
+		require.NotNil(t, got.ExpiresInDays)
+		assert.Equal(t, 90, *got.ExpiresInDays)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{
+			ID:     "new-id",
+			Name:   got.Name,
+			Prefix: "abcdef0123456789",
+			RawKey: "sk_deadbeefcafebabe",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	days := 90
+	resp, err := c.CreateAPIKey("u1", &types.CreateAPIKeyRequest{Name: "ci", ExpiresInDays: &days})
+	require.NoError(t, err)
+	assert.Equal(t, "new-id", resp.ID)
+	assert.Equal(t, "sk_deadbeefcafebabe", resp.RawKey, "raw key must be surfaced on create")
+}
+
+func TestCreateAPIKey_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "Forbidden"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	days := 30
+	resp, err := c.CreateAPIKey("other-user", &types.CreateAPIKeyRequest{Name: "x", ExpiresInDays: &days})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
+func TestDeleteAPIKey_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/users/u1/api-keys/k1", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.DeleteAPIKey("u1", "k1"))
+}
+
+func TestDeleteAPIKey_NotFound(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "API key not found"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	err := c.DeleteAPIKey("u1", "missing")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusNotFound, apiErr.StatusCode)
+}
+
+// TestAPIKeyClient_DoesNotLogRawKey asserts the documented security contract:
+// the debug writer never sees the raw API key, even when the create response
+// includes it in the body. The current do() implementation logs only the
+// request line + a small set of headers (with masking), never the body.
+func TestAPIKeyClient_DoesNotLogRawKey(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{
+			ID: "id", Name: "n", Prefix: "p", RawKey: "sk_secret-should-never-leak",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	var dbg strings.Builder
+	c.Debug = true
+	c.DebugWriter = &dbg
+
+	days := 30
+	resp, err := c.CreateAPIKey("u1", &types.CreateAPIKeyRequest{Name: "n", ExpiresInDays: &days})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotContains(t, dbg.String(), "sk_secret-should-never-leak",
+		"debug log must NEVER contain the raw API key")
+	assert.NotContains(t, dbg.String(), "secret-should-never-leak",
+		"debug log must not contain any part of the raw key")
+}
+
+func TestAPIKeyClient_APIErrorMatrix(t *testing.T) {
+	t.Parallel()
+	statuses := []int{http.StatusUnauthorized, http.StatusNotFound, http.StatusInternalServerError}
+	days := 30
+	calls := []struct {
+		name string
+		call func(c *Client) error
+	}{
+		{"List", func(c *Client) error { _, err := c.ListAPIKeys("u1"); return err }},
+		{"Create", func(c *Client) error {
+			_, err := c.CreateAPIKey("u1", &types.CreateAPIKeyRequest{Name: "x", ExpiresInDays: &days})
+			return err
+		}},
+		{"Delete", func(c *Client) error { return c.DeleteAPIKey("u1", "k1") }},
+	}
+	for _, call := range calls {
+		call := call
+		for _, status := range statuses {
+			status := status
+			t.Run(fmt.Sprintf("%s_%d", call.name, status), func(t *testing.T) {
+				t.Parallel()
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(status)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "x"})
+				}))
+				defer server.Close()
+				c := New(server.URL)
+				err := call.call(c)
+				require.Error(t, err)
+				var apiErr *APIError
+				require.ErrorAs(t, err, &apiErr)
+				assert.Equal(t, status, apiErr.StatusCode)
+			})
+		}
+	}
+}
+
 // ---------- shared values ----------
 
 func TestListSharedValues_Success(t *testing.T) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -162,6 +162,58 @@ type ResetPasswordRequest struct {
 	Password string `json:"password" yaml:"password"`
 }
 
+// APIKey is one entry in the response of GET /api/v1/users/:id/api-keys.
+// Mirrors backend models.APIKey.
+//
+// Population: only returned on a 2xx response. On non-2xx the client surfaces
+// an APIError and the struct is left zero-valued by the caller. The KeyHash
+// is tagged json:"-" on the server side and is never present in any
+// response; the raw key is only ever returned by Create (see
+// CreateAPIKeyResponse) and is non-retrievable thereafter.
+//
+// Field semantics:
+//   - Prefix — first 16 chars of the raw key, safe to display and used for
+//     quick visual identification.
+//   - LastUsedAt — nil until the key has authenticated at least one request.
+//   - ExpiresAt — always present in responses (the backend rejects creation
+//     without an expiry), modelled as pointer to allow zero-value omission
+//     in JSON tooling.
+type APIKey struct {
+	ID         string     `json:"id" yaml:"id"`
+	UserID     string     `json:"user_id" yaml:"user_id"`
+	Name       string     `json:"name" yaml:"name"`
+	Prefix     string     `json:"prefix" yaml:"prefix"`
+	CreatedAt  time.Time  `json:"created_at" yaml:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty" yaml:"last_used_at,omitempty"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+}
+
+// CreateAPIKeyRequest is the body for POST /api/v1/users/:id/api-keys.
+// The backend requires an expiry — exactly one of ExpiresAt or ExpiresInDays
+// must be set. Setting both returns 400. ExpiresAt accepts RFC3339 or
+// YYYY-MM-DD; the latter is treated as 23:59:59 UTC of that day. The expiry
+// must be strictly in the future and may be capped by the server's
+// API_KEY_MAX_LIFETIME_DAYS setting.
+type CreateAPIKeyRequest struct {
+	Name          string  `json:"name" yaml:"name"`
+	ExpiresAt     *string `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+	ExpiresInDays *int    `json:"expires_in_days,omitempty" yaml:"expires_in_days,omitempty"`
+}
+
+// CreateAPIKeyResponse is returned ONCE by POST /api/v1/users/:id/api-keys
+// (HTTP 201). The RawKey field carries the plaintext key prefixed with
+// "sk_" — it is never persisted server-side and cannot be retrieved again.
+// Callers must surface it immediately (typically to stdout for piping) and
+// must not store it in config files.
+type CreateAPIKeyResponse struct {
+	ID        string     `json:"id" yaml:"id"`
+	Name      string     `json:"name" yaml:"name"`
+	Prefix    string     `json:"prefix" yaml:"prefix"`
+	RawKey    string     `json:"raw_key" yaml:"raw_key"`
+	CreatedAt time.Time  `json:"created_at" yaml:"created_at"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty" yaml:"expires_at,omitempty"`
+}
+
 // CreateStackRequest is the request body for POST /api/v1/stack-instances.
 // It contains only the writable fields — server-owned fields like ID, owner,
 // namespace, status are excluded to avoid backend validation errors.

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2449,7 +2449,10 @@ func startE2EAPIKeyMockServer(t *testing.T) *httptest.Server {
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
 			return
 		}
-		parts := strings.SplitN(trimmed, "/", 3)
+		// Use unbounded Split so a request like /users/u/api-keys/k/garbage
+		// yields len(parts) == 4 and reaches the unknown-path 404 branch
+		// below, rather than being absorbed as a delete on key-id "k/garbage".
+		parts := strings.Split(trimmed, "/")
 		if len(parts) < 2 || parts[1] != "api-keys" {
 			w.WriteHeader(http.StatusNotFound)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2480,9 +2480,13 @@ func startE2EAPIKeyMockServer(t *testing.T) *httptest.Server {
 				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
 				return
 			}
-			if body.Name == "" || (body.ExpiresAt == nil && body.ExpiresInDays == nil) {
+			hasAt := body.ExpiresAt != nil
+			hasDays := body.ExpiresInDays != nil
+			if body.Name == "" || (!hasAt && !hasDays) || (hasAt && hasDays) {
 				w.WriteHeader(http.StatusBadRequest)
-				_ = json.NewEncoder(w).Encode(map[string]string{"error": "name and expiry are required"})
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error": "name and exactly one of expires_at or expires_in_days are required",
+				})
 				return
 			}
 			mu.Lock()
@@ -2514,6 +2518,13 @@ func startE2EAPIKeyMockServer(t *testing.T) *httptest.Server {
 				return
 			}
 			w.WriteHeader(http.StatusNoContent)
+
+		case len(parts) >= 4:
+			// e.g. /users/:id/api-keys/:keyId/<garbage> — not a real route;
+			// 404 matches the cleanup-policy mock convention and avoids
+			// misleading 405 responses for routes that don't exist.
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
 
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2414,3 +2414,133 @@ func TestE2EAuthRegisterAndUserList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "alice")
 }
+
+// startE2EAPIKeyMockServer is an in-memory backend for the apikey e2e tests.
+// Implements /auth/me + the api-keys CRUD surface for one caller user.
+func startE2EAPIKeyMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	const callerID = "caller-uuid"
+	type key struct {
+		ID        string `json:"id"`
+		UserID    string `json:"user_id"`
+		Name      string `json:"name"`
+		Prefix    string `json:"prefix"`
+		CreatedAt string `json:"created_at"`
+		ExpiresAt string `json:"expires_at,omitempty"`
+	}
+	var (
+		mu     sync.Mutex
+		nextID = 1
+		keys   = map[string]*key{}
+	)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/auth/me" && r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": callerID, "username": "me", "role": "user",
+			})
+			return
+		}
+
+		trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/users/")
+		if trimmed == r.URL.Path {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+			return
+		}
+		parts := strings.SplitN(trimmed, "/", 3)
+		if len(parts) < 2 || parts[1] != "api-keys" {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+			return
+		}
+		userID := parts[0]
+
+		switch {
+		case len(parts) == 2 && r.Method == http.MethodGet:
+			mu.Lock()
+			out := make([]key, 0, len(keys))
+			for _, k := range keys {
+				if k.UserID == userID {
+					out = append(out, *k)
+				}
+			}
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(out)
+
+		case len(parts) == 2 && r.Method == http.MethodPost:
+			var body struct {
+				Name          string  `json:"name"`
+				ExpiresAt     *string `json:"expires_at"`
+				ExpiresInDays *int    `json:"expires_in_days"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+				return
+			}
+			if body.Name == "" || (body.ExpiresAt == nil && body.ExpiresInDays == nil) {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "name and expiry are required"})
+				return
+			}
+			mu.Lock()
+			id := fmt.Sprintf("key-%d", nextID)
+			nextID++
+			k := &key{
+				ID: id, UserID: userID, Name: body.Name,
+				Prefix: "abcdef0123456789", CreatedAt: "2026-05-01T12:00:00Z",
+			}
+			keys[id] = k
+			mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": k.ID, "name": k.Name, "prefix": k.Prefix,
+				"raw_key": "sk_" + id + "-raw", "created_at": k.CreatedAt,
+			})
+
+		case len(parts) == 3 && r.Method == http.MethodDelete:
+			keyID := parts[2]
+			mu.Lock()
+			_, exists := keys[keyID]
+			if exists {
+				delete(keys, keyID)
+			}
+			mu.Unlock()
+			if !exists {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "API key not found"})
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+func TestE2EAPIKeyCreateQuietBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EAPIKeyMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	// stackctl apikey create --name ci --expires-in-days 90 --quiet
+	// Verifies the documented CI-bootstrap contract: stdout is EXACTLY the
+	// raw key followed by a single newline — pipeable into a token file
+	// with no extra bytes. The mock generates IDs as key-1, key-2, ...
+	// and returns "sk_<id>-raw" so the first call yields "sk_key-1-raw".
+	stdout, stderr, err := runStackctl(t, dir,
+		"apikey", "create", "--name", "ci", "--expires-in-days", "90", "--quiet")
+	require.NoError(t, err)
+	assert.Equal(t, "sk_key-1-raw\n", stdout,
+		"quiet stdout must be EXACTLY the raw key plus one newline — no other bytes")
+	assert.Empty(t, stderr, "quiet mode must produce no stderr noise")
+}

--- a/cli/test/integration/apikey_integration_test.go
+++ b/cli/test/integration/apikey_integration_test.go
@@ -166,6 +166,14 @@ func TestAPIKeyCobra_CreateListRevoke_QuietBootstrap(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Reset root persistent flags before the FIRST Execute() so this test
+	// doesn't inherit state from any earlier in-process Cobra test that
+	// ran in the same package. ResetFlagsForTest() only resets root
+	// persistent flags (--output, --quiet, --api-url, etc.) — subcommand
+	// flags like --name/--expires-in-days are scoped to the command and
+	// not affected.
+	cmd.ResetFlagsForTest()
+
 	// apikey create --name ci --expires-in-days 30 --quiet
 	// Verifies the CI-bootstrap contract: stdout is the raw key ONLY,
 	// one line, pipeable.

--- a/cli/test/integration/apikey_integration_test.go
+++ b/cli/test/integration/apikey_integration_test.go
@@ -1,0 +1,216 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/cmd"
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// apikeyMockState backs the apikey integration tests.
+type apikeyMockState struct {
+	mu     sync.Mutex
+	nextID int
+	keys   map[string]*types.APIKey // keyed by APIKey.ID
+	caller string                   // user ID returned by /auth/me
+}
+
+func newAPIKeyMockState() *apikeyMockState {
+	return &apikeyMockState{nextID: 1, keys: map[string]*types.APIKey{}, caller: "caller-uuid"}
+}
+
+func startAPIKeyMockServer(t *testing.T, state *apikeyMockState) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v1/auth/me" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(types.User{Base: types.Base{ID: state.caller}, Username: "me", Role: "user"})
+			return
+		}
+
+		trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/users/")
+		if trimmed == r.URL.Path {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+			return
+		}
+		// trimmed = "<userID>/api-keys" OR "<userID>/api-keys/<keyID>"
+		parts := strings.SplitN(trimmed, "/", 3)
+		if len(parts) < 2 || parts[1] != "api-keys" {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+			return
+		}
+		userID := parts[0]
+
+		switch {
+		case len(parts) == 2 && r.Method == http.MethodGet:
+			state.mu.Lock()
+			out := make([]types.APIKey, 0, len(state.keys))
+			for _, k := range state.keys {
+				if k.UserID == userID {
+					out = append(out, *k)
+				}
+			}
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(out)
+
+		case len(parts) == 2 && r.Method == http.MethodPost:
+			var req types.CreateAPIKeyRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid body"})
+				return
+			}
+			if req.ExpiresAt == nil && req.ExpiresInDays == nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "expiry required"})
+				return
+			}
+			state.mu.Lock()
+			id := fmt.Sprintf("key-%d", state.nextID)
+			state.nextID++
+			now := time.Now().UTC()
+			var exp *time.Time
+			if req.ExpiresInDays != nil {
+				t := now.AddDate(0, 0, *req.ExpiresInDays)
+				exp = &t
+			}
+			key := &types.APIKey{
+				ID: id, UserID: userID, Name: req.Name,
+				Prefix: "abcdef0123456789", CreatedAt: now, ExpiresAt: exp,
+			}
+			state.keys[id] = key
+			state.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(types.CreateAPIKeyResponse{
+				ID: key.ID, Name: key.Name, Prefix: key.Prefix,
+				RawKey: "sk_" + id + "-raw", CreatedAt: key.CreatedAt, ExpiresAt: key.ExpiresAt,
+			})
+
+		case len(parts) == 3 && r.Method == http.MethodDelete:
+			keyID := parts[2]
+			state.mu.Lock()
+			_, exists := state.keys[keyID]
+			if exists {
+				delete(state.keys, keyID)
+			}
+			state.mu.Unlock()
+			if !exists {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "API key not found"})
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+}
+
+func TestAPIKeyWorkflow_CreateListRevoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := newAPIKeyMockState()
+	server := startAPIKeyMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	days := 30
+	resp, err := c.CreateAPIKey(state.caller, &types.CreateAPIKeyRequest{Name: "ci", ExpiresInDays: &days})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.RawKey)
+	assert.True(t, strings.HasPrefix(resp.RawKey, "sk_"), "raw key must carry sk_ prefix")
+
+	keys, err := c.ListAPIKeys(state.caller)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "ci", keys[0].Name)
+
+	require.NoError(t, c.DeleteAPIKey(state.caller, resp.ID))
+	keys, err = c.ListAPIKeys(state.caller)
+	require.NoError(t, err)
+	assert.Empty(t, keys)
+}
+
+func TestAPIKeyCobra_CreateListRevoke_QuietBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	state := newAPIKeyMockState()
+	server := startAPIKeyMockServer(t, state)
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+
+	// apikey create --name ci --expires-in-days 30 --quiet
+	// Verifies the CI-bootstrap contract: stdout is the raw key ONLY,
+	// one line, pipeable.
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"apikey", "create", "--name", "ci", "--expires-in-days", "30", "--quiet"})
+	require.NoError(t, cmd.Execute())
+	rawKey := strings.TrimRight(buf.String(), "\n")
+	require.NotEmpty(t, rawKey)
+	assert.True(t, strings.HasPrefix(rawKey, "sk_"), "quiet output must start with sk_")
+	assert.NotContains(t, rawKey, "\n", "quiet output must be a single line")
+
+	// apikey list — created key visible, raw key never appears (the list
+	// endpoint never returns raw_key; this assertion guards against a
+	// future regression where the CLI starts including request bodies in
+	// table output or accidentally surfaces a cached create-response).
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"apikey", "list"})
+	require.NoError(t, cmd.Execute())
+	listOut := buf.String()
+	assert.Contains(t, listOut, "ci")
+	assert.NotContains(t, listOut, "raw_key", "list output must NEVER contain raw_key field")
+	assert.NotContains(t, listOut, "sk_", "list output must NEVER contain the sk_ prefix")
+
+	// Locate the created key ID from server state.
+	state.mu.Lock()
+	var createdID string
+	for id := range state.keys {
+		createdID = id
+	}
+	state.mu.Unlock()
+	require.NotEmpty(t, createdID)
+
+	// apikey revoke <id> --yes
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"apikey", "revoke", createdID, "--yes"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "Revoked")
+
+	state.mu.Lock()
+	_, exists := state.keys[createdID]
+	state.mu.Unlock()
+	assert.False(t, exists)
+}


### PR DESCRIPTION
## Summary

Implements the `apikey` CLI surface from epic #59 phase 4 (issue #70):

- `stackctl apikey list [--user <uuid>]`
- `stackctl apikey create --name X (--expires-at|--expires-in-days) [--user <uuid>]`
- `stackctl apikey revoke <key-id> [--user <uuid>] [--yes]`

All routes hang under `/api/v1/users/:id/api-keys`. The backend (`canAccessUserKeys`) allows callers to manage their own keys and admins to manage any user's; `--user` defaults to the caller's own user ID resolved via `GET /api/v1/auth/me`.

## Security contract

The raw key is returned **once** by Create (HTTP 201, prefixed `sk_`) and is non-retrievable thereafter. Three explicit guardrails:

1. **Debug log never contains raw key** — `TestAPIKeyClient_DoesNotLogRawKey` enables `client.Debug`, calls Create, and asserts the raw key never appears in the debug writer. The client's `do()` only logs the request line and a small set of HEADERS (with masking) — never request/response bodies.
2. **`apikey create --quiet` emits exactly one line** — stdout is *exactly* the raw key plus one newline; stderr is empty. The e2e test asserts exact-string equality so the contract can't drift. Pipeable into a token file with no extra bytes:
   ```
   stackctl apikey create --name ci --expires-in-days 365 --quiet > /run/secrets/stackctl-token
   ```
3. **`apikey list` output never leaks raw_key** — the integration test asserts the list output never contains `raw_key` or the `sk_` prefix.

## Create wire-format

Backend enforces these and the CLI mirrors them client-side (clear error before contacting the backend):

- Exactly one of `--expires-at` (YYYY-MM-DD or RFC3339) or `--expires-in-days` (positive int) must be set. Both → 400; neither → 400.
- `--name` is required (marked via `MarkFlagRequired`).
- Default and JSON/YAML outputs include the raw key with a "store now — non-retrievable" annotation.

## Tests

All three layers green (`go test ./... && go vet ./...` from `cli/`):

- **Unit (cmd):** 20 tests in `cli/cmd/apikey_test.go` — list output modes, list with explicit `--user` skipping `/auth/me`, create wire-format for both expiry modes, quiet-mode raw-key-only contract, mutually-exclusive expiry rejection, negative-days rejection, revoke with `--yes` / `--dry-run` / interactive decline / quiet, plus per-command 401/404/500 matrix.
- **Unit (client):** 5 method tests + the debug-leak test + 9-subtest error matrix.
- **Integration:** full client CRUD round-trip + Cobra-in-process bootstrap (verifies the quiet contract end-to-end and asserts list output never leaks `raw_key`).
- **E2E:** binary exec'd against a stub server for `apikey create --quiet`, asserts stdout is exactly `sk_<key>\n` and stderr is empty.

Independent code review found no blockers. Two CI-hardening nits applied before commit: tightened the e2e stdout assertion to exact equality, and added `NotContains(raw_key|sk_)` belts to the integration list path.

## Test plan

- [x] `go test ./... -v` passes
- [x] `go vet ./...` clean
- [x] Coverage on new code ≥80%
- [ ] Manually exercise `apikey create --quiet > token` followed by re-auth with that token against a dev backend once merged

Closes #70
Tracks #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added apikey command group with list, create, and revoke subcommands
  * Supports table/JSON/YAML output and quiet mode; create quiet prints only the raw key, list never exposes raw key
  * Create requires expiry (either expires-at or expires-in-days), enforces mutual exclusivity and positive days, and accepts an explicit target user
  * Revoke supports dry-run and confirmation toggles (--yes)

* **Tests**
  * Comprehensive unit, integration, and end-to-end tests covering list/create/revoke behaviors and error cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->