### PR TITLE
feat(notification): list/count/read + preferences

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,6 +43,9 @@ reviews:
             cluster utilization → namespace names
             cluster health → derived status label (healthy/degraded/unknown)
             cluster test-connection → connection status string (success/error)
+            notification prefs get/set → event_type names (the (user_id,
+              event_type) tuple is the backend primary key; opaque UUID IDs
+              are useless for scripting like `prefs get -q | grep failed`)
         - Destructive commands require --yes flag and stderr confirmation prompt
         - All API calls go through pkg/client via newClient()
         - parseID() for sub-resource IDs; resolveStackID() (and the

--- a/.github/instructions/commands.instructions.md
+++ b/.github/instructions/commands.instructions.md
@@ -39,6 +39,7 @@ default:
   - `cluster utilization <id>` → prints namespace names via `printer.PrintIDs`
   - `cluster health <id>` → prints the derived status label (`healthy`/`degraded`/`unknown`) via `fmt.Fprintln(printer.Writer, deriveHealthStatus(health))`
   - `cluster test-connection <id>` → prints `result.Status` (only on 2xx responses; non-2xx surfaces as an `APIError` command error, nothing is printed to stdout) via `fmt.Fprintln(printer.Writer, result.Status)`
+  - `notification prefs get` / `notification prefs set` → prints `event_type` for each preference. Preferences are keyed by `(user_id, event_type)` server-side, so `EventType` is the stable functional identifier; the database UUID `ID` field is opaque and unstable across resets, so scripting like `prefs get -q \| grep failed` requires the event type.
 
 ## Destructive Operations
 Commands that delete or clean resources must:

--- a/cli/cmd/notification.go
+++ b/cli/cmd/notification.go
@@ -60,6 +60,12 @@ Examples:
   stackctl notification list --quiet`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if notifFlagLimit < 0 {
+			return fmt.Errorf("--limit must be >= 0")
+		}
+		if notifFlagOffset < 0 {
+			return fmt.Errorf("--offset must be >= 0")
+		}
 		c, err := newClient()
 		if err != nil {
 			return err
@@ -226,6 +232,13 @@ Examples:
 		}
 
 		if printer.Quiet {
+			// Documented quiet-mode exception: notification preferences are
+			// keyed by (user_id, event_type) server-side, so EventType is the
+			// stable functional identifier — the UUID `ID` is opaque database
+			// state that changes when a row is recreated and is useless for
+			// scripting ("disable stack.deploy.failed" rather than "disable
+			// 7f3c…"). Listed in .coderabbit.yaml alongside the other docu-
+			// mented exceptions (cluster nodes/namespaces, orphaned list).
 			for _, p := range prefs {
 				fmt.Fprintln(printer.Writer, p.EventType)
 			}
@@ -318,6 +331,7 @@ Examples:
 		}
 
 		if printer.Quiet {
+			// Same documented quiet-mode exception as prefs get above.
 			for _, p := range updated {
 				fmt.Fprintln(printer.Writer, p.EventType)
 			}

--- a/cli/cmd/notification.go
+++ b/cli/cmd/notification.go
@@ -1,0 +1,374 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// notificationCmd is the top-level group. The `prefs` subgroup mirrors the
+// backend grouping of /api/v1/notifications/preferences and leaves the
+// single-noun verbs (list/count/read) at the same level as the API's
+// path structure.
+var notificationCmd = &cobra.Command{
+	Use:     "notification",
+	Aliases: []string{"notifications"},
+	Short:   "List, mark, and configure in-app notifications",
+	Long: `Read and manage the authenticated user's in-app notifications.
+
+  list      — paginated list (table/json/yaml/quiet)
+  count     — unread count for the current user (badge value)
+  read      — mark a single notification as read
+  read-all  — mark every notification as read
+  prefs get — list notification preferences
+  prefs set — update notification preferences from a JSON file
+
+All endpoints require an authenticated session and operate on the calling
+user's own data (ownership is enforced server-side).`,
+}
+
+var (
+	notifFlagUnreadOnly bool
+	notifFlagLimit      int
+	notifFlagOffset     int
+
+	notifPrefsFlagFile string
+)
+
+var notificationListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List notifications",
+	Long: `List the authenticated user's notifications.
+
+The server caps the page size at 100. Use --unread-only to filter to unread
+notifications. The table footer reports the unread count (badge value)
+returned by the server alongside the page; --quiet prints just the IDs.
+
+Examples:
+  stackctl notification list
+  stackctl notification list --unread-only --limit 50
+  stackctl notification list -o json
+  stackctl notification list --quiet`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		page, err := c.ListNotifications(client.NotificationListParams{
+			UnreadOnly: notifFlagUnreadOnly,
+			Limit:      notifFlagLimit,
+			Offset:     notifFlagOffset,
+		})
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, n := range page.Notifications {
+				fmt.Fprintln(printer.Writer, n.ID)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(page)
+		case output.FormatYAML:
+			return printer.PrintYAML(page)
+		default:
+			if len(page.Notifications) == 0 {
+				printer.PrintMessage("No notifications.")
+				return nil
+			}
+			headers := []string{"ID", "TYPE", "READ", "CREATED", "TITLE"}
+			rows := make([][]string, len(page.Notifications))
+			for i, n := range page.Notifications {
+				rows[i] = []string{
+					n.ID,
+					n.Type,
+					strconv.FormatBool(n.IsRead),
+					n.CreatedAt.UTC().Format("2006-01-02 15:04"),
+					truncate(n.Title, 60),
+				}
+			}
+			if err := printer.PrintTable(headers, rows); err != nil {
+				return err
+			}
+			printer.PrintMessage("(%d unread of %d total)", page.UnreadCount, page.Total)
+			return nil
+		}
+	},
+}
+
+var notificationCountCmd = &cobra.Command{
+	Use:   "count",
+	Short: "Print the unread notification count",
+	Long: `Print the unread notification count for the authenticated user.
+
+In table mode (default) the output is a single integer suitable for shell
+scripting; -o json wraps it in {"unread_count": N} matching the server
+response shape.
+
+Examples:
+  stackctl notification count          # 7
+  stackctl notification count -o json  # {"unread_count":7}`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		count, err := c.CountUnreadNotifications()
+		if err != nil {
+			return err
+		}
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(types.UnreadCountResponse{UnreadCount: count})
+		case output.FormatYAML:
+			return printer.PrintYAML(types.UnreadCountResponse{UnreadCount: count})
+		default:
+			fmt.Fprintln(printer.Writer, count)
+			return nil
+		}
+	},
+}
+
+var notificationReadCmd = &cobra.Command{
+	Use:   "read <id>",
+	Short: "Mark a notification as read",
+	Long: `Mark a single notification as read. The backend verifies ownership
+and returns 404 (surfaced as "Resource not found") if the notification
+belongs to a different user or does not exist.
+
+Examples:
+  stackctl notification read abc-123`,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id, err := parseID(args[0])
+		if err != nil {
+			return err
+		}
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		if err := c.MarkNotificationAsRead(id); err != nil {
+			return err
+		}
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, id)
+		} else {
+			printer.PrintMessage("Marked notification %s as read.", id)
+		}
+		return nil
+	},
+}
+
+var notificationReadAllCmd = &cobra.Command{
+	Use:   "read-all",
+	Short: "Mark every notification as read",
+	Long: `Mark every notification for the authenticated user as read in
+a single request.
+
+Examples:
+  stackctl notification read-all`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		if err := c.MarkAllNotificationsAsRead(); err != nil {
+			return err
+		}
+		if !printer.Quiet {
+			printer.PrintMessage("Marked all notifications as read.")
+		}
+		return nil
+	},
+}
+
+var notificationPrefsCmd = &cobra.Command{
+	Use:   "prefs",
+	Short: "Get/set notification preferences",
+}
+
+var notificationPrefsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "List notification preferences",
+	Long: `List the authenticated user's notification preferences (event
+type, enabled flag, delivery channel).
+
+Examples:
+  stackctl notification prefs get
+  stackctl notification prefs get -o json`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		prefs, err := c.GetNotificationPreferences()
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, p := range prefs {
+				fmt.Fprintln(printer.Writer, p.EventType)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(prefs)
+		case output.FormatYAML:
+			return printer.PrintYAML(prefs)
+		default:
+			if len(prefs) == 0 {
+				printer.PrintMessage("No notification preferences configured.")
+				return nil
+			}
+			headers := []string{"EVENT TYPE", "ENABLED", "CHANNEL"}
+			rows := make([][]string, len(prefs))
+			for i, p := range prefs {
+				rows[i] = []string{p.EventType, strconv.FormatBool(p.Enabled), p.Channel}
+			}
+			return printer.PrintTable(headers, rows)
+		}
+	},
+}
+
+var notificationPrefsSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Update notification preferences from a JSON file",
+	Long: `Update notification preferences. The file must contain a JSON
+array of preference objects:
+
+  [
+    {"event_type": "stack.deploy.failed", "enabled": true, "channel": "in_app"},
+    {"event_type": "stack.deploy.succeeded", "enabled": false}
+  ]
+
+The "channel" field is optional and defaults to "in_app" server-side.
+An empty array, or any element with an empty event_type, is rejected
+with HTTP 400.
+
+The roundtrip "prefs get -o json | edit | prefs set --from-file -" works
+because GET returns the same shape PUT accepts (with id and user_id
+ignored on the wire). Pass "-" as the filename to read from stdin.
+
+Examples:
+  stackctl notification prefs set --from-file prefs.json
+  stackctl notification prefs get -o json > p.json && stackctl notification prefs set --from-file p.json`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if notifPrefsFlagFile == "" {
+			return fmt.Errorf("--from-file is required")
+		}
+
+		var data []byte
+		if notifPrefsFlagFile == "-" {
+			b, err := readAllStdin(cmd)
+			if err != nil {
+				return fmt.Errorf("reading stdin: %w", err)
+			}
+			data = b
+		} else {
+			for _, segment := range strings.Split(filepath.ToSlash(notifPrefsFlagFile), "/") {
+				if segment == ".." {
+					return fmt.Errorf("input file path must not contain '..' segments")
+				}
+			}
+			b, err := os.ReadFile(filepath.Clean(notifPrefsFlagFile))
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", notifPrefsFlagFile, err)
+			}
+			data = b
+		}
+
+		var prefs []types.NotificationPreference
+		if err := json.Unmarshal(data, &prefs); err != nil {
+			return fmt.Errorf("invalid JSON in %s: %w", notifPrefsFlagFile, err)
+		}
+		if len(prefs) == 0 {
+			return fmt.Errorf("at least one preference is required")
+		}
+
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		updated, err := c.UpdateNotificationPreferences(prefs)
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, p := range updated {
+				fmt.Fprintln(printer.Writer, p.EventType)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(updated)
+		case output.FormatYAML:
+			return printer.PrintYAML(updated)
+		default:
+			printer.PrintMessage("Updated %d notification preferences.", len(updated))
+			return nil
+		}
+	},
+}
+
+// readAllStdin reads cmd.InOrStdin() into a byte slice. Extracted so the
+// notification prefs set command can be unit-tested with a custom reader.
+func readAllStdin(cmd *cobra.Command) ([]byte, error) {
+	return io.ReadAll(cmd.InOrStdin())
+}
+
+func init() {
+	notificationListCmd.Flags().BoolVar(&notifFlagUnreadOnly, "unread-only", false, "Only return unread notifications")
+	notificationListCmd.Flags().IntVar(&notifFlagLimit, "limit", 0, "Page size (default 20, max 100)")
+	notificationListCmd.Flags().IntVar(&notifFlagOffset, "offset", 0, "Pagination offset")
+
+	notificationPrefsSetCmd.Flags().StringVar(&notifPrefsFlagFile, "from-file", "", "Path to a JSON array of preference objects (use '-' for stdin)")
+
+	notificationPrefsCmd.AddCommand(notificationPrefsGetCmd)
+	notificationPrefsCmd.AddCommand(notificationPrefsSetCmd)
+
+	notificationCmd.AddCommand(notificationListCmd)
+	notificationCmd.AddCommand(notificationCountCmd)
+	notificationCmd.AddCommand(notificationReadCmd)
+	notificationCmd.AddCommand(notificationReadAllCmd)
+	notificationCmd.AddCommand(notificationPrefsCmd)
+
+	rootCmd.AddCommand(notificationCmd)
+}
+
+// ResetNotificationFlagsForTest clears the notification command flag vars
+// between in-process Cobra invocations. Subcommand flags are NOT covered
+// by ResetFlagsForTest.
+func ResetNotificationFlagsForTest() {
+	notifFlagUnreadOnly = false
+	notifFlagLimit = 0
+	notifFlagOffset = 0
+	notifPrefsFlagFile = ""
+}
+
+func resetNotificationFlagsForTest() { ResetNotificationFlagsForTest() }

--- a/cli/cmd/notification_test.go
+++ b/cli/cmd/notification_test.go
@@ -191,6 +191,36 @@ func TestNotificationCountCmd_JSONOutput(t *testing.T) {
 	assert.Equal(t, int64(7), got.UnreadCount)
 }
 
+func TestNotificationCountCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.UnreadCountResponse{UnreadCount: 7})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+	require.NoError(t, notificationCountCmd.RunE(notificationCountCmd, []string{}))
+	assert.Contains(t, buf.String(), "unread_count: 7")
+}
+
+// TestNotificationCountCmd_QuietOutput documents that --quiet on `count`
+// falls through to the scalar table path (a single integer). There is no
+// list of identifiers to suppress — and a count IS already the shell-
+// scriptable form — so it behaves identically to default table mode.
+func TestNotificationCountCmd_QuietOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.UnreadCountResponse{UnreadCount: 7})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, notificationCountCmd.RunE(notificationCountCmd, []string{}))
+	assert.Equal(t, "7", strings.TrimSpace(buf.String()))
+}
+
 // ---------- notification read ----------
 
 func TestNotificationReadCmd_Success(t *testing.T) {
@@ -205,6 +235,20 @@ func TestNotificationReadCmd_Success(t *testing.T) {
 	buf := setupStackTestCmd(t, server.URL)
 	require.NoError(t, notificationReadCmd.RunE(notificationReadCmd, []string{"n1"}))
 	assert.Contains(t, buf.String(), "Marked notification n1 as read")
+}
+
+func TestNotificationReadCmd_QuietPrintsID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, notificationReadCmd.RunE(notificationReadCmd, []string{"n1"}))
+	assert.Equal(t, "n1", strings.TrimSpace(buf.String()))
+	assert.NotContains(t, buf.String(), "Marked")
 }
 
 func TestNotificationReadCmd_404(t *testing.T) {
@@ -236,6 +280,23 @@ func TestNotificationReadAllCmd_Success(t *testing.T) {
 	assert.Contains(t, buf.String(), "Marked all notifications as read")
 }
 
+// TestNotificationReadAllCmd_QuietSilent locks in the documented quiet
+// contract for read-all: there's no list of identifiers to emit, so quiet
+// mode suppresses the human-readable confirmation entirely. The empty
+// stdout is the signal — scripts rely on $? for success.
+func TestNotificationReadAllCmd_QuietSilent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, notificationReadAllCmd.RunE(notificationReadAllCmd, []string{}))
+	assert.Empty(t, strings.TrimSpace(buf.String()))
+}
+
 // ---------- notification prefs get ----------
 
 func TestNotificationPrefsGetCmd_TableOutput(t *testing.T) {
@@ -254,6 +315,38 @@ func TestNotificationPrefsGetCmd_TableOutput(t *testing.T) {
 	assert.Contains(t, out, "EVENT TYPE")
 	assert.Contains(t, out, "stack.deploy.failed")
 	assert.Contains(t, out, "in_app")
+}
+
+func TestNotificationPrefsGetCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+	require.NoError(t, notificationPrefsGetCmd.RunE(notificationPrefsGetCmd, []string{}))
+
+	var got []types.NotificationPreference
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, "stack.deploy.failed", got[0].EventType)
+}
+
+func TestNotificationPrefsGetCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+	require.NoError(t, notificationPrefsGetCmd.RunE(notificationPrefsGetCmd, []string{}))
+	out := buf.String()
+	assert.Contains(t, out, "event_type: stack.deploy.failed")
+	assert.Contains(t, out, "channel: in_app")
 }
 
 func TestNotificationPrefsGetCmd_QuietPrintsEventTypes(t *testing.T) {
@@ -314,6 +407,112 @@ func TestNotificationPrefsSetCmd_FromFile(t *testing.T) {
 	require.NoError(t, json.Unmarshal(gotBody, &sent))
 	require.Len(t, sent, 1)
 	assert.Equal(t, "stack.deploy.failed", sent[0].EventType)
+}
+
+func TestNotificationPrefsSetCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	printer.Format = output.FormatJSON
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prefs.json")
+	require.NoError(t, os.WriteFile(path, []byte(`[{"event_type":"x","enabled":true}]`), 0600))
+	notifPrefsFlagFile = path
+
+	require.NoError(t, notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{}))
+	var got []types.NotificationPreference
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+	// JSON mode must return the server's updated list, NOT the "Updated N…" message.
+	assert.NotContains(t, buf.String(), "Updated")
+}
+
+func TestNotificationPrefsSetCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	printer.Format = output.FormatYAML
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prefs.json")
+	require.NoError(t, os.WriteFile(path, []byte(`[{"event_type":"x","enabled":true}]`), 0600))
+	notifPrefsFlagFile = path
+
+	require.NoError(t, notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{}))
+	out := buf.String()
+	assert.Contains(t, out, "event_type: stack.deploy.failed")
+	assert.NotContains(t, out, "Updated")
+}
+
+func TestNotificationPrefsSetCmd_QuietPrintsEventTypes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	printer.Quiet = true
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prefs.json")
+	require.NoError(t, os.WriteFile(path, []byte(`[{"event_type":"x","enabled":true}]`), 0600))
+	notifPrefsFlagFile = path
+
+	require.NoError(t, notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{}))
+	got := strings.TrimSpace(buf.String())
+	assert.Equal(t, "stack.deploy.failed\nstack.deploy.succeeded", got)
+}
+
+// ---------- list pagination validation ----------
+
+func TestNotificationListCmd_NegativeLimitRejected(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	notifFlagLimit = -1
+	err := notificationListCmd.RunE(notificationListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--limit")
+	assert.False(t, called, "API must not be called when --limit is negative")
+}
+
+func TestNotificationListCmd_NegativeOffsetRejected(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	notifFlagOffset = -5
+	err := notificationListCmd.RunE(notificationListCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--offset")
+	assert.False(t, called, "API must not be called when --offset is negative")
 }
 
 func TestNotificationPrefsSetCmd_RequiresFlag(t *testing.T) {

--- a/cli/cmd/notification_test.go
+++ b/cli/cmd/notification_test.go
@@ -1,0 +1,413 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests here mutate package-level globals (printer, flagAPIURL, notifFlag*)
+// so they do NOT use t.Parallel().
+
+func sampleNotifications() []types.Notification {
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 2, 11, 30, 0, 0, time.UTC)
+	return []types.Notification{
+		{ID: "n1", Type: "stack.deploy.succeeded", Title: "Deploy succeeded", IsRead: false, CreatedAt: t1, UserID: "u1"},
+		{ID: "n2", Type: "stack.deploy.failed", Title: "Deploy failed", IsRead: true, CreatedAt: t2, UserID: "u1", Message: "exit 1", EntityType: "stack", EntityID: "s-1"},
+	}
+}
+
+func samplePrefs() []types.NotificationPreference {
+	return []types.NotificationPreference{
+		{EventType: "stack.deploy.failed", Enabled: true, Channel: "in_app", ID: "p1", UserID: "u1"},
+		{EventType: "stack.deploy.succeeded", Enabled: false, Channel: "in_app", ID: "p2", UserID: "u1"},
+	}
+}
+
+// ---------- notification list ----------
+
+func TestNotificationListCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/notifications", r.URL.Path)
+		require.Empty(t, r.URL.RawQuery, "no flags → no query string")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{
+			Notifications: sampleNotifications(), Total: 2, UnreadCount: 1,
+		})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	require.NoError(t, notificationListCmd.RunE(notificationListCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "stack.deploy.succeeded")
+	assert.Contains(t, out, "n1")
+	assert.Contains(t, out, "1 unread of 2 total")
+}
+
+func TestNotificationListCmd_FlagsForwardedAsQuery(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	notifFlagUnreadOnly = true
+	notifFlagLimit = 50
+	notifFlagOffset = 5
+	require.NoError(t, notificationListCmd.RunE(notificationListCmd, []string{}))
+
+	assert.Contains(t, gotQuery, "unread_only=true")
+	assert.Contains(t, gotQuery, "limit=50")
+	assert.Contains(t, gotQuery, "offset=5")
+}
+
+func TestNotificationListCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{
+			Notifications: sampleNotifications(), Total: 2, UnreadCount: 1,
+		})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	printer.Format = output.FormatJSON
+	require.NoError(t, notificationListCmd.RunE(notificationListCmd, []string{}))
+
+	var got types.PaginatedNotifications
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, int64(1), got.UnreadCount)
+	assert.Len(t, got.Notifications, 2)
+}
+
+func TestNotificationListCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{
+			Notifications: sampleNotifications(), Total: 2, UnreadCount: 1,
+		})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	printer.Format = output.FormatYAML
+	require.NoError(t, notificationListCmd.RunE(notificationListCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "unread_count: 1")
+	assert.Contains(t, out, "id: n1")
+}
+
+func TestNotificationListCmd_QuietOutputIDsOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{
+			Notifications: sampleNotifications(), Total: 2, UnreadCount: 1,
+		})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	printer.Quiet = true
+	require.NoError(t, notificationListCmd.RunE(notificationListCmd, []string{}))
+
+	got := strings.TrimSpace(buf.String())
+	assert.Equal(t, "n1\nn2", got)
+	assert.NotContains(t, got, "TYPE")
+}
+
+func TestNotificationListCmd_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	require.NoError(t, notificationListCmd.RunE(notificationListCmd, []string{}))
+
+	assert.Contains(t, buf.String(), "No notifications.")
+}
+
+// ---------- notification count ----------
+
+func TestNotificationCountCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/notifications/count", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.UnreadCountResponse{UnreadCount: 7})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, notificationCountCmd.RunE(notificationCountCmd, []string{}))
+	assert.Equal(t, "7", strings.TrimSpace(buf.String()))
+}
+
+func TestNotificationCountCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.UnreadCountResponse{UnreadCount: 7})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+	require.NoError(t, notificationCountCmd.RunE(notificationCountCmd, []string{}))
+
+	var got types.UnreadCountResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, int64(7), got.UnreadCount)
+}
+
+// ---------- notification read ----------
+
+func TestNotificationReadCmd_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/notifications/n1/read", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, notificationReadCmd.RunE(notificationReadCmd, []string{"n1"}))
+	assert.Contains(t, buf.String(), "Marked notification n1 as read")
+}
+
+func TestNotificationReadCmd_404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"notification not found"}`))
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	err := notificationReadCmd.RunE(notificationReadCmd, []string{"missing"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ---------- notification read-all ----------
+
+func TestNotificationReadAllCmd_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/notifications/read-all", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, notificationReadAllCmd.RunE(notificationReadAllCmd, []string{}))
+	assert.Contains(t, buf.String(), "Marked all notifications as read")
+}
+
+// ---------- notification prefs get ----------
+
+func TestNotificationPrefsGetCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/notifications/preferences", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, notificationPrefsGetCmd.RunE(notificationPrefsGetCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "EVENT TYPE")
+	assert.Contains(t, out, "stack.deploy.failed")
+	assert.Contains(t, out, "in_app")
+}
+
+func TestNotificationPrefsGetCmd_QuietPrintsEventTypes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, notificationPrefsGetCmd.RunE(notificationPrefsGetCmd, []string{}))
+	got := strings.TrimSpace(buf.String())
+	assert.Equal(t, "stack.deploy.failed\nstack.deploy.succeeded", got)
+}
+
+func TestNotificationPrefsGetCmd_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, notificationPrefsGetCmd.RunE(notificationPrefsGetCmd, []string{}))
+	assert.Contains(t, buf.String(), "No notification preferences configured.")
+}
+
+// ---------- notification prefs set ----------
+
+func TestNotificationPrefsSetCmd_FromFile(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/notifications/preferences", r.URL.Path)
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prefs.json")
+	payload := []byte(`[{"event_type":"stack.deploy.failed","enabled":true,"channel":"in_app"}]`)
+	require.NoError(t, os.WriteFile(path, payload, 0600))
+	notifPrefsFlagFile = path
+
+	require.NoError(t, notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{}))
+	assert.Contains(t, buf.String(), "Updated 2 notification preferences.")
+
+	// Roundtrip: the body we sent must equal what was on disk (after JSON
+	// normalization) — proves the CLI does not silently mutate the payload.
+	var sent []types.NotificationPreference
+	require.NoError(t, json.Unmarshal(gotBody, &sent))
+	require.Len(t, sent, 1)
+	assert.Equal(t, "stack.deploy.failed", sent[0].EventType)
+}
+
+func TestNotificationPrefsSetCmd_RequiresFlag(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	err := notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--from-file")
+}
+
+func TestNotificationPrefsSetCmd_EmptyArrayRejected(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.json")
+	require.NoError(t, os.WriteFile(path, []byte("[]"), 0600))
+	notifPrefsFlagFile = path
+	err := notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one preference")
+}
+
+func TestNotificationPrefsSetCmd_InvalidJSONRejected(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not-json"), 0600))
+	notifPrefsFlagFile = path
+	err := notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON")
+}
+
+func TestNotificationPrefsSetCmd_PathTraversalRejected(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	notifPrefsFlagFile = "../escape.json"
+	err := notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "..")
+}
+
+func TestNotificationPrefsSetCmd_FromStdin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(samplePrefs())
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetNotificationFlagsForTest()
+	defer resetNotificationFlagsForTest()
+	notifPrefsFlagFile = "-"
+
+	// Pipe the JSON via cmd.InOrStdin().
+	notificationPrefsSetCmd.SetIn(bytes.NewBufferString(`[{"event_type":"stack.deploy.failed","enabled":true}]`))
+	defer notificationPrefsSetCmd.SetIn(nil)
+	require.NoError(t, notificationPrefsSetCmd.RunE(notificationPrefsSetCmd, []string{}))
+}
+
+// ---------- API error mapping ----------
+
+func TestNotificationCmds_APIError401(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"login required"}`))
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{"list", func() error { return notificationListCmd.RunE(notificationListCmd, []string{}) }},
+		{"count", func() error { return notificationCountCmd.RunE(notificationCountCmd, []string{}) }},
+		{"read-all", func() error { return notificationReadAllCmd.RunE(notificationReadAllCmd, []string{}) }},
+		{"prefs get", func() error { return notificationPrefsGetCmd.RunE(notificationPrefsGetCmd, []string{}) }},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setupStackTestCmd(t, server.URL)
+			resetNotificationFlagsForTest()
+			defer resetNotificationFlagsForTest()
+			err := tc.run()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Not authenticated")
+		})
+	}
+}
+

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1502,3 +1502,85 @@ func encodeQueryParams(params map[string]string) string {
 	}
 	return q.Encode()
 }
+
+// NotificationListParams holds the optional query parameters for
+// ListNotifications. Empty / zero fields are omitted from the wire request.
+type NotificationListParams struct {
+	UnreadOnly bool
+	Limit      int
+	Offset     int
+}
+
+// ListNotifications returns a page of the authenticated user's notifications.
+// Backend defaults: limit=20 (max 100), offset=0, unread_only=false.
+//
+// @see GET /api/v1/notifications
+func (c *Client) ListNotifications(p NotificationListParams) (*types.PaginatedNotifications, error) {
+	q := map[string]string{}
+	if p.UnreadOnly {
+		q["unread_only"] = "true"
+	}
+	if p.Limit > 0 {
+		q["limit"] = strconv.Itoa(p.Limit)
+	}
+	if p.Offset > 0 {
+		q["offset"] = strconv.Itoa(p.Offset)
+	}
+	var resp types.PaginatedNotifications
+	if err := c.GetWithQuery("/api/v1/notifications", q, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CountUnreadNotifications returns the unread count for badge display.
+//
+// @see GET /api/v1/notifications/count
+func (c *Client) CountUnreadNotifications() (int64, error) {
+	var resp types.UnreadCountResponse
+	if err := c.Get("/api/v1/notifications/count", &resp); err != nil {
+		return 0, err
+	}
+	return resp.UnreadCount, nil
+}
+
+// MarkNotificationAsRead marks a single notification as read. The backend
+// verifies ownership and returns 404 if the notification belongs to another
+// user (or does not exist).
+//
+// @see POST /api/v1/notifications/{id}/read
+func (c *Client) MarkNotificationAsRead(id string) error {
+	return c.Post(fmt.Sprintf("/api/v1/notifications/%s/read", id), nil, nil)
+}
+
+// MarkAllNotificationsAsRead marks every notification for the authenticated
+// user as read in a single request.
+//
+// @see POST /api/v1/notifications/read-all
+func (c *Client) MarkAllNotificationsAsRead() error {
+	return c.Post("/api/v1/notifications/read-all", nil, nil)
+}
+
+// GetNotificationPreferences returns the user's notification preferences.
+//
+// @see GET /api/v1/notifications/preferences
+func (c *Client) GetNotificationPreferences() ([]types.NotificationPreference, error) {
+	var prefs []types.NotificationPreference
+	if err := c.Get("/api/v1/notifications/preferences", &prefs); err != nil {
+		return nil, err
+	}
+	return prefs, nil
+}
+
+// UpdateNotificationPreferences sends an array of preference updates and
+// returns the full updated preference list on success. The backend rejects
+// the request if any element has an empty event_type.
+//
+// @see PUT /api/v1/notifications/preferences
+func (c *Client) UpdateNotificationPreferences(prefs []types.NotificationPreference) ([]types.NotificationPreference, error) {
+	var resp []types.NotificationPreference
+	if err := c.Put("/api/v1/notifications/preferences", prefs, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -3251,6 +3251,173 @@ func TestAuditLogsClient_APIErrorMatrix(t *testing.T) {
 	}
 }
 
+// ---------- notifications ----------
+
+func TestListNotifications_NoFilters(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/notifications", r.URL.Path)
+		assert.Empty(t, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{
+			Notifications: []types.Notification{{ID: "n1", Type: "stack.deploy.failed"}},
+			Total:         1, UnreadCount: 1,
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.ListNotifications(NotificationListParams{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), got.UnreadCount)
+	require.Len(t, got.Notifications, 1)
+	assert.Equal(t, "n1", got.Notifications[0].ID)
+}
+
+func TestListNotifications_ForwardsFilters(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		assert.Equal(t, "true", q.Get("unread_only"))
+		assert.Equal(t, "50", q.Get("limit"))
+		assert.Equal(t, "10", q.Get("offset"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	_, err := c.ListNotifications(NotificationListParams{UnreadOnly: true, Limit: 50, Offset: 10})
+	require.NoError(t, err)
+}
+
+func TestCountUnreadNotifications_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/notifications/count", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"unread_count":42}`))
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.CountUnreadNotifications()
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), got)
+}
+
+func TestMarkNotificationAsRead_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/notifications/n1/read", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.MarkNotificationAsRead("n1"))
+}
+
+func TestMarkAllNotificationsAsRead_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/notifications/read-all", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.MarkAllNotificationsAsRead())
+}
+
+func TestGetNotificationPreferences_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/notifications/preferences", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.NotificationPreference{
+			{EventType: "stack.deploy.failed", Enabled: true, Channel: "in_app"},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.GetNotificationPreferences()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "stack.deploy.failed", got[0].EventType)
+}
+
+func TestUpdateNotificationPreferences_RoundTrip(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/api/v1/notifications/preferences", r.URL.Path)
+		var got []types.NotificationPreference
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		require.Len(t, got, 1)
+		assert.Equal(t, "stack.deploy.failed", got[0].EventType)
+		assert.True(t, got[0].Enabled)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(got)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	updated, err := c.UpdateNotificationPreferences([]types.NotificationPreference{
+		{EventType: "stack.deploy.failed", Enabled: true, Channel: "in_app"},
+	})
+	require.NoError(t, err)
+	require.Len(t, updated, 1)
+}
+
+func TestNotificationsClient_APIErrorMatrix(t *testing.T) {
+	t.Parallel()
+	statuses := []int{http.StatusUnauthorized, http.StatusNotFound, http.StatusInternalServerError}
+	calls := []struct {
+		name string
+		call func(c *Client) error
+	}{
+		{"List", func(c *Client) error { _, err := c.ListNotifications(NotificationListParams{}); return err }},
+		{"Count", func(c *Client) error { _, err := c.CountUnreadNotifications(); return err }},
+		{"MarkAsRead", func(c *Client) error { return c.MarkNotificationAsRead("n1") }},
+		{"MarkAllAsRead", func(c *Client) error { return c.MarkAllNotificationsAsRead() }},
+		{"GetPrefs", func(c *Client) error { _, err := c.GetNotificationPreferences(); return err }},
+		{"UpdatePrefs", func(c *Client) error {
+			_, err := c.UpdateNotificationPreferences([]types.NotificationPreference{{EventType: "x", Enabled: true}})
+			return err
+		}},
+	}
+	for _, call := range calls {
+		call := call
+		for _, status := range statuses {
+			status := status
+			t.Run(fmt.Sprintf("%s_%d", call.name, status), func(t *testing.T) {
+				t.Parallel()
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(status)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "x"})
+				}))
+				defer server.Close()
+				c := New(server.URL)
+				err := call.call(c)
+				require.Error(t, err)
+				var apiErr *APIError
+				require.ErrorAs(t, err, &apiErr)
+				assert.Equal(t, status, apiErr.StatusCode)
+			})
+		}
+	}
+}
+
 // ---------- shared values ----------
 
 func TestListSharedValues_Success(t *testing.T) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -335,6 +335,57 @@ type AuditLogListParams struct {
 	Offset     int        `json:"offset,omitempty" yaml:"offset,omitempty"`
 }
 
+// Notification is one in-app notification. Mirrors backend models.Notification.
+//
+// Population: only returned on HTTP 200 (list endpoint).
+//
+// Field declaration order is alphabetical by json tag so encoding/json
+// emits keys in stable alphabetical order — required for golden-file
+// JSON comparisons in tests. Do not reorder.
+type Notification struct {
+	CreatedAt  time.Time `json:"created_at" yaml:"created_at"`
+	EntityID   string    `json:"entity_id,omitempty" yaml:"entity_id,omitempty"`
+	EntityType string    `json:"entity_type,omitempty" yaml:"entity_type,omitempty"`
+	ID         string    `json:"id" yaml:"id"`
+	IsRead     bool      `json:"is_read" yaml:"is_read"`
+	Message    string    `json:"message" yaml:"message"`
+	Title      string    `json:"title" yaml:"title"`
+	Type       string    `json:"type" yaml:"type"`
+	UserID     string    `json:"user_id" yaml:"user_id"`
+}
+
+// PaginatedNotifications is the success-path response of GET /api/v1/notifications.
+// Mirrors backend models.PaginatedNotifications.
+//
+// Field declaration order is alphabetical by json tag (see Notification).
+type PaginatedNotifications struct {
+	Notifications []Notification `json:"notifications" yaml:"notifications"`
+	Total         int64          `json:"total" yaml:"total"`
+	UnreadCount   int64          `json:"unread_count" yaml:"unread_count"`
+}
+
+// NotificationPreference is one row in the user's notification preferences.
+// Mirrors backend models.NotificationPreference.
+//
+// The Channel field is optional in PUT requests — the backend defaults it
+// to "in_app" when omitted. On GET responses Channel is always populated.
+//
+// Field declaration order is alphabetical by json tag (see Notification).
+type NotificationPreference struct {
+	Channel   string `json:"channel,omitempty" yaml:"channel,omitempty"`
+	Enabled   bool   `json:"enabled" yaml:"enabled"`
+	EventType string `json:"event_type" yaml:"event_type"`
+	ID        string `json:"id,omitempty" yaml:"id,omitempty"`
+	UserID    string `json:"user_id,omitempty" yaml:"user_id,omitempty"`
+}
+
+// UnreadCountResponse is the success-path response of GET /api/v1/notifications/count.
+// The endpoint returns a single key {"unread_count": N} rather than a wrapped
+// object — modelled as a struct so JSON/YAML decode cleanly.
+type UnreadCountResponse struct {
+	UnreadCount int64 `json:"unread_count" yaml:"unread_count"`
+}
+
 // CreateStackRequest is the request body for POST /api/v1/stack-instances.
 // It contains only the writable fields — server-owned fields like ID, owner,
 // namespace, status are excluded to avoid backend validation errors.

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -364,11 +364,22 @@ type PaginatedNotifications struct {
 	UnreadCount   int64          `json:"unread_count" yaml:"unread_count"`
 }
 
-// NotificationPreference is one row in the user's notification preferences.
+// NotificationPreference is one row in the notification-preference payload
+// used by GET /api/v1/notifications/preferences and PUT /api/v1/notifications/preferences.
 // Mirrors backend models.NotificationPreference.
 //
-// The Channel field is optional in PUT requests — the backend defaults it
-// to "in_app" when omitted. On GET responses Channel is always populated.
+// Population: returned on HTTP 200 from GET and PUT. On non-2xx the client
+// surfaces an APIError and callers should treat the value as zero-valued.
+//
+// Field semantics:
+//   - EventType is required and always populated on GET/PUT responses;
+//     forms the primary key with UserID server-side.
+//   - Enabled is required and always populated (default true on first PUT).
+//   - Channel is OPTIONAL on PUT — backend defaults to "in_app" when the
+//     field is empty. Always populated on GET responses.
+//   - ID and UserID are populated on GET/PUT responses; they may be omitted
+//     in PUT request bodies (the backend keys on EventType + the
+//     authenticated user, not on the wire ID).
 //
 // Field declaration order is alphabetical by json tag (see Notification).
 type NotificationPreference struct {

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2614,6 +2614,47 @@ func TestE2EAnalyticsOverviewJSONParses(t *testing.T) {
 	assert.Equal(t, 7, got.TotalTemplates)
 }
 
+// startE2ENotificationMockServer serves a deterministic notification list
+// so the e2e JSON contract can be diffed across runs.
+func startE2ENotificationMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/notifications":
+			_, _ = w.Write([]byte(
+				`{"notifications":[{"id":"n1","type":"stack.deploy.failed","title":"Deploy failed","is_read":false,"created_at":"2026-05-01T10:00:00Z","user_id":"u1"}],"total":1,"unread_count":1}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}
+	}))
+}
+
+// TestE2ENotificationListJSON proves `stackctl notification list -o json`
+// produces parseable JSON the operator can pipe to jq.
+func TestE2ENotificationListJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2ENotificationMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, stderr, err := runStackctl(t, dir, "notification", "list", "-o", "json")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var got types.PaginatedNotifications
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+	assert.Equal(t, int64(1), got.UnreadCount)
+	require.Len(t, got.Notifications, 1)
+	assert.Equal(t, "stack.deploy.failed", got.Notifications[0].Type)
+}
+
 // startE2EAuditMockServer serves a deterministic audit log list and a CSV
 // export crafted to exercise CSV quoting rules (commas + newlines).
 func startE2EAuditMockServer(t *testing.T) *httptest.Server {

--- a/cli/test/integration/notification_integration_test.go
+++ b/cli/test/integration/notification_integration_test.go
@@ -1,0 +1,235 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/cmd"
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// notificationState mirrors the backend's notification store closely enough
+// to round-trip the read-all + count workflow: an atomic counter for unread,
+// plus a slice of preferences that GET and PUT share.
+type notificationState struct {
+	unread int64
+	prefs  []types.NotificationPreference
+}
+
+// startNotificationMockServer returns a mock that respects the unread counter
+// (so `count` → `read-all` → `count` truly drops from N→0) and persists the
+// preference array across GET/PUT.
+func startNotificationMockServer(t *testing.T, state *notificationState) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/notifications":
+			_ = json.NewEncoder(w).Encode(types.PaginatedNotifications{
+				Notifications: []types.Notification{
+					{ID: "n1", Type: "stack.deploy.failed", Title: "Deploy failed", CreatedAt: time.Now().UTC()},
+				},
+				Total:       1,
+				UnreadCount: atomic.LoadInt64(&state.unread),
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/notifications/count":
+			_ = json.NewEncoder(w).Encode(types.UnreadCountResponse{
+				UnreadCount: atomic.LoadInt64(&state.unread),
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/notifications/read-all":
+			atomic.StoreInt64(&state.unread, 0)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/notifications/preferences":
+			_ = json.NewEncoder(w).Encode(state.prefs)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/notifications/preferences":
+			var got []types.NotificationPreference
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: err.Error()})
+				return
+			}
+			// Backend defaults empty channel to "in_app" on store.
+			for i := range got {
+				if got[i].Channel == "" {
+					got[i].Channel = "in_app"
+				}
+			}
+			state.prefs = got
+			_ = json.NewEncoder(w).Encode(state.prefs)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+		}
+	}))
+}
+
+// TestNotificationWorkflow_CountReadAllRoundTrip exercises the issue's
+// acceptance criterion via the client: "Unread count matches server after
+// read-all". count → 3 → read-all → count → 0.
+func TestNotificationWorkflow_CountReadAllRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := &notificationState{unread: 3}
+	server := startNotificationMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	got, err := c.CountUnreadNotifications()
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), got)
+
+	require.NoError(t, c.MarkAllNotificationsAsRead())
+
+	got, err = c.CountUnreadNotifications()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got, "read-all must drop the unread count to zero")
+}
+
+// TestNotificationWorkflow_PrefsRoundTrip exercises the issue's other
+// acceptance criterion: "prefs get | jq … | prefs set round-trip works".
+// GET → mutate → PUT → GET should observe the mutation.
+func TestNotificationWorkflow_PrefsRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	state := &notificationState{
+		prefs: []types.NotificationPreference{
+			{EventType: "stack.deploy.failed", Enabled: true, Channel: "in_app"},
+			{EventType: "stack.deploy.succeeded", Enabled: true, Channel: "in_app"},
+		},
+	}
+	server := startNotificationMockServer(t, state)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	got, err := c.GetNotificationPreferences()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	// Mutate: disable succeeded.
+	for i := range got {
+		if got[i].EventType == "stack.deploy.succeeded" {
+			got[i].Enabled = false
+		}
+	}
+	updated, err := c.UpdateNotificationPreferences(got)
+	require.NoError(t, err)
+
+	// Verify the mutation persisted.
+	var found bool
+	for _, p := range updated {
+		if p.EventType == "stack.deploy.succeeded" {
+			assert.False(t, p.Enabled, "PUT must persist the Enabled=false mutation")
+			found = true
+		}
+	}
+	assert.True(t, found, "PUT response must include the mutated preference")
+
+	// Re-fetch and confirm.
+	again, err := c.GetNotificationPreferences()
+	require.NoError(t, err)
+	for _, p := range again {
+		if p.EventType == "stack.deploy.succeeded" {
+			assert.False(t, p.Enabled, "second GET must reflect the mutation")
+		}
+	}
+}
+
+// TestNotificationCobra_FullWorkflow exercises the Cobra command surface
+// end-to-end: list → count → read-all → count and the prefs file workflow.
+// Verifies that the notification subcommand flag vars don't leak between
+// in-process Execute calls.
+func TestNotificationCobra_FullWorkflow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	state := &notificationState{
+		unread: 5,
+		prefs: []types.NotificationPreference{
+			{EventType: "stack.deploy.failed", Enabled: true, Channel: "in_app"},
+		},
+	}
+	server := startNotificationMockServer(t, state)
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+	resetAll := func() {
+		cmd.ResetFlagsForTest()
+		cmd.ResetNotificationFlagsForTest()
+		buf.Reset()
+		cmd.SetOut(&buf)
+	}
+
+	// count → 5
+	resetAll()
+	cmd.SetArgs([]string{"notification", "count"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "5")
+
+	// list — verify entries surface
+	resetAll()
+	cmd.SetArgs([]string{"notification", "list"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "stack.deploy.failed")
+
+	// read-all
+	resetAll()
+	cmd.SetArgs([]string{"notification", "read-all"})
+	require.NoError(t, cmd.Execute())
+
+	// count → 0
+	resetAll()
+	cmd.SetArgs([]string{"notification", "count"})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "0", strings.TrimSpace(buf.String()))
+
+	// prefs get | mutate | prefs set
+	resetAll()
+	cmd.SetArgs([]string{"notification", "prefs", "get", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+
+	var prefs []types.NotificationPreference
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &prefs))
+	require.Len(t, prefs, 1)
+	prefs[0].Enabled = false
+
+	mutated, err := json.Marshal(prefs)
+	require.NoError(t, err)
+	prefsPath := filepath.Join(t.TempDir(), "prefs.json")
+	require.NoError(t, os.WriteFile(prefsPath, mutated, 0600))
+
+	resetAll()
+	cmd.SetArgs([]string{"notification", "prefs", "set", "--from-file", prefsPath})
+	require.NoError(t, cmd.Execute())
+
+	resetAll()
+	cmd.SetArgs([]string{"notification", "prefs", "get", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+	var after []types.NotificationPreference
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &after))
+	require.Len(t, after, 1)
+	assert.False(t, after[0].Enabled, "round-trip must persist Enabled=false")
+}
+


### PR DESCRIPTION
## Summary
- Six new `stackctl notification` subcommands against `/api/v1/notifications[/...]`: list, count, read `<id>`, read-all, prefs get, prefs set.
- `prefs set --from-file` accepts a JSON file or stdin (`-`); roundtrips with `prefs get -o json`.
- Types alphabetically ordered by json tag (golden-file contract); client methods carry `@see HTTP verb + route` godoc.
- `ResetNotificationFlagsForTest` exported so integration tests can clear subcommand flag vars between in-process `Execute()` calls.

## Acceptance criteria

- [x] Unread count matches server after `read`/`read-all` — integration test does count→3, read-all, count→0 round-trip at both client and Cobra layers.
- [x] `prefs get | jq … | prefs set` round-trip works — integration test GETs preferences, flips `Enabled`, PUTs, re-GETs, asserts mutation persisted in both the PUT response and the second GET.

## Test plan

- [x] `go test ./... -count=1` green (cmd 11.3s, client 4.4s, integration 13.4s, e2e 4.4s)
- [x] `go vet ./...` clean
- [x] Unit (`cli/cmd/notification_test.go`, additions in `cli/pkg/client/client_test.go`)
- [x] Integration (`cli/test/integration/notification_integration_test.go`) — stateful mock with atomic unread counter
- [x] E2E (`stackctl notification list -o json` happy path)

Tracks #59
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI group for notifications: list, count, mark read (single/all) and prefs (get/set); supports unread-only, limit, offset, table/JSON/YAML and quiet output.
* **Documentation**
  * Command conventions updated: quiet mode for prefs prints stable event_type names; CodeRabbit config aligned.
* **Tests**
  * Added unit, integration and end-to-end tests covering listing, counting, read actions and prefs round-trips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->