### PR TITLE
feat(audit): list with filters + export json/csv

### DIFF
--- a/cli/cmd/audit.go
+++ b/cli/cmd/audit.go
@@ -1,0 +1,325 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// auditCmd is the top-level command group. The intermediate `audit log`
+// noun mirrors the API path /api/v1/audit-logs and leaves room for future
+// audit subgroups (settings, retention) without restructuring later.
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Audit log queries and exports (admin/devops)",
+	Long: `Inspect the platform audit log.
+
+  log list    — paginated query with filters
+  log export  — bulk export as JSON or CSV (admin-only)
+
+All audit endpoints surface backend permission errors as command errors;
+non-admin callers on the export endpoint receive 403.`,
+}
+
+var auditLogCmd = &cobra.Command{
+	Use:   "log",
+	Short: "Audit log subcommands",
+}
+
+// Filter flags shared between list and export. Declared at package scope so
+// the cmd.Flags().Get* calls in RunE can read them; populated by cobra when
+// the user passes --user / --action / etc.
+var (
+	auditFlagUser       string
+	auditFlagAction     string
+	auditFlagEntityType string
+	auditFlagEntityID   string
+	auditFlagSince      string
+	auditFlagUntil      string
+	auditFlagLimit      int
+	auditFlagOffset     int
+	auditFlagCursor     string
+
+	auditFlagFormat     string
+	auditFlagOutputFile string
+)
+
+var auditLogListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List audit log entries",
+	Long: `List audit log entries with optional filters and pagination.
+
+Time filters (--since / --until) accept either an absolute RFC3339 timestamp
+(e.g. 2026-05-01T00:00:00Z) or a Go duration relative to now (e.g. 24h, 7d).
+Relative values are negated and added to time.Now() before being sent to the
+backend as RFC3339.
+
+Examples:
+  stackctl audit log list
+  stackctl audit log list --user u-123 --action stack.deploy
+  stackctl audit log list --entity-type stack --since 24h
+  stackctl audit log list --since 2026-05-01T00:00:00Z --limit 100
+  stackctl audit log list --cursor eyJpZCI6...`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		params, err := buildAuditListParams()
+		if err != nil {
+			return err
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		page, err := c.ListAuditLogs(params)
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, e := range page.Data {
+				fmt.Fprintln(printer.Writer, e.ID)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(page)
+		case output.FormatYAML:
+			return printer.PrintYAML(page)
+		default:
+			if len(page.Data) == 0 {
+				printer.PrintMessage("No audit log entries found.")
+				return nil
+			}
+			headers := []string{"TIMESTAMP", "USER", "ACTION", "ENTITY", "ENTITY ID", "DETAILS"}
+			rows := make([][]string, len(page.Data))
+			for i, e := range page.Data {
+				rows[i] = []string{
+					e.Timestamp.UTC().Format(time.RFC3339),
+					auditUserLabel(e),
+					e.Action,
+					e.EntityType,
+					e.EntityID,
+					truncate(e.Details, 60),
+				}
+			}
+			if err := printer.PrintTable(headers, rows); err != nil {
+				return err
+			}
+			if page.NextCursor != "" {
+				printer.PrintMessage("(more results — re-run with --cursor %s)", page.NextCursor)
+			}
+			return nil
+		}
+	},
+}
+
+var auditLogExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export audit logs as JSON or CSV (admin)",
+	Long: `Export the audit log as a JSON array or CSV file.
+
+The server caps each export at 10,000 entries (most-recent first). Use
+--since / --until to narrow the window for larger histories.
+
+By default the export is written to stdout. Use --output-file to write to a
+file instead. The export endpoint is admin-only; non-admin callers receive
+a 403 surfaced as a command error.
+
+The --format flag is independent of the global --output (-o) flag: --output
+controls how the command's own progress messages are formatted (table is
+fine), --format controls the server's response encoding.
+
+Examples:
+  stackctl audit log export                       # JSON to stdout
+  stackctl audit log export --format csv > log.csv
+  stackctl audit log export --format csv --output-file log.csv
+  stackctl audit log export --since 7d --format csv --output-file weekly.csv`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format := strings.ToLower(strings.TrimSpace(auditFlagFormat))
+		if format != "json" && format != "csv" {
+			return fmt.Errorf("invalid --format %q: must be 'json' or 'csv'", auditFlagFormat)
+		}
+
+		// Validate --output-file up front so an obvious misconfiguration is
+		// rejected before we hit the API and pull down a 10k-row payload.
+		// Defense-in-depth against accidental `..` slips — NOT a sandbox;
+		// absolute paths and symlinks are still resolved by os.WriteFile.
+		if auditFlagOutputFile != "" {
+			for _, segment := range strings.Split(filepath.ToSlash(auditFlagOutputFile), "/") {
+				if segment == ".." {
+					return fmt.Errorf("output file path must not contain '..' segments")
+				}
+			}
+		}
+
+		params, err := buildAuditListParams()
+		if err != nil {
+			return err
+		}
+		// Server enforces limit/offset=0/maxExportLimit on export; passing user
+		// values would be ignored. Skip sending them to avoid confusion.
+		params.Limit = 0
+		params.Offset = 0
+		params.Cursor = ""
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		data, err := c.ExportAuditLogs(format, params)
+		if err != nil {
+			return err
+		}
+
+		if auditFlagOutputFile != "" {
+			outPath := filepath.Clean(auditFlagOutputFile)
+			if err := os.WriteFile(outPath, data, 0600); err != nil {
+				return fmt.Errorf("writing file %s: %w", outPath, err)
+			}
+			if !printer.Quiet {
+				printer.PrintMessage("Exported %d bytes (%s) to %s", len(data), format, outPath)
+			}
+			return nil
+		}
+
+		_, err = printer.Writer.Write(data)
+		return err
+	},
+}
+
+// buildAuditListParams converts the package-level flag vars into the typed
+// query-param struct. Time flags are parsed here so an invalid input is
+// rejected before an API call is made.
+func buildAuditListParams() (types.AuditLogListParams, error) {
+	p := types.AuditLogListParams{
+		UserID:     auditFlagUser,
+		Action:     auditFlagAction,
+		EntityType: auditFlagEntityType,
+		EntityID:   auditFlagEntityID,
+		Cursor:     auditFlagCursor,
+		Limit:      auditFlagLimit,
+		Offset:     auditFlagOffset,
+	}
+	now := time.Now().UTC()
+	if auditFlagSince != "" {
+		t, err := parseTimeFlag(auditFlagSince, now)
+		if err != nil {
+			return p, fmt.Errorf("--since: %w", err)
+		}
+		p.StartDate = &t
+	}
+	if auditFlagUntil != "" {
+		t, err := parseTimeFlag(auditFlagUntil, now)
+		if err != nil {
+			return p, fmt.Errorf("--until: %w", err)
+		}
+		p.EndDate = &t
+	}
+	return p, nil
+}
+
+// parseTimeFlag accepts either an absolute RFC3339 timestamp or a Go
+// duration ("24h", "30m", "2h45m"). Durations are subtracted from `now` to
+// produce an absolute timestamp, which is what the backend requires.
+//
+// Note: time.ParseDuration does NOT accept "d" / "w" units (Go's stdlib
+// limitation). For "7 days" the user must pass "168h". We document this in
+// the error message rather than rolling a custom parser, to keep behaviour
+// predictable and avoid silently misinterpreting "1d".
+func parseTimeFlag(v string, now time.Time) (time.Time, error) {
+	v = strings.TrimSpace(v)
+	if t, err := time.Parse(time.RFC3339, v); err == nil {
+		return t.UTC(), nil
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		if d < 0 {
+			return time.Time{}, fmt.Errorf("duration must be positive, got %q", v)
+		}
+		return now.Add(-d).UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("invalid time %q: expected RFC3339 (2026-05-01T00:00:00Z) or Go duration (24h, 30m)", v)
+}
+
+// auditUserLabel returns a printable user label for a log entry. Backend
+// guarantees UserID is set; Username can be empty when the user has been
+// deleted. Prefer the username for human readability, fall back to the ID.
+func auditUserLabel(e types.AuditLogEntry) string {
+	if e.Username != "" {
+		return e.Username
+	}
+	if e.UserID != "" {
+		return e.UserID
+	}
+	return "-"
+}
+
+// truncate shortens s to at most n runes, appending an ellipsis when cut.
+// Used to keep audit-log "details" column readable in table mode without
+// hard-wrapping; JSON/YAML output is never truncated.
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n-1]) + "…"
+}
+
+func init() {
+	// Filter flags are shared between list and export. Register them ONCE on
+	// the parent `audit log` group as persistent flags so both subcommands
+	// see the same values without double-binding the same package-level var
+	// to two distinct Flags() sets (which would silently override defaults
+	// and share state across commands within one Execute()).
+	auditLogCmd.PersistentFlags().StringVar(&auditFlagUser, "user", "", "Filter by user ID")
+	auditLogCmd.PersistentFlags().StringVar(&auditFlagAction, "action", "", "Filter by action name (e.g. stack.deploy)")
+	auditLogCmd.PersistentFlags().StringVar(&auditFlagEntityType, "entity-type", "", "Filter by entity type (e.g. stack, template)")
+	auditLogCmd.PersistentFlags().StringVar(&auditFlagEntityID, "entity-id", "", "Filter by entity ID")
+	auditLogCmd.PersistentFlags().StringVar(&auditFlagSince, "since", "", "Lower bound (RFC3339 or duration like 24h)")
+	auditLogCmd.PersistentFlags().StringVar(&auditFlagUntil, "until", "", "Upper bound (RFC3339 or duration like 24h)")
+
+	// Pagination flags are only meaningful for list — export server-side
+	// caps the row count and ignores limit/offset/cursor.
+	auditLogListCmd.Flags().IntVar(&auditFlagLimit, "limit", 0, "Page size (default 25, max 100)")
+	auditLogListCmd.Flags().IntVar(&auditFlagOffset, "offset", 0, "Pagination offset")
+	auditLogListCmd.Flags().StringVar(&auditFlagCursor, "cursor", "", "Pagination cursor (from previous page)")
+
+	// Export-only flags.
+	auditLogExportCmd.Flags().StringVar(&auditFlagFormat, "format", "json", "Export format: json or csv")
+	auditLogExportCmd.Flags().StringVar(&auditFlagOutputFile, "output-file", "", "Write export to file instead of stdout")
+
+	auditLogCmd.AddCommand(auditLogListCmd)
+	auditLogCmd.AddCommand(auditLogExportCmd)
+	auditCmd.AddCommand(auditLogCmd)
+	rootCmd.AddCommand(auditCmd)
+}
+
+// resetAuditFlagsForTest clears the package-level audit flag vars between
+// in-process Cobra invocations in tests. Subcommand flags are NOT reset by
+// ResetFlagsForTest (which only handles persistent flags on rootCmd).
+func resetAuditFlagsForTest() {
+	auditFlagUser = ""
+	auditFlagAction = ""
+	auditFlagEntityType = ""
+	auditFlagEntityID = ""
+	auditFlagSince = ""
+	auditFlagUntil = ""
+	auditFlagLimit = 0
+	auditFlagOffset = 0
+	auditFlagCursor = ""
+	auditFlagFormat = "json"
+	auditFlagOutputFile = ""
+}
+

--- a/cli/cmd/audit.go
+++ b/cli/cmd/audit.go
@@ -56,9 +56,10 @@ var auditLogListCmd = &cobra.Command{
 	Long: `List audit log entries with optional filters and pagination.
 
 Time filters (--since / --until) accept either an absolute RFC3339 timestamp
-(e.g. 2026-05-01T00:00:00Z) or a Go duration relative to now (e.g. 24h, 7d).
-Relative values are negated and added to time.Now() before being sent to the
-backend as RFC3339.
+(e.g. 2026-05-01T00:00:00Z) or a Go duration relative to now (e.g. 24h, 168h
+for 7 days). Day/week units ("7d", "1w") are NOT accepted — Go's standard
+time.ParseDuration only understands ns/us/ms/s/m/h. Relative values are
+negated and added to time.Now() before being sent to the backend as RFC3339.
 
 Examples:
   stackctl audit log list
@@ -306,10 +307,16 @@ func init() {
 	rootCmd.AddCommand(auditCmd)
 }
 
-// resetAuditFlagsForTest clears the package-level audit flag vars between
-// in-process Cobra invocations in tests. Subcommand flags are NOT reset by
-// ResetFlagsForTest (which only handles persistent flags on rootCmd).
-func resetAuditFlagsForTest() {
+// ResetAuditFlagsForTest clears the package-level audit flag vars between
+// in-process Cobra invocations in tests. The persistent filter flags on
+// `audit log` are NOT reset by ResetFlagsForTest (which only handles
+// persistent flags on rootCmd), so integration tests that exercise multiple
+// audit subcommands within one process MUST call this between Execute()s to
+// avoid filter leakage from a previous call.
+//
+// Exported so the integration_test package can call it; the lowercase alias
+// remains available within the cmd package itself.
+func ResetAuditFlagsForTest() {
 	auditFlagUser = ""
 	auditFlagAction = ""
 	auditFlagEntityType = ""
@@ -322,4 +329,8 @@ func resetAuditFlagsForTest() {
 	auditFlagFormat = "json"
 	auditFlagOutputFile = ""
 }
+
+// resetAuditFlagsForTest is the in-package alias retained so existing cmd-
+// package test files don't need updating.
+func resetAuditFlagsForTest() { ResetAuditFlagsForTest() }
 

--- a/cli/cmd/audit.go
+++ b/cli/cmd/audit.go
@@ -143,7 +143,7 @@ Examples:
   stackctl audit log export                       # JSON to stdout
   stackctl audit log export --format csv > log.csv
   stackctl audit log export --format csv --output-file log.csv
-  stackctl audit log export --since 7d --format csv --output-file weekly.csv`,
+  stackctl audit log export --since 168h --format csv --output-file weekly.csv`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format := strings.ToLower(strings.TrimSpace(auditFlagFormat))

--- a/cli/cmd/audit_test.go
+++ b/cli/cmd/audit_test.go
@@ -1,0 +1,482 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests in this file mutate package-level globals (printer, flagAPIURL,
+// auditFlag*) and therefore do not use t.Parallel(). The test helper
+// resets every audit flag before each test so flag leakage between in-
+// process Cobra invocations is impossible.
+
+func sampleAuditEntries() []types.AuditLogEntry {
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 2, 11, 30, 0, 0, time.UTC)
+	return []types.AuditLogEntry{
+		{
+			Action:     "stack.deploy",
+			Details:    "deployed via UI",
+			EntityID:   "stack-1",
+			EntityType: "stack",
+			ID:         "a1",
+			Timestamp:  t1,
+			UserID:     "u1",
+			Username:   "alice",
+		},
+		{
+			Action:     "template.publish",
+			Details:    "",
+			EntityID:   "tpl-9",
+			EntityType: "template",
+			ID:         "a2",
+			Timestamp:  t2,
+			UserID:     "u2",
+			Username:   "bob",
+		},
+	}
+}
+
+func samplePaginatedAuditLogs() types.PaginatedAuditLogs {
+	return types.PaginatedAuditLogs{
+		Data:   sampleAuditEntries(),
+		Total:  2,
+		Limit:  25,
+		Offset: 0,
+	}
+}
+
+// ---------- parseTimeFlag ----------
+
+func TestParseTimeFlag(t *testing.T) {
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+		want    time.Time
+	}{
+		{name: "rfc3339_utc", input: "2026-05-01T00:00:00Z", want: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "rfc3339_with_offset", input: "2026-05-01T02:00:00+02:00", want: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "duration_24h", input: "24h", want: now.Add(-24 * time.Hour)},
+		{name: "duration_30m", input: "30m", want: now.Add(-30 * time.Minute)},
+		{name: "duration_composed", input: "2h45m", want: now.Add(-(2*time.Hour + 45*time.Minute))},
+		{name: "negative_duration_rejected", input: "-1h", wantErr: true},
+		{name: "days_rejected", input: "7d", wantErr: true}, // documented gotcha
+		{name: "garbage", input: "yesterday", wantErr: true},
+		{name: "empty_after_trim", input: "   ", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTimeFlag(tc.input, now)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, got.Equal(tc.want), "got %v want %v", got, tc.want)
+		})
+	}
+}
+
+// ---------- buildAuditListParams ----------
+
+func TestBuildAuditListParams_AllFilters(t *testing.T) {
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagUser = "u1"
+	auditFlagAction = "stack.deploy"
+	auditFlagEntityType = "stack"
+	auditFlagEntityID = "stack-1"
+	auditFlagSince = "2026-05-01T00:00:00Z"
+	auditFlagUntil = "2026-05-02T00:00:00Z"
+	auditFlagLimit = 50
+	auditFlagOffset = 10
+	auditFlagCursor = "c-abc"
+
+	p, err := buildAuditListParams()
+	require.NoError(t, err)
+	assert.Equal(t, "u1", p.UserID)
+	assert.Equal(t, "stack.deploy", p.Action)
+	assert.Equal(t, "stack", p.EntityType)
+	assert.Equal(t, "stack-1", p.EntityID)
+	assert.Equal(t, "c-abc", p.Cursor)
+	assert.Equal(t, 50, p.Limit)
+	assert.Equal(t, 10, p.Offset)
+	require.NotNil(t, p.StartDate)
+	require.NotNil(t, p.EndDate)
+	assert.Equal(t, "2026-05-01T00:00:00Z", p.StartDate.UTC().Format(time.RFC3339))
+	assert.Equal(t, "2026-05-02T00:00:00Z", p.EndDate.UTC().Format(time.RFC3339))
+}
+
+func TestBuildAuditListParams_InvalidSince(t *testing.T) {
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagSince = "garbage"
+	_, err := buildAuditListParams()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--since")
+}
+
+// ---------- audit log list ----------
+
+func TestAuditLogListCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/audit-logs", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		// No filters set → query should be empty
+		assert.Empty(t, r.URL.Query().Encode())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePaginatedAuditLogs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	require.NoError(t, auditLogListCmd.RunE(auditLogListCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "TIMESTAMP")
+	assert.Contains(t, out, "stack.deploy")
+	assert.Contains(t, out, "template.publish")
+	assert.Contains(t, out, "alice")
+}
+
+func TestAuditLogListCmd_ForwardsFiltersAsQueryParams(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedAuditLogs{})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagUser = "u-42"
+	auditFlagAction = "stack.deploy"
+	auditFlagEntityType = "stack"
+	auditFlagEntityID = "s-1"
+	auditFlagSince = "2026-05-01T00:00:00Z"
+	auditFlagUntil = "2026-05-02T00:00:00Z"
+	auditFlagLimit = 50
+	auditFlagOffset = 10
+
+	require.NoError(t, auditLogListCmd.RunE(auditLogListCmd, []string{}))
+
+	assert.Contains(t, gotQuery, "user_id=u-42")
+	assert.Contains(t, gotQuery, "action=stack.deploy")
+	assert.Contains(t, gotQuery, "entity_type=stack")
+	assert.Contains(t, gotQuery, "entity_id=s-1")
+	assert.Contains(t, gotQuery, "start_date=2026-05-01T00%3A00%3A00Z")
+	assert.Contains(t, gotQuery, "end_date=2026-05-02T00%3A00%3A00Z")
+	assert.Contains(t, gotQuery, "limit=50")
+	assert.Contains(t, gotQuery, "offset=10")
+}
+
+func TestAuditLogListCmd_QuietOutputIDsOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePaginatedAuditLogs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	printer.Quiet = true
+	require.NoError(t, auditLogListCmd.RunE(auditLogListCmd, []string{}))
+
+	out := strings.TrimSpace(buf.String())
+	assert.Equal(t, "a1\na2", out)
+	assert.NotContains(t, out, "TIMESTAMP")
+}
+
+func TestAuditLogListCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePaginatedAuditLogs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	printer.Format = output.FormatJSON
+	require.NoError(t, auditLogListCmd.RunE(auditLogListCmd, []string{}))
+
+	var got types.PaginatedAuditLogs
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, int64(2), got.Total)
+	assert.Len(t, got.Data, 2)
+	assert.Equal(t, "a1", got.Data[0].ID)
+}
+
+func TestAuditLogListCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePaginatedAuditLogs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	printer.Format = output.FormatYAML
+	require.NoError(t, auditLogListCmd.RunE(auditLogListCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "total: 2")
+	assert.Contains(t, out, "action: stack.deploy")
+	assert.Contains(t, out, "id: a1")
+}
+
+func TestAuditLogListCmd_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedAuditLogs{})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	require.NoError(t, auditLogListCmd.RunE(auditLogListCmd, []string{}))
+
+	assert.Contains(t, buf.String(), "No audit log entries found.")
+}
+
+func TestAuditLogListCmd_NextCursorHint(t *testing.T) {
+	page := samplePaginatedAuditLogs()
+	page.NextCursor = "c-next"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(page)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	require.NoError(t, auditLogListCmd.RunE(auditLogListCmd, []string{}))
+
+	assert.Contains(t, buf.String(), "--cursor c-next")
+}
+
+func TestAuditLogListCmd_InvalidSinceFlagRejectedBeforeAPICall(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagSince = "yesterday"
+	err := auditLogListCmd.RunE(auditLogListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--since")
+	assert.False(t, called, "API must not be called when flag parsing fails")
+}
+
+// ---------- audit log export ----------
+
+func TestAuditLogExportCmd_JSONToStdout(t *testing.T) {
+	want := []byte(`[{"id":"a1","action":"stack.deploy"}]`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/audit-logs/export", r.URL.Path)
+		assert.Equal(t, "json", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(want)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	require.NoError(t, auditLogExportCmd.RunE(auditLogExportCmd, []string{}))
+	assert.Equal(t, string(want), buf.String())
+}
+
+func TestAuditLogExportCmd_CSVQuotesCommasAndNewlines(t *testing.T) {
+	// Backend-produced CSV with deliberately tricky fields. The CLI streams
+	// it verbatim — proving we don't re-encode and don't drop quoting.
+	csvBody := "ID,Timestamp,Details\r\n" +
+		"a1,2026-05-01T10:00:00Z,\"value,with,commas\"\r\n" +
+		"a2,2026-05-02T10:00:00Z,\"line1\nline2\"\r\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "csv", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte(csvBody))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagFormat = "csv"
+	require.NoError(t, auditLogExportCmd.RunE(auditLogExportCmd, []string{}))
+	assert.Equal(t, csvBody, buf.String(), "CSV body must be streamed byte-for-byte")
+}
+
+func TestAuditLogExportCmd_WriteToFile(t *testing.T) {
+	want := []byte("ID,Timestamp\r\na1,2026-05-01T10:00:00Z\r\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write(want)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "audit.csv")
+	auditFlagFormat = "csv"
+	auditFlagOutputFile = dst
+	require.NoError(t, auditLogExportCmd.RunE(auditLogExportCmd, []string{}))
+
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	// Stdout should report the file write, NOT the bytes themselves.
+	assert.Contains(t, buf.String(), dst)
+	assert.NotContains(t, buf.String(), "a1,")
+}
+
+func TestAuditLogExportCmd_RejectsPathTraversal(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagOutputFile = "../escape.json"
+	err := auditLogExportCmd.RunE(auditLogExportCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}
+
+func TestAuditLogExportCmd_InvalidFormatRejected(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagFormat = "xml"
+	err := auditLogExportCmd.RunE(auditLogExportCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "json")
+	assert.False(t, called, "API must not be called for invalid --format")
+}
+
+func TestAuditLogExportCmd_StripsPaginationFlags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Server enforces its own limit/offset on export, so the client must
+		// not echo user-supplied pagination — those would be silently ignored
+		// and confuse the operator otherwise.
+		q := r.URL.Query()
+		assert.Empty(t, q.Get("limit"))
+		assert.Empty(t, q.Get("offset"))
+		assert.Empty(t, q.Get("cursor"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	auditFlagLimit = 50
+	auditFlagOffset = 10
+	auditFlagCursor = "abc"
+	require.NoError(t, auditLogExportCmd.RunE(auditLogExportCmd, []string{}))
+}
+
+// ---------- API error mapping ----------
+
+func TestAuditLogListCmd_APIError403(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"devops role required"}`))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	err := auditLogListCmd.RunE(auditLogListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Permission denied")
+}
+
+func TestAuditLogExportCmd_APIError403(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"admin role required"}`))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	err := auditLogExportCmd.RunE(auditLogExportCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Permission denied")
+}
+
+func TestAuditLogListCmd_APIError500(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"db down"}`))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetAuditFlagsForTest()
+	defer resetAuditFlagsForTest()
+	err := auditLogListCmd.RunE(auditLogListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Server error")
+}
+
+// ---------- helpers ----------
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{in: "abc", n: 5, want: "abc"},
+		{in: "abcdefgh", n: 5, want: "abcd…"},
+		{in: "abc", n: 0, want: ""},
+		{in: "", n: 10, want: ""},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, truncate(tc.in, tc.n))
+	}
+}
+
+func TestAuditUserLabel(t *testing.T) {
+	assert.Equal(t, "alice", auditUserLabel(types.AuditLogEntry{Username: "alice", UserID: "u1"}))
+	assert.Equal(t, "u1", auditUserLabel(types.AuditLogEntry{UserID: "u1"}))
+	assert.Equal(t, "-", auditUserLabel(types.AuditLogEntry{}))
+}
+

--- a/cli/cmd/audit_test.go
+++ b/cli/cmd/audit_test.go
@@ -78,6 +78,7 @@ func TestParseTimeFlag(t *testing.T) {
 		{name: "empty_after_trim", input: "   ", wantErr: true},
 	}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := parseTimeFlag(tc.input, now)
 			if tc.wantErr {

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1406,3 +1406,99 @@ func (c *Client) GetAnalyticsUsers() ([]types.UserStats, error) {
 	}
 	return stats, nil
 }
+
+// auditLogParamsToQuery converts the typed filter struct into the
+// backend's expected query-param shape. Empty / zero fields are omitted.
+// Time fields are formatted as RFC3339 — the only format the backend accepts.
+func auditLogParamsToQuery(p types.AuditLogListParams) map[string]string {
+	q := map[string]string{}
+	if p.UserID != "" {
+		q["user_id"] = p.UserID
+	}
+	if p.EntityType != "" {
+		q["entity_type"] = p.EntityType
+	}
+	if p.EntityID != "" {
+		q["entity_id"] = p.EntityID
+	}
+	if p.Action != "" {
+		q["action"] = p.Action
+	}
+	if p.Cursor != "" {
+		q["cursor"] = p.Cursor
+	}
+	if p.StartDate != nil {
+		q["start_date"] = p.StartDate.UTC().Format(time.RFC3339)
+	}
+	if p.EndDate != nil {
+		q["end_date"] = p.EndDate.UTC().Format(time.RFC3339)
+	}
+	if p.Limit > 0 {
+		q["limit"] = strconv.Itoa(p.Limit)
+	}
+	if p.Offset > 0 {
+		q["offset"] = strconv.Itoa(p.Offset)
+	}
+	return q
+}
+
+// ListAuditLogs returns a page of audit log entries matching the filters.
+// All filter fields are optional; an empty struct returns the default page
+// (limit=25, offset=0). Backend supports cursor pagination via NextCursor.
+//
+// @see GET /api/v1/audit-logs
+func (c *Client) ListAuditLogs(p types.AuditLogListParams) (*types.PaginatedAuditLogs, error) {
+	var resp types.PaginatedAuditLogs
+	if err := c.GetWithQuery("/api/v1/audit-logs", auditLogParamsToQuery(p), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ExportAuditLogs returns the raw body of the audit log export endpoint.
+// Format must be "json" or "csv"; the backend rejects anything else with 400.
+// Admin-gated — non-admin callers (including devops) receive APIError 403.
+//
+// The body is returned untouched so the CLI can stream the server's CSV
+// (with its own quoting rules) directly to disk without re-encoding.
+//
+// @see GET /api/v1/audit-logs/export
+func (c *Client) ExportAuditLogs(format string, p types.AuditLogListParams) ([]byte, error) {
+	q := auditLogParamsToQuery(p)
+	q["format"] = format
+	path := "/api/v1/audit-logs/export"
+	if encoded := encodeQueryParams(q); encoded != "" {
+		path = path + "?" + encoded
+	}
+	resp, err := c.doWithRetry(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	// Server caps the export at 10,000 rows; with realistic row sizes that
+	// fits comfortably inside 25MB. Use a LimitReader as a defense against
+	// a misconfigured/compromised backend streaming an unbounded body.
+	const maxAuditExportSize = 25 * 1024 * 1024 // 25MB
+	limited := io.LimitReader(resp.Body, maxAuditExportSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	if int64(len(data)) > maxAuditExportSize {
+		return nil, fmt.Errorf("audit export response exceeds maximum size of %d bytes", maxAuditExportSize)
+	}
+	return data, nil
+}
+
+// encodeQueryParams builds a stable-ordered URL-encoded query string from a
+// map of non-empty values. Identical to the body of GetWithQuery but factored
+// out because ExportAuditLogs needs the raw URL (not doJSON).
+func encodeQueryParams(params map[string]string) string {
+	q := url.Values{}
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	return q.Encode()
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -3105,6 +3105,152 @@ func TestAnalyticsClient_APIErrorMatrix(t *testing.T) {
 	}
 }
 
+// ---------- audit logs ----------
+
+func TestListAuditLogs_NoFilters(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/audit-logs", r.URL.Path)
+		assert.Empty(t, r.URL.RawQuery, "no filters → no query string")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedAuditLogs{
+			Data:  []types.AuditLogEntry{{ID: "a1", Action: "stack.deploy"}},
+			Total: 1, Limit: 25,
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.ListAuditLogs(types.AuditLogListParams{})
+	require.NoError(t, err)
+	require.Len(t, got.Data, 1)
+	assert.Equal(t, "a1", got.Data[0].ID)
+}
+
+func TestListAuditLogs_ForwardsFilters(t *testing.T) {
+	t.Parallel()
+	start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		assert.Equal(t, "u-1", q.Get("user_id"))
+		assert.Equal(t, "stack.deploy", q.Get("action"))
+		assert.Equal(t, "stack", q.Get("entity_type"))
+		assert.Equal(t, "s-9", q.Get("entity_id"))
+		assert.Equal(t, "cur-x", q.Get("cursor"))
+		assert.Equal(t, "100", q.Get("limit"))
+		assert.Equal(t, "50", q.Get("offset"))
+		assert.Equal(t, start.Format(time.RFC3339), q.Get("start_date"))
+		assert.Equal(t, end.Format(time.RFC3339), q.Get("end_date"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	_, err := c.ListAuditLogs(types.AuditLogListParams{
+		UserID: "u-1", Action: "stack.deploy", EntityType: "stack", EntityID: "s-9",
+		Cursor: "cur-x", Limit: 100, Offset: 50,
+		StartDate: &start, EndDate: &end,
+	})
+	require.NoError(t, err)
+}
+
+func TestExportAuditLogs_CSVStreamsRawBody(t *testing.T) {
+	t.Parallel()
+	// Build a CSV that exercises the standard CSV quoting tokens: embedded
+	// commas, embedded newlines, embedded double quotes. The client must
+	// return the body byte-for-byte so the on-disk CSV remains valid.
+	csv := "ID,Details\r\n" +
+		"a1,\"value,with,commas\"\r\n" +
+		"a2,\"line1\nline2\"\r\n" +
+		"a3,\"quote\"\"inside\"\r\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/audit-logs/export", r.URL.Path)
+		assert.Equal(t, "csv", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte(csv))
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.ExportAuditLogs("csv", types.AuditLogListParams{})
+	require.NoError(t, err)
+	assert.Equal(t, csv, string(got), "client must stream raw bytes — no re-encoding")
+}
+
+func TestExportAuditLogs_JSONStreamsRawBody(t *testing.T) {
+	t.Parallel()
+	body := []byte(`[{"id":"a1","action":"stack.deploy"},{"id":"a2","action":"stack.stop"}]`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "json", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.ExportAuditLogs("json", types.AuditLogListParams{})
+	require.NoError(t, err)
+	assert.Equal(t, body, got)
+}
+
+func TestExportAuditLogs_Forbidden(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "csv", r.URL.Query().Get("format"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	data, err := c.ExportAuditLogs("csv", types.AuditLogListParams{})
+	require.Error(t, err)
+	assert.Nil(t, data)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
+func TestAuditLogsClient_APIErrorMatrix(t *testing.T) {
+	t.Parallel()
+	statuses := []int{http.StatusUnauthorized, http.StatusNotFound, http.StatusInternalServerError}
+	calls := []struct {
+		name string
+		call func(c *Client) error
+	}{
+		{"List", func(c *Client) error { _, err := c.ListAuditLogs(types.AuditLogListParams{}); return err }},
+		{"ExportJSON", func(c *Client) error { _, err := c.ExportAuditLogs("json", types.AuditLogListParams{}); return err }},
+		{"ExportCSV", func(c *Client) error { _, err := c.ExportAuditLogs("csv", types.AuditLogListParams{}); return err }},
+	}
+	for _, call := range calls {
+		call := call
+		for _, status := range statuses {
+			status := status
+			t.Run(fmt.Sprintf("%s_%d", call.name, status), func(t *testing.T) {
+				t.Parallel()
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(status)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "x"})
+				}))
+				defer server.Close()
+				c := New(server.URL)
+				err := call.call(c)
+				require.Error(t, err)
+				var apiErr *APIError
+				require.ErrorAs(t, err, &apiErr)
+				assert.Equal(t, status, apiErr.StatusCode)
+			})
+		}
+	}
+}
+
 // ---------- shared values ----------
 
 func TestListSharedValues_Success(t *testing.T) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -275,6 +275,61 @@ type UserStats struct {
 	Username      string     `json:"username" yaml:"username"`
 }
 
+// AuditLogEntry is one row in the audit log. Mirrors backend models.AuditLog.
+//
+// Population: only returned on HTTP 200 (list endpoint). The export endpoint
+// returns the same shape inside a top-level JSON array, or as a CSV with the
+// header order documented in the export godoc — not this struct.
+//
+// Field declaration order is ALPHABETICAL by json tag so encoding/json
+// emits keys in stable alphabetical order — required for golden-file
+// JSON comparisons in tests. Do not reorder.
+type AuditLogEntry struct {
+	Action     string    `json:"action" yaml:"action"`
+	Details    string    `json:"details" yaml:"details"`
+	EntityID   string    `json:"entity_id" yaml:"entity_id"`
+	EntityType string    `json:"entity_type" yaml:"entity_type"`
+	ID         string    `json:"id" yaml:"id"`
+	Timestamp  time.Time `json:"timestamp" yaml:"timestamp"`
+	UserID     string    `json:"user_id" yaml:"user_id"`
+	Username   string    `json:"username" yaml:"username"`
+}
+
+// PaginatedAuditLogs is the success-path response of GET /api/v1/audit-logs.
+// Mirrors backend models.PaginatedAuditLogs.
+//
+// Population: only returned on HTTP 200. NextCursor is empty when no more
+// pages exist; offset-based pagination is also supported via Limit/Offset.
+//
+// Field declaration order is alphabetical by json tag (see AuditLogEntry).
+type PaginatedAuditLogs struct {
+	Data       []AuditLogEntry `json:"data" yaml:"data"`
+	Limit      int             `json:"limit" yaml:"limit"`
+	NextCursor string          `json:"next_cursor,omitempty" yaml:"next_cursor,omitempty"`
+	Offset     int             `json:"offset" yaml:"offset"`
+	Total      int64           `json:"total" yaml:"total"`
+}
+
+// AuditLogListParams holds the query parameters accepted by GET /api/v1/audit-logs
+// and GET /api/v1/audit-logs/export. The client forwards only the fields the
+// caller sets — empty strings and zero ints are omitted from the wire request.
+//
+// StartDate / EndDate are formatted as RFC3339 before being sent — the backend
+// rejects any other format with HTTP 400. The CLI translates --since/--until
+// shorthand (e.g. "24h") to absolute RFC3339 timestamps before populating this
+// struct.
+type AuditLogListParams struct {
+	StartDate  *time.Time
+	EndDate    *time.Time
+	UserID     string
+	EntityType string
+	EntityID   string
+	Action     string
+	Cursor     string
+	Limit      int
+	Offset     int
+}
+
 // CreateStackRequest is the request body for POST /api/v1/stack-instances.
 // It contains only the writable fields — server-owned fields like ID, owner,
 // namespace, status are excluded to avoid backend validation errors.

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -318,16 +318,21 @@ type PaginatedAuditLogs struct {
 // rejects any other format with HTTP 400. The CLI translates --since/--until
 // shorthand (e.g. "24h") to absolute RFC3339 timestamps before populating this
 // struct.
+//
+// The struct is never sent as a body — fields are flattened to URL query
+// parameters by client.auditLogParamsToQuery. The json/yaml tags are present
+// for consistency with the cli/pkg/types convention (every exported field has
+// both tags) and so the struct can be safely printed by debugging code.
 type AuditLogListParams struct {
-	StartDate  *time.Time
-	EndDate    *time.Time
-	UserID     string
-	EntityType string
-	EntityID   string
-	Action     string
-	Cursor     string
-	Limit      int
-	Offset     int
+	StartDate  *time.Time `json:"start_date,omitempty" yaml:"start_date,omitempty"`
+	EndDate    *time.Time `json:"end_date,omitempty" yaml:"end_date,omitempty"`
+	UserID     string     `json:"user_id,omitempty" yaml:"user_id,omitempty"`
+	EntityType string     `json:"entity_type,omitempty" yaml:"entity_type,omitempty"`
+	EntityID   string     `json:"entity_id,omitempty" yaml:"entity_id,omitempty"`
+	Action     string     `json:"action,omitempty" yaml:"action,omitempty"`
+	Cursor     string     `json:"cursor,omitempty" yaml:"cursor,omitempty"`
+	Limit      int        `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Offset     int        `json:"offset,omitempty" yaml:"offset,omitempty"`
 }
 
 // CreateStackRequest is the request body for POST /api/v1/stack-instances.

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -15,6 +17,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/omattsson/stackctl/cli/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2609,4 +2612,93 @@ func TestE2EAnalyticsOverviewJSONParses(t *testing.T) {
 	assert.Equal(t, 3, got.RunningInstances)
 	assert.Equal(t, 42, got.TotalDeploys)
 	assert.Equal(t, 7, got.TotalTemplates)
+}
+
+// startE2EAuditMockServer serves a deterministic audit log list and a CSV
+// export crafted to exercise CSV quoting rules (commas + newlines).
+func startE2EAuditMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/audit-logs":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(
+				`{"data":[{"id":"a1","action":"stack.deploy","entity_type":"stack","entity_id":"s-1","user_id":"u1","username":"alice","timestamp":"2026-05-01T10:00:00Z"}],"total":1,"limit":25,"offset":0}`))
+		case "/api/v1/audit-logs/export":
+			switch r.URL.Query().Get("format") {
+			case "csv":
+				w.Header().Set("Content-Type", "text/csv")
+				_, _ = w.Write([]byte(
+					"ID,Timestamp,Action,Details\r\n" +
+						"a1,2026-05-01T10:00:00Z,stack.deploy,\"value,with,commas\"\r\n"))
+			default:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[{"id":"a1","action":"stack.deploy"}]`))
+			}
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}
+	}))
+}
+
+// TestE2EAuditLogExportCSVProducesValidFile builds the binary, runs
+// `stackctl audit log export --format csv --output-file …`, and asserts the
+// file on disk parses as well-formed CSV (i.e. embedded commas/newlines are
+// quoted correctly per RFC 4180).
+func TestE2EAuditLogExportCSVProducesValidFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EAuditMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	csvPath := filepath.Join(dir, "audit.csv")
+	stdout, stderr, err := runStackctl(t, dir,
+		"audit", "log", "export",
+		"--format", "csv",
+		"--output-file", csvPath,
+	)
+	require.NoError(t, err, "stderr=%q stdout=%q", stderr, stdout)
+
+	written, err := os.ReadFile(csvPath)
+	require.NoError(t, err)
+
+	// Real CSV parser: if quoting is wrong (e.g. value,with,commas split
+	// across three columns) this fails.
+	records, err := csv.NewReader(bytes.NewReader(written)).ReadAll()
+	require.NoError(t, err, "exported file must be valid CSV: %q", string(written))
+	require.GreaterOrEqual(t, len(records), 2, "header + ≥1 row")
+	dataRow := records[1]
+	// "value,with,commas" must arrive as ONE field, not three.
+	assert.Contains(t, dataRow, "value,with,commas",
+		"quoted comma field must survive round-trip; got row %v", dataRow)
+}
+
+// TestE2EAuditLogListJSON proves the list command produces valid JSON the
+// operator can pipe to jq.
+func TestE2EAuditLogListJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EAuditMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, stderr, err := runStackctl(t, dir, "audit", "log", "list", "-o", "json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var got types.PaginatedAuditLogs
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	require.Len(t, got.Data, 1)
+	assert.Equal(t, "stack.deploy", got.Data[0].Action)
 }

--- a/cli/test/integration/audit_integration_test.go
+++ b/cli/test/integration/audit_integration_test.go
@@ -145,8 +145,18 @@ func TestAuditCobra_ListAndExport(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// resetAll wraps the standard root flag reset with the audit-specific
+	// reset because ResetFlagsForTest only touches rootCmd's persistent
+	// flags — the persistent filter flags on `audit log` (--user/--since/…)
+	// would otherwise leak from one Execute() call to the next within a
+	// single test process.
+	resetAll := func() {
+		cmd.ResetFlagsForTest()
+		cmd.ResetAuditFlagsForTest()
+	}
+
 	// audit log list — default table output
-	cmd.ResetFlagsForTest()
+	resetAll()
 	buf.Reset()
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{"audit", "log", "list"})
@@ -156,15 +166,17 @@ func TestAuditCobra_ListAndExport(t *testing.T) {
 
 	// audit log list --user u-1 (filter forwarding; we only assert success
 	// here — the unit tests verify the wire format).
-	cmd.ResetFlagsForTest()
+	resetAll()
 	buf.Reset()
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{"audit", "log", "list", "--user", "u-1", "--since", "24h"})
 	require.NoError(t, cmd.Execute())
 
-	// audit log export → CSV to file
+	// audit log export → CSV to file. The previous Execute set --user and
+	// --since; without resetAll, those would persist into the export call
+	// and silently filter the CSV server-side.
 	csvPath := filepath.Join(t.TempDir(), "audit.csv")
-	cmd.ResetFlagsForTest()
+	resetAll()
 	buf.Reset()
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{"audit", "log", "export", "--format", "csv", "--output-file", csvPath})
@@ -193,6 +205,7 @@ func TestAuditCobra_ExportForbiddenForDevops(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd.ResetFlagsForTest()
+	cmd.ResetAuditFlagsForTest()
 	cmd.SetOut(&buf)
 	cmd.SetArgs([]string{"audit", "log", "export", "--format", "json"})
 	err := cmd.Execute()

--- a/cli/test/integration/audit_integration_test.go
+++ b/cli/test/integration/audit_integration_test.go
@@ -1,0 +1,201 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/cmd"
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startAuditMockServer mirrors the role gating of the real backend:
+//   - /api/v1/audit-logs           → any authenticated user
+//   - /api/v1/audit-logs/export    → admin-only (returns 403 otherwise)
+//
+// Filter params are echoed back so tests can prove the CLI is forwarding
+// them. CSV bodies include intentionally tricky quoting (commas + newlines
+// + embedded quotes) so the client's "stream the raw bytes" contract is
+// exercised end-to-end.
+func startAuditMockServer(t *testing.T, role string) *httptest.Server {
+	t.Helper()
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 2, 11, 30, 0, 0, time.UTC)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/audit-logs":
+			w.Header().Set("Content-Type", "application/json")
+			// Echo a single deterministic entry so tests can assert content.
+			_ = json.NewEncoder(w).Encode(types.PaginatedAuditLogs{
+				Data: []types.AuditLogEntry{
+					{ID: "a1", Action: "stack.deploy", Timestamp: t1, UserID: "u1", Username: "alice", EntityType: "stack", EntityID: "s-1"},
+					{ID: "a2", Action: "template.publish", Timestamp: t2, UserID: "u2", Username: "bob", EntityType: "template", EntityID: "tpl-9"},
+				},
+				Total:  2,
+				Limit:  25,
+				Offset: 0,
+			})
+		case "/api/v1/audit-logs/export":
+			if role != "admin" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "admin role required"})
+				return
+			}
+			switch r.URL.Query().Get("format") {
+			case "csv":
+				w.Header().Set("Content-Type", "text/csv")
+				_, _ = w.Write([]byte(
+					"ID,Timestamp,UserID,Username,Action,EntityType,EntityID,Details\r\n" +
+						"a1,2026-05-01T10:00:00Z,u1,alice,stack.deploy,stack,s-1,\"value,with,commas\"\r\n" +
+						"a2,2026-05-02T11:30:00Z,u2,bob,template.publish,template,tpl-9,\"line1\nline2\"\r\n"))
+			default:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`[{"id":"a1","action":"stack.deploy"}]`))
+			}
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+		}
+	}))
+}
+
+// TestAuditWorkflow_ListAndExportViaClient exercises the client-layer
+// methods directly — no Cobra. Proves that role gating, filter forwarding,
+// and CSV streaming all work end-to-end with the real HTTP transport.
+func TestAuditWorkflow_ListAndExportViaClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	server := startAuditMockServer(t, "admin")
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	page, err := c.ListAuditLogs(types.AuditLogListParams{})
+	require.NoError(t, err)
+	require.Len(t, page.Data, 2)
+	assert.Equal(t, "stack.deploy", page.Data[0].Action)
+
+	data, err := c.ExportAuditLogs("json", types.AuditLogListParams{})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"action":"stack.deploy"`)
+
+	csv, err := c.ExportAuditLogs("csv", types.AuditLogListParams{})
+	require.NoError(t, err)
+	// The "value,with,commas" detail row must arrive with its quoting intact
+	// — otherwise CSV parsers on the operator's machine would split it into
+	// three columns. This is the test the "CSV quotes commas correctly"
+	// acceptance criterion locks in.
+	assert.Contains(t, string(csv), `"value,with,commas"`)
+	// Embedded newline must also be preserved.
+	assert.Contains(t, string(csv), "\"line1\nline2\"")
+}
+
+// TestAuditWorkflow_ExportForbiddenForNonAdmin asserts that the 403 on
+// export surfaces as APIError with the right status, separate from a 200
+// on the list endpoint same session.
+func TestAuditWorkflow_ExportForbiddenForNonAdmin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	server := startAuditMockServer(t, "devops")
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	// devops can list...
+	_, err := c.ListAuditLogs(types.AuditLogListParams{})
+	require.NoError(t, err)
+
+	// ...but cannot export.
+	_, err = c.ExportAuditLogs("csv", types.AuditLogListParams{})
+	require.Error(t, err)
+	var apiErr *client.APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusForbidden, apiErr.StatusCode)
+}
+
+// TestAuditCobra_ListAndExport exercises the full Cobra invocation path,
+// proving that filter flags wire through to the client correctly.
+func TestAuditCobra_ListAndExport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	server := startAuditMockServer(t, "admin")
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+
+	// audit log list — default table output
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"audit", "log", "list"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "stack.deploy")
+	assert.Contains(t, buf.String(), "alice")
+
+	// audit log list --user u-1 (filter forwarding; we only assert success
+	// here — the unit tests verify the wire format).
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"audit", "log", "list", "--user", "u-1", "--since", "24h"})
+	require.NoError(t, cmd.Execute())
+
+	// audit log export → CSV to file
+	csvPath := filepath.Join(t.TempDir(), "audit.csv")
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"audit", "log", "export", "--format", "csv", "--output-file", csvPath})
+	require.NoError(t, cmd.Execute())
+	written, err := os.ReadFile(csvPath)
+	require.NoError(t, err)
+	// Same quoting assertion as the client-layer test, just one layer up.
+	assert.Contains(t, string(written), `"value,with,commas"`)
+	// The output should report the destination, not dump the body to stdout.
+	assert.Contains(t, buf.String(), csvPath)
+	assert.NotContains(t, buf.String(), "value,with,commas")
+}
+
+// TestAuditCobra_ExportForbiddenForDevops verifies that the 403 from a
+// non-admin export attempt propagates as a non-zero cobra exit.
+func TestAuditCobra_ExportForbiddenForDevops(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	server := startAuditMockServer(t, "devops")
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+	cmd.ResetFlagsForTest()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"audit", "log", "export", "--format", "json"})
+	err := cmd.Execute()
+	require.Error(t, err, "non-admin export must exit non-zero")
+	assert.Contains(t, strings.ToLower(err.Error()), "permission denied")
+}


### PR DESCRIPTION
## Summary
- New `stackctl audit log list` + `stackctl audit log export` against `/api/v1/audit-logs[/export]`.
- Filter flags (`--user --action --entity-type --entity-id --since --until`) registered as `PersistentFlags` on the `audit log` group so list and export share state without double-binding the same vars.
- `--since` / `--until` accept either RFC3339 (`2026-05-01T00:00:00Z`) or a Go duration (`24h`, `30m`); invalid input is rejected before any API call.
- `audit log export` streams the server's CSV byte-for-byte (no CLI re-encoding); 25MB `LimitReader` cap.
- Defense-in-depth guard on `--output-file` rejecting `..` segments; file written with `0600`.

## Acceptance criteria

- [x] CSV export quotes embedded commas/newlines correctly — verified at all 4 test layers, including a real `encoding/csv.NewReader` round-trip in the e2e test.
- [x] Filters forwarded as query params — asserted in cmd + client tests.
- [x] `--since` / `--until` accept RFC3339 OR relative duration — covered by `TestParseTimeFlag` table.
- [x] Admin gate on export surfaces as "Permission denied" at both client and Cobra layers.

## Test plan

- [x] `go test ./... -count=1` green
- [x] `go vet ./...` clean
- [x] Unit (`cli/cmd/audit_test.go`, additions in `cli/pkg/client/client_test.go`)
- [x] Integration (`cli/test/integration/audit_integration_test.go`)
- [x] E2E (additions in `cli/test/e2e/cli_e2e_test.go`)

Tracks #59
Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI audit commands: list and export with filters (user/action/entity) and time-range via RFC3339 or relative durations
  * Export to JSON or CSV (streams raw bytes); CSV preserves quoting, commas, and newlines
  * Output modes: table (truncated details + next-cursor hint), JSON, YAML, quiet (IDs only)

* **Bug Fixes / Behavior**
  * Export validates format and rejects unsafe output paths; export reports destination when writing to file

* **Tests**
  * Added comprehensive unit, integration, and e2e tests covering parsing, output modes, exports, and permission errors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->