### PR TITLE
feat(favorite,git): favorites CRUD + git providers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,6 +46,8 @@ reviews:
             notification prefs get/set → event_type names (the (user_id,
               event_type) tuple is the backend primary key; opaque UUID IDs
               are useless for scripting like `prefs get -q | grep failed`)
+            git providers → provider type names (azure_devops, gitlab) —
+              the response shape has no ID field at all
         - Destructive commands require --yes flag and stderr confirmation prompt
         - All API calls go through pkg/client via newClient()
         - parseID() for sub-resource IDs; resolveStackID() (and the

--- a/.github/instructions/commands.instructions.md
+++ b/.github/instructions/commands.instructions.md
@@ -40,6 +40,7 @@ default:
   - `cluster health <id>` → prints the derived status label (`healthy`/`degraded`/`unknown`) via `fmt.Fprintln(printer.Writer, deriveHealthStatus(health))`
   - `cluster test-connection <id>` → prints `result.Status` (only on 2xx responses; non-2xx surfaces as an `APIError` command error, nothing is printed to stdout) via `fmt.Fprintln(printer.Writer, result.Status)`
   - `notification prefs get` / `notification prefs set` → prints `event_type` for each preference. Preferences are keyed by `(user_id, event_type)` server-side, so `EventType` is the stable functional identifier; the database UUID `ID` field is opaque and unstable across resets, so scripting like `prefs get -q \| grep failed` requires the event type.
+  - `git providers` → prints provider `type` names (`azure_devops`, `gitlab`). The response shape (`gitprovider.ProviderStatus`) has no ID field at all — the provider type IS the identifier.
 
 ## Destructive Operations
 Commands that delete or clean resources must:

--- a/cli/cmd/favorite.go
+++ b/cli/cmd/favorite.go
@@ -1,0 +1,210 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+var favoriteCmd = &cobra.Command{
+	Use:     "favorite",
+	Aliases: []string{"favorites", "fav"},
+	Short:   "Manage the authenticated user's favorited entities",
+	Long: `Manage stack definitions, instances, and templates favorited by the
+authenticated user.
+
+  list   — show all favorites (default table; --quiet prints entity IDs)
+  add    — favorite an entity by --type/--id (idempotent server-side)
+  remove — un-favorite an entity by --type/--id (idempotent server-side)
+
+The "entity type" must be one of: definition, instance, template.
+Favorites are scoped to the calling user; no admin gate.`,
+}
+
+// Distinct flag vars per subcommand. Sharing one pair of vars between `add`
+// and `remove` would mean the second StringVar() call in init() silently
+// overrides the first command's default and ties their state together for
+// the lifetime of the process — exactly the fragility that motivated
+// audit's PersistentFlags refactor. Here `list` takes no filters, so
+// per-command locals are the cleanest split.
+var (
+	favoriteAddType    string
+	favoriteAddID      string
+	favoriteRemoveType string
+	favoriteRemoveID   string
+)
+
+// favoriteEntityTypes mirrors the backend allowlist
+// (backend/internal/models/user_favorite.go validFavoriteEntityTypes).
+// Duplicated client-side so an invalid --type fails before any API call.
+var favoriteEntityTypes = map[string]bool{
+	"definition": true,
+	"instance":   true,
+	"template":   true,
+}
+
+func validateFavoriteType(t string) error {
+	if t == "" {
+		return fmt.Errorf("--type is required (one of: definition, instance, template)")
+	}
+	if !favoriteEntityTypes[t] {
+		return fmt.Errorf("--type %q is invalid: must be one of definition, instance, template", t)
+	}
+	return nil
+}
+
+var favoriteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List favorited entities",
+	Long: `List the authenticated user's favorited entities (definitions,
+instances, templates).
+
+Examples:
+  stackctl favorite list
+  stackctl favorite list -o json
+  stackctl favorite list --quiet`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		favs, err := c.ListFavorites()
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			for _, f := range favs {
+				fmt.Fprintln(printer.Writer, f.EntityID)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(favs)
+		case output.FormatYAML:
+			return printer.PrintYAML(favs)
+		default:
+			if len(favs) == 0 {
+				printer.PrintMessage("No favorites.")
+				return nil
+			}
+			headers := []string{"ENTITY TYPE", "ENTITY ID", "FAVORITED AT"}
+			rows := make([][]string, len(favs))
+			for i, f := range favs {
+				rows[i] = []string{f.EntityType, f.EntityID, f.CreatedAt.UTC().Format("2006-01-02 15:04")}
+			}
+			return printer.PrintTable(headers, rows)
+		}
+	},
+}
+
+var favoriteAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add an entity to favorites",
+	Long: `Favorite an entity by --type and --id. The backend is idempotent —
+re-adding the same (entity_type, entity_id) returns the existing row
+without a duplicate-key error, so this command is safe to script.
+
+Examples:
+  stackctl favorite add --type definition --id 42
+  stackctl favorite add --type template --id 9 -o json`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateFavoriteType(favoriteAddType); err != nil {
+			return err
+		}
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		fav, err := c.AddFavorite(types.AddFavoriteRequest{
+			EntityType: favoriteAddType,
+			EntityID:   favoriteAddID,
+		})
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, fav.EntityID)
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(fav)
+		case output.FormatYAML:
+			return printer.PrintYAML(fav)
+		default:
+			printer.PrintMessage("Favorited %s %s.", fav.EntityType, fav.EntityID)
+			return nil
+		}
+	},
+}
+
+var favoriteRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove an entity from favorites",
+	Long: `Un-favorite an entity by --type and --id. The backend is
+idempotent — removing a non-existent favorite returns 204 No Content
+rather than 404, so this command is safe to script.
+
+Examples:
+  stackctl favorite remove --type definition --id 42`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateFavoriteType(favoriteRemoveType); err != nil {
+			return err
+		}
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		if err := c.RemoveFavorite(favoriteRemoveType, favoriteRemoveID); err != nil {
+			return err
+		}
+		if printer.Quiet {
+			fmt.Fprintln(printer.Writer, favoriteRemoveID)
+			return nil
+		}
+		printer.PrintMessage("Removed favorite %s %s.", favoriteRemoveType, favoriteRemoveID)
+		return nil
+	},
+}
+
+func init() {
+	favoriteAddCmd.Flags().StringVar(&favoriteAddType, "type", "", "Entity type (definition, instance, template) — required")
+	favoriteAddCmd.Flags().StringVar(&favoriteAddID, "id", "", "Entity ID — required")
+	// `--id` validation goes through cobra's MarkFlagRequired (consistent
+	// usage error + exit code + --help hint). `--type` stays hand-rolled
+	// so validateFavoriteType can emit the allowlist hint
+	// ("definition, instance, template") that the bare cobra error doesn't.
+	_ = favoriteAddCmd.MarkFlagRequired("id")
+
+	favoriteRemoveCmd.Flags().StringVar(&favoriteRemoveType, "type", "", "Entity type (definition, instance, template) — required")
+	favoriteRemoveCmd.Flags().StringVar(&favoriteRemoveID, "id", "", "Entity ID — required")
+	_ = favoriteRemoveCmd.MarkFlagRequired("id")
+
+	favoriteCmd.AddCommand(favoriteListCmd)
+	favoriteCmd.AddCommand(favoriteAddCmd)
+	favoriteCmd.AddCommand(favoriteRemoveCmd)
+	rootCmd.AddCommand(favoriteCmd)
+}
+
+// ResetFavoriteFlagsForTest clears the per-subcommand favorite flag vars
+// between in-process Cobra invocations. Subcommand flags are NOT covered
+// by ResetFlagsForTest.
+func ResetFavoriteFlagsForTest() {
+	favoriteAddType = ""
+	favoriteAddID = ""
+	favoriteRemoveType = ""
+	favoriteRemoveID = ""
+}
+
+// Internal alias for cmd-package test files.
+func resetFavoriteFlagsForTest() { ResetFavoriteFlagsForTest() }

--- a/cli/cmd/favorite.go
+++ b/cli/cmd/favorite.go
@@ -118,13 +118,17 @@ Examples:
 		if err := validateFavoriteType(favoriteAddType); err != nil {
 			return err
 		}
+		id, err := parseID(favoriteAddID)
+		if err != nil {
+			return err
+		}
 		c, err := newClient()
 		if err != nil {
 			return err
 		}
 		fav, err := c.AddFavorite(types.AddFavoriteRequest{
 			EntityType: favoriteAddType,
-			EntityID:   favoriteAddID,
+			EntityID:   id,
 		})
 		if err != nil {
 			return err
@@ -161,18 +165,22 @@ Examples:
 		if err := validateFavoriteType(favoriteRemoveType); err != nil {
 			return err
 		}
+		id, err := parseID(favoriteRemoveID)
+		if err != nil {
+			return err
+		}
 		c, err := newClient()
 		if err != nil {
 			return err
 		}
-		if err := c.RemoveFavorite(favoriteRemoveType, favoriteRemoveID); err != nil {
+		if err := c.RemoveFavorite(favoriteRemoveType, id); err != nil {
 			return err
 		}
 		if printer.Quiet {
-			fmt.Fprintln(printer.Writer, favoriteRemoveID)
+			fmt.Fprintln(printer.Writer, id)
 			return nil
 		}
-		printer.PrintMessage("Removed favorite %s %s.", favoriteRemoveType, favoriteRemoveID)
+		printer.PrintMessage("Removed favorite %s %s.", favoriteRemoveType, id)
 		return nil
 	},
 }

--- a/cli/cmd/favorite_test.go
+++ b/cli/cmd/favorite_test.go
@@ -215,6 +215,36 @@ func TestFavoriteAddCmd_MissingFlagsRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "--type")
 }
 
+// TestFavoriteAddCmd_MarkFlagRequiredOnID exercises the Execute path so
+// cobra's MarkFlagRequired("id") fires. RunE-direct calls (above) bypass
+// flag parsing entirely, so the required-flag behaviour is only observable
+// through Execute().
+func TestFavoriteAddCmd_MarkFlagRequiredOnID(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+
+	// Snapshot + restore the rootCmd args/out so the rest of the suite is
+	// unaffected.
+	rootCmd.SetArgs([]string{"favorite", "add", "--type", "definition"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"id"`, "cobra should reject the missing --id flag before RunE is called")
+}
+
+func TestFavoriteRemoveCmd_MarkFlagRequiredOnID(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+
+	rootCmd.SetArgs([]string{"favorite", "remove", "--type", "definition"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"id"`)
+}
+
 // ---------- favorite remove ----------
 
 func TestFavoriteRemoveCmd_Success(t *testing.T) {

--- a/cli/cmd/favorite_test.go
+++ b/cli/cmd/favorite_test.go
@@ -1,0 +1,349 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/output"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests in this file mutate package-level globals (printer, flagAPIURL,
+// favoriteFlag*). They do NOT use t.Parallel().
+
+func sampleFavorites() []types.Favorite {
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	return []types.Favorite{
+		{ID: "f1", UserID: "u1", EntityType: "definition", EntityID: "42", CreatedAt: t1},
+		{ID: "f2", UserID: "u1", EntityType: "template", EntityID: "9", CreatedAt: t1},
+	}
+}
+
+// ---------- favorite list ----------
+
+func TestFavoriteListCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/favorites", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleFavorites())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, favoriteListCmd.RunE(favoriteListCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "ENTITY TYPE")
+	assert.Contains(t, out, "definition")
+	assert.Contains(t, out, "42")
+	assert.Contains(t, out, "template")
+}
+
+func TestFavoriteListCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleFavorites())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+	require.NoError(t, favoriteListCmd.RunE(favoriteListCmd, []string{}))
+
+	var got []types.Favorite
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+}
+
+func TestFavoriteListCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleFavorites())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+	require.NoError(t, favoriteListCmd.RunE(favoriteListCmd, []string{}))
+	assert.Contains(t, buf.String(), "entity_type: definition")
+}
+
+func TestFavoriteListCmd_QuietPrintsEntityIDs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleFavorites())
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, favoriteListCmd.RunE(favoriteListCmd, []string{}))
+	assert.Equal(t, "42\n9", strings.TrimSpace(buf.String()))
+	assert.NotContains(t, buf.String(), "ENTITY TYPE")
+}
+
+func TestFavoriteListCmd_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, favoriteListCmd.RunE(favoriteListCmd, []string{}))
+	assert.Contains(t, buf.String(), "No favorites.")
+}
+
+// ---------- favorite add ----------
+
+func TestFavoriteAddCmd_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/favorites", r.URL.Path)
+		var req types.AddFavoriteRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "definition", req.EntityType)
+		assert.Equal(t, "42", req.EntityID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.Favorite{ID: "f1", EntityType: "definition", EntityID: "42"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	favoriteAddType = "definition"
+	favoriteAddID = "42"
+	require.NoError(t, favoriteAddCmd.RunE(favoriteAddCmd, []string{}))
+	assert.Contains(t, buf.String(), "Favorited definition 42")
+}
+
+// TestFavoriteAddCmd_IdempotentReAdd locks in the acceptance criterion:
+// re-adding the same favorite must not error. The backend returns the
+// existing row with 201; the CLI must surface that as success, not a 5xx.
+func TestFavoriteAddCmd_IdempotentReAdd(t *testing.T) {
+	var callCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.Favorite{ID: "f1", EntityType: "definition", EntityID: "42"})
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	favoriteAddType = "definition"
+	favoriteAddID = "42"
+	require.NoError(t, favoriteAddCmd.RunE(favoriteAddCmd, []string{}))
+	require.NoError(t, favoriteAddCmd.RunE(favoriteAddCmd, []string{}))
+	assert.Equal(t, 2, callCount, "both calls must reach the backend; idempotency is server-side")
+}
+
+func TestFavoriteAddCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.Favorite{ID: "f1", EntityType: "definition", EntityID: "42"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	printer.Format = output.FormatJSON
+	favoriteAddType = "definition"
+	favoriteAddID = "42"
+	require.NoError(t, favoriteAddCmd.RunE(favoriteAddCmd, []string{}))
+
+	var got types.Favorite
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, "f1", got.ID)
+}
+
+func TestFavoriteAddCmd_QuietPrintsEntityID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.Favorite{ID: "f1", EntityType: "definition", EntityID: "42"})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	printer.Quiet = true
+	favoriteAddType = "definition"
+	favoriteAddID = "42"
+	require.NoError(t, favoriteAddCmd.RunE(favoriteAddCmd, []string{}))
+	assert.Equal(t, "42", strings.TrimSpace(buf.String()))
+}
+
+func TestFavoriteAddCmd_InvalidTypeRejectedClientSide(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	favoriteAddType = "garbage"
+	favoriteAddID = "42"
+	err := favoriteAddCmd.RunE(favoriteAddCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "definition, instance, template")
+	assert.False(t, called, "API must not be called for invalid --type")
+}
+
+func TestFavoriteAddCmd_MissingFlagsRejected(t *testing.T) {
+	_ = setupStackTestCmd(t, "http://unused")
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	err := favoriteAddCmd.RunE(favoriteAddCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--type")
+}
+
+// ---------- favorite remove ----------
+
+func TestFavoriteRemoveCmd_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		require.Equal(t, "/api/v1/favorites/definition/42", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	favoriteRemoveType = "definition"
+	favoriteRemoveID = "42"
+	require.NoError(t, favoriteRemoveCmd.RunE(favoriteRemoveCmd, []string{}))
+	assert.Contains(t, buf.String(), "Removed favorite definition 42")
+}
+
+// TestFavoriteRemoveCmd_IdempotentMissing locks the second half of the
+// acceptance criterion: removing a non-existent favorite must succeed
+// (backend returns 204 — not 404 — for unknown rows).
+func TestFavoriteRemoveCmd_IdempotentMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	favoriteRemoveType = "definition"
+	favoriteRemoveID = "missing"
+	require.NoError(t, favoriteRemoveCmd.RunE(favoriteRemoveCmd, []string{}))
+}
+
+func TestFavoriteRemoveCmd_QuietPrintsID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	printer.Quiet = true
+	favoriteRemoveType = "definition"
+	favoriteRemoveID = "42"
+	require.NoError(t, favoriteRemoveCmd.RunE(favoriteRemoveCmd, []string{}))
+	assert.Equal(t, "42", strings.TrimSpace(buf.String()))
+}
+
+func TestFavoriteRemoveCmd_InvalidTypeRejectedClientSide(t *testing.T) {
+	var called bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	resetFavoriteFlagsForTest()
+	defer resetFavoriteFlagsForTest()
+	favoriteRemoveType = "garbage"
+	favoriteRemoveID = "42"
+	err := favoriteRemoveCmd.RunE(favoriteRemoveCmd, []string{})
+	require.Error(t, err)
+	assert.False(t, called)
+}
+
+// ---------- API error matrix ----------
+
+func TestFavoriteCmds_APIError401(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"login required"}`))
+	}))
+	defer server.Close()
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{"list", func() error { return favoriteListCmd.RunE(favoriteListCmd, []string{}) }},
+		{"add", func() error {
+			favoriteAddType = "definition"
+			favoriteAddID = "42"
+			return favoriteAddCmd.RunE(favoriteAddCmd, []string{})
+		}},
+		{"remove", func() error {
+			favoriteRemoveType = "definition"
+			favoriteRemoveID = "42"
+			return favoriteRemoveCmd.RunE(favoriteRemoveCmd, []string{})
+		}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_ = setupStackTestCmd(t, server.URL)
+			resetFavoriteFlagsForTest()
+			defer resetFavoriteFlagsForTest()
+			err := tc.run()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Not authenticated")
+		})
+	}
+}
+
+// ---------- validateFavoriteType ----------
+
+func TestValidateFavoriteType(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+	}{
+		{in: "definition"},
+		{in: "instance"},
+		{in: "template"},
+		{in: "", wantErr: true},
+		{in: "stack", wantErr: true},
+		{in: "Definition", wantErr: true}, // case-sensitive
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			err := validateFavoriteType(tc.in)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cli/cmd/git.go
+++ b/cli/cmd/git.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/omattsson/stackctl/cli/pkg/output"
 	"github.com/spf13/cobra"
 )
@@ -9,6 +12,58 @@ var gitCmd = &cobra.Command{
 	Use:   "git",
 	Short: "Git repository operations",
 	Long:  "List branches and validate branch names for git repositories.",
+}
+
+var gitProvidersCmd = &cobra.Command{
+	Use:   "providers",
+	Short: "List configured git providers and their availability",
+	Long: `List the status of all Git providers configured on the backend
+(azure_devops, gitlab). Availability reflects whether each provider was
+configured at server start; it is NOT a live connectivity check.
+
+Examples:
+  stackctl git providers
+  stackctl git providers -o json
+  stackctl git providers --quiet  # prints provider type names only`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := newClient()
+		if err != nil {
+			return err
+		}
+		providers, err := c.ListGitProviders()
+		if err != nil {
+			return err
+		}
+
+		if printer.Quiet {
+			// Provider "type" (azure_devops, gitlab) is the stable functional
+			// identifier; the response carries no UUID. Documented in
+			// .coderabbit.yaml alongside the other quiet-mode exceptions.
+			for _, p := range providers {
+				fmt.Fprintln(printer.Writer, p.Type)
+			}
+			return nil
+		}
+
+		switch printer.Format {
+		case output.FormatJSON:
+			return printer.PrintJSON(providers)
+		case output.FormatYAML:
+			return printer.PrintYAML(providers)
+		default:
+			if len(providers) == 0 {
+				printer.PrintMessage("No git providers configured.")
+				return nil
+			}
+			headers := []string{"TYPE", "AVAILABLE"}
+			rows := make([][]string, len(providers))
+			for i, p := range providers {
+				rows[i] = []string{p.Type, strconv.FormatBool(p.Available)}
+			}
+			return printer.PrintTable(headers, rows)
+		}
+	},
 }
 
 var gitBranchesCmd = &cobra.Command{
@@ -106,5 +161,6 @@ func init() {
 
 	gitCmd.AddCommand(gitBranchesCmd)
 	gitCmd.AddCommand(gitValidateCmd)
+	gitCmd.AddCommand(gitProvidersCmd)
 	rootCmd.AddCommand(gitCmd)
 }

--- a/cli/cmd/git_test.go
+++ b/cli/cmd/git_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/omattsson/stackctl/cli/pkg/output"
@@ -285,4 +286,106 @@ func TestGitValidateCmd_YAMLOutput(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "valid: true")
 	assert.Contains(t, out, "branch: main")
+}
+
+// ---------- git providers ----------
+
+func sampleGitProviders() []types.GitProvider {
+	return []types.GitProvider{
+		{Type: "azure_devops", Available: true},
+		{Type: "gitlab", Available: false},
+	}
+}
+
+func TestGitProvidersCmd_TableOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/git/providers", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleGitProviders())
+	}))
+	defer server.Close()
+
+	buf := setupGitTestCmd(t, server.URL)
+	require.NoError(t, gitProvidersCmd.RunE(gitProvidersCmd, []string{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "TYPE")
+	assert.Contains(t, out, "AVAILABLE")
+	assert.Contains(t, out, "azure_devops")
+	assert.Contains(t, out, "true")
+	assert.Contains(t, out, "gitlab")
+	assert.Contains(t, out, "false")
+}
+
+func TestGitProvidersCmd_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleGitProviders())
+	}))
+	defer server.Close()
+
+	buf := setupGitTestCmd(t, server.URL)
+	printer.Format = output.FormatJSON
+	require.NoError(t, gitProvidersCmd.RunE(gitProvidersCmd, []string{}))
+
+	var got []types.GitProvider
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, "azure_devops", got[0].Type)
+	assert.True(t, got[0].Available)
+}
+
+func TestGitProvidersCmd_YAMLOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleGitProviders())
+	}))
+	defer server.Close()
+
+	buf := setupGitTestCmd(t, server.URL)
+	printer.Format = output.FormatYAML
+	require.NoError(t, gitProvidersCmd.RunE(gitProvidersCmd, []string{}))
+	out := buf.String()
+	assert.Contains(t, out, "type: azure_devops")
+	assert.Contains(t, out, "available: true")
+}
+
+func TestGitProvidersCmd_QuietPrintsTypes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleGitProviders())
+	}))
+	defer server.Close()
+
+	buf := setupGitTestCmd(t, server.URL)
+	printer.Quiet = true
+	require.NoError(t, gitProvidersCmd.RunE(gitProvidersCmd, []string{}))
+	assert.Equal(t, "azure_devops\ngitlab", strings.TrimSpace(buf.String()))
+	assert.NotContains(t, buf.String(), "TYPE")
+}
+
+func TestGitProvidersCmd_Empty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	buf := setupGitTestCmd(t, server.URL)
+	require.NoError(t, gitProvidersCmd.RunE(gitProvidersCmd, []string{}))
+	assert.Contains(t, buf.String(), "No git providers configured.")
+}
+
+func TestGitProvidersCmd_APIError500(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"db down"}`))
+	}))
+	defer server.Close()
+
+	_ = setupGitTestCmd(t, server.URL)
+	err := gitProvidersCmd.RunE(gitProvidersCmd, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Server error")
 }

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -1584,3 +1584,56 @@ func (c *Client) UpdateNotificationPreferences(prefs []types.NotificationPrefere
 	}
 	return resp, nil
 }
+
+// ListFavorites returns the authenticated user's favorited entities.
+//
+// @see GET /api/v1/favorites
+func (c *Client) ListFavorites() ([]types.Favorite, error) {
+	var favs []types.Favorite
+	if err := c.Get("/api/v1/favorites", &favs); err != nil {
+		return nil, err
+	}
+	return favs, nil
+}
+
+// AddFavorite adds an entity to the user's favorites. Idempotent on the
+// backend — re-adding the same (user_id, entity_type, entity_id) tuple
+// returns 201 with the existing row (no duplicate-key error).
+//
+// @see POST /api/v1/favorites
+func (c *Client) AddFavorite(req types.AddFavoriteRequest) (*types.Favorite, error) {
+	var fav types.Favorite
+	if err := c.Post("/api/v1/favorites", req, &fav); err != nil {
+		return nil, err
+	}
+	return &fav, nil
+}
+
+// RemoveFavorite removes an entity from the user's favorites. The backend
+// returns 204 No Content; idempotent — removing a non-existent favorite
+// also succeeds rather than returning 404.
+//
+// entityID is user-supplied free text; url.PathEscape guards against odd
+// characters (slashes, control chars) silently splitting the path. The
+// allowlisted entityType doesn't need escaping but goes through the same
+// helper for consistency.
+//
+// @see DELETE /api/v1/favorites/{entityType}/{entityId}
+func (c *Client) RemoveFavorite(entityType, entityID string) error {
+	return c.Delete(fmt.Sprintf("/api/v1/favorites/%s/%s",
+		url.PathEscape(entityType), url.PathEscape(entityID)))
+}
+
+// ListGitProviders returns the status of all configured Git providers
+// (azure_devops, gitlab). Status reflects whether the provider was
+// configured at server start; it does NOT perform a live connectivity
+// check.
+//
+// @see GET /api/v1/git/providers
+func (c *Client) ListGitProviders() ([]types.GitProvider, error) {
+	var providers []types.GitProvider
+	if err := c.Get("/api/v1/git/providers", &providers); err != nil {
+		return nil, err
+	}
+	return providers, nil
+}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3416,6 +3417,173 @@ func TestNotificationsClient_APIErrorMatrix(t *testing.T) {
 			})
 		}
 	}
+}
+
+// ---------- favorites ----------
+
+func TestListFavorites_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/favorites", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.Favorite{
+			{ID: "f1", EntityType: "definition", EntityID: "42"},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.ListFavorites()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "definition", got[0].EntityType)
+}
+
+func TestAddFavorite_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/favorites", r.URL.Path)
+		var req types.AddFavoriteRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "definition", req.EntityType)
+		assert.Equal(t, "42", req.EntityID)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.Favorite{ID: "f1", EntityType: req.EntityType, EntityID: req.EntityID})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.AddFavorite(types.AddFavoriteRequest{EntityType: "definition", EntityID: "42"})
+	require.NoError(t, err)
+	assert.Equal(t, "f1", got.ID)
+}
+
+// TestAddFavorite_IdempotentReAdd locks in the acceptance criterion: the
+// backend returns 201 + existing row for a duplicate add (no 409/500),
+// and the client surfaces that as nil error.
+func TestAddFavorite_IdempotentReAdd(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(types.Favorite{ID: "f1", EntityType: "definition", EntityID: "42"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	for i := 0; i < 3; i++ {
+		_, err := c.AddFavorite(types.AddFavoriteRequest{EntityType: "definition", EntityID: "42"})
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
+func TestRemoveFavorite_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v1/favorites/definition/42", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.RemoveFavorite("definition", "42"))
+}
+
+// TestRemoveFavorite_IdempotentMissing covers the backend's documented
+// behaviour of returning 204 even when the row doesn't exist.
+func TestRemoveFavorite_IdempotentMissing(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	require.NoError(t, c.RemoveFavorite("definition", "missing"))
+}
+
+func TestFavoritesClient_APIErrorMatrix(t *testing.T) {
+	t.Parallel()
+	statuses := []int{http.StatusUnauthorized, http.StatusBadRequest, http.StatusInternalServerError}
+	calls := []struct {
+		name string
+		call func(c *Client) error
+	}{
+		{"List", func(c *Client) error { _, err := c.ListFavorites(); return err }},
+		{"Add", func(c *Client) error {
+			_, err := c.AddFavorite(types.AddFavoriteRequest{EntityType: "definition", EntityID: "1"})
+			return err
+		}},
+		{"Remove", func(c *Client) error { return c.RemoveFavorite("definition", "1") }},
+	}
+	for _, call := range calls {
+		call := call
+		for _, status := range statuses {
+			status := status
+			t.Run(fmt.Sprintf("%s_%d", call.name, status), func(t *testing.T) {
+				t.Parallel()
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(status)
+					_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "x"})
+				}))
+				defer server.Close()
+				c := New(server.URL)
+				err := call.call(c)
+				require.Error(t, err)
+				var apiErr *APIError
+				require.ErrorAs(t, err, &apiErr)
+				assert.Equal(t, status, apiErr.StatusCode)
+			})
+		}
+	}
+}
+
+// ---------- git providers ----------
+
+func TestListGitProviders_Success(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/git/providers", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]types.GitProvider{
+			{Type: "azure_devops", Available: true},
+			{Type: "gitlab", Available: false},
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	got, err := c.ListGitProviders()
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "azure_devops", got[0].Type)
+	assert.True(t, got[0].Available)
+	assert.False(t, got[1].Available)
+}
+
+func TestListGitProviders_APIError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"db down"}`))
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	_, err := c.ListGitProviders()
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusInternalServerError, apiErr.StatusCode)
 }
 
 // ---------- shared values ----------

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -397,6 +397,53 @@ type UnreadCountResponse struct {
 	UnreadCount int64 `json:"unread_count" yaml:"unread_count"`
 }
 
+// Favorite is one row in the authenticated user's favorites collection.
+// Mirrors backend models.UserFavorite.
+//
+// Population: returned on HTTP 200/201 from GET /api/v1/favorites and POST
+// /api/v1/favorites. On non-2xx the client surfaces an APIError.
+//
+// Field semantics:
+//   - EntityType is one of "definition", "instance", "template" (validated
+//     server-side).
+//   - EntityID is the target entity's ID — there is no name-or-ID
+//     resolution at this endpoint.
+//   - ID and UserID are server-assigned and only populated in responses.
+//
+// Field declaration order is alphabetical by json tag (golden-file
+// contract — required for stable JSON output).
+type Favorite struct {
+	CreatedAt  time.Time `json:"created_at" yaml:"created_at"`
+	EntityID   string    `json:"entity_id" yaml:"entity_id"`
+	EntityType string    `json:"entity_type" yaml:"entity_type"`
+	ID         string    `json:"id,omitempty" yaml:"id,omitempty"`
+	UserID     string    `json:"user_id,omitempty" yaml:"user_id,omitempty"`
+}
+
+// AddFavoriteRequest is the request body for POST /api/v1/favorites.
+//
+// Both fields are required; the backend rejects an empty EntityType or
+// EntityID with HTTP 400. EntityType must be one of "definition",
+// "instance", or "template".
+type AddFavoriteRequest struct {
+	EntityID   string `json:"entity_id" yaml:"entity_id"`
+	EntityType string `json:"entity_type" yaml:"entity_type"`
+}
+
+// GitProvider is the status of one configured Git provider returned by
+// GET /api/v1/git/providers. Mirrors backend gitprovider.ProviderStatus.
+//
+// Population: only returned on HTTP 200. The backend reports availability
+// based on whether the provider was configured at server start; it does
+// NOT perform a live connectivity check at request time (see the registry
+// HealthCheck for that).
+//
+// Field declaration order is alphabetical by json tag.
+type GitProvider struct {
+	Available bool   `json:"available" yaml:"available"`
+	Type      string `json:"type" yaml:"type"`
+}
+
 // CreateStackRequest is the request body for POST /api/v1/stack-instances.
 // It contains only the writable fields — server-owned fields like ID, owner,
 // namespace, status are excluded to avoid backend validation errors.

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2614,6 +2614,44 @@ func TestE2EAnalyticsOverviewJSONParses(t *testing.T) {
 	assert.Equal(t, 7, got.TotalTemplates)
 }
 
+// startE2EFavoriteMockServer serves a deterministic favorites list for the
+// `stackctl favorite list -o quiet` happy-path scenario.
+func startE2EFavoriteMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/favorites":
+			_, _ = w.Write([]byte(
+				`[{"id":"f1","entity_type":"definition","entity_id":"42","created_at":"2026-05-01T10:00:00Z"},` +
+					`{"id":"f2","entity_type":"template","entity_id":"9","created_at":"2026-05-01T10:00:00Z"}]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"not found"}`))
+		}
+	}))
+}
+
+// TestE2EFavoriteListQuiet exercises the issue's happy-path acceptance
+// scenario: `stackctl favorite list --quiet` prints entity IDs only.
+func TestE2EFavoriteListQuiet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EFavoriteMockServer(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, stderr, err := runStackctl(t, dir, "favorite", "list", "--quiet")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.Equal(t, "42\n9", strings.TrimSpace(stdout))
+	assert.NotContains(t, stdout, "ENTITY TYPE")
+}
+
 // startE2ENotificationMockServer serves a deterministic notification list
 // so the e2e JSON contract can be diffed across runs.
 func startE2ENotificationMockServer(t *testing.T) *httptest.Server {

--- a/cli/test/integration/favorite_integration_test.go
+++ b/cli/test/integration/favorite_integration_test.go
@@ -1,0 +1,255 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/cmd"
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// favoriteStore is a thread-safe in-memory mock of the favorites backend.
+// It enforces the same uniqueness key (user_id, entity_type, entity_id) as
+// the real DB so the "add → list → remove → list" workflow round-trips end
+// to end. The backend's documented idempotency behaviour is replicated:
+// duplicate add returns the existing row with 201; missing remove returns 204.
+type favoriteStore struct {
+	mu   sync.Mutex
+	rows map[string]types.Favorite // key: entityType + ":" + entityID
+}
+
+func newFavoriteStore() *favoriteStore { return &favoriteStore{rows: map[string]types.Favorite{}} }
+
+func (s *favoriteStore) key(t, id string) string { return t + ":" + id }
+
+func (s *favoriteStore) list() []types.Favorite {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]types.Favorite, 0, len(s.rows))
+	for _, f := range s.rows {
+		out = append(out, f)
+	}
+	return out
+}
+
+func (s *favoriteStore) add(t, id string) types.Favorite {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := s.key(t, id)
+	if existing, ok := s.rows[k]; ok {
+		return existing
+	}
+	fav := types.Favorite{ID: "fav-" + k, EntityType: t, EntityID: id}
+	s.rows[k] = fav
+	return fav
+}
+
+func (s *favoriteStore) remove(t, id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.rows, s.key(t, id))
+}
+
+// startFavoriteMockServer wires the in-memory store to the standard
+// /api/v1/favorites routes.
+func startFavoriteMockServer(t *testing.T, store *favoriteStore) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/favorites":
+			_ = json.NewEncoder(w).Encode(store.list())
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/favorites":
+			var req types.AddFavoriteRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.EntityType == "" || req.EntityID == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "invalid request"})
+				return
+			}
+			fav := store.add(req.EntityType, req.EntityID)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(fav)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/favorites/"):
+			parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/v1/favorites/"), "/")
+			if len(parts) != 2 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			store.remove(parts[0], parts[1])
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "not found"})
+		}
+	}))
+}
+
+// TestFavoriteWorkflow_AddListRemoveList exercises the issue's acceptance
+// criterion: idempotent add/remove with a real round-trip. add → list (1) →
+// add again → list (still 1) → remove → list (0) → remove again → list (0).
+func TestFavoriteWorkflow_AddListRemoveList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	store := newFavoriteStore()
+	server := startFavoriteMockServer(t, store)
+	defer server.Close()
+
+	c := client.New(server.URL)
+
+	// add
+	_, err := c.AddFavorite(types.AddFavoriteRequest{EntityType: "definition", EntityID: "42"})
+	require.NoError(t, err)
+
+	favs, err := c.ListFavorites()
+	require.NoError(t, err)
+	require.Len(t, favs, 1)
+
+	// add same — must remain 1
+	_, err = c.AddFavorite(types.AddFavoriteRequest{EntityType: "definition", EntityID: "42"})
+	require.NoError(t, err)
+	favs, err = c.ListFavorites()
+	require.NoError(t, err)
+	require.Len(t, favs, 1, "duplicate add must be idempotent")
+
+	// remove
+	require.NoError(t, c.RemoveFavorite("definition", "42"))
+	favs, err = c.ListFavorites()
+	require.NoError(t, err)
+	require.Empty(t, favs)
+
+	// remove same — must succeed
+	require.NoError(t, c.RemoveFavorite("definition", "42"), "remove missing must be idempotent")
+}
+
+// TestFavoriteCobra_AddListRemove drives the same workflow through Cobra,
+// proving that flag wiring + output formatting + exit codes all behave
+// correctly end-to-end inside a single Go test binary.
+func TestFavoriteCobra_AddListRemove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	store := newFavoriteStore()
+	server := startFavoriteMockServer(t, store)
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+	resetAll := func() {
+		cmd.ResetFlagsForTest()
+		cmd.ResetFavoriteFlagsForTest()
+		buf.Reset()
+		cmd.SetOut(&buf)
+	}
+
+	// add
+	resetAll()
+	cmd.SetArgs([]string{"favorite", "add", "--type", "definition", "--id", "42"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "Favorited definition 42")
+
+	// list — 1 row
+	resetAll()
+	cmd.SetArgs([]string{"favorite", "list"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "definition")
+	assert.Contains(t, buf.String(), "42")
+
+	// add same again — idempotent
+	resetAll()
+	cmd.SetArgs([]string{"favorite", "add", "--type", "definition", "--id", "42"})
+	require.NoError(t, cmd.Execute())
+
+	resetAll()
+	cmd.SetArgs([]string{"favorite", "list", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+	var got []types.Favorite
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1, "favorite list must show exactly 1 row after duplicate add")
+
+	// remove
+	resetAll()
+	cmd.SetArgs([]string{"favorite", "remove", "--type", "definition", "--id", "42"})
+	require.NoError(t, cmd.Execute())
+
+	resetAll()
+	cmd.SetArgs([]string{"favorite", "list"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "No favorites.")
+}
+
+// startGitProvidersMockServer serves a deterministic /git/providers
+// response so the integration test for the existing git command group can
+// be extended without touching its branches/validate mocks.
+func startGitProvidersMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/git/providers":
+			_ = json.NewEncoder(w).Encode([]types.GitProvider{
+				{Type: "azure_devops", Available: true},
+				{Type: "gitlab", Available: false},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestGitProvidersCobra exercises `stackctl git providers` end-to-end
+// through Cobra, asserting table + JSON outputs round-trip and the quiet
+// mode follows the documented "type names" exception.
+func TestGitProvidersCobra(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	server := startGitProvidersMockServer(t)
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+
+	// default table
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"git", "providers"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "azure_devops")
+	assert.Contains(t, buf.String(), "gitlab")
+
+	// JSON
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"git", "providers", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+	var got []types.GitProvider
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+
+	// Quiet → provider type names (documented exception)
+	cmd.ResetFlagsForTest()
+	buf.Reset()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"git", "providers", "--quiet"})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "azure_devops\ngitlab", strings.TrimSpace(buf.String()))
+}


### PR DESCRIPTION
## Summary
- New `stackctl favorite list|add|remove` against `/api/v1/favorites` plus a `git providers` subcommand extending the existing `git` group against `/api/v1/git/providers`.
- Client-side `--type` allowlist validation (definition/instance/template) before any API call; `--id` registered via `MarkFlagRequired` for a consistent missing-flag error.
- `RemoveFavorite` URL-escapes both path components defensively (entity_id is user-supplied free text).
- Per-subcommand flag vars (no shared bindings between `add` and `remove`).
- Documented `git providers → type names` as a quiet-mode exception in `.coderabbit.yaml` + `commands.instructions.md` — the response shape has no ID field.

## Acceptance criteria

- [x] `favorite add/remove` is idempotent — locked at client unit (`TestAddFavorite_IdempotentReAdd`, `TestRemoveFavorite_IdempotentMissing`), cmd unit, and integration (stateful in-memory store mirrors backend uniqueness key, full add→list→add→list→remove→list→remove round-trip).
- [x] `git providers` lists configured providers with their status — locked at client + cmd + integration with table/JSON/YAML/quiet output modes.

## Test plan

- [x] `go test ./... -count=1` green (cmd 12.4s, client 5.7s, integration 14.2s, e2e 5.1s)
- [x] `go vet ./...` clean
- [x] Unit (`cli/cmd/favorite_test.go`, additions in `cli/cmd/git_test.go` + `cli/pkg/client/client_test.go`)
- [x] Integration (`cli/test/integration/favorite_integration_test.go`) — stateful store + Cobra round-trip
- [x] E2E (`stackctl favorite list --quiet` happy path)

Tracks #59
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `stackctl favorite` with `list`, `add`, and `remove` to manage your favorites (table, JSON, YAML, or quiet mode showing entity IDs).
  * Added `stackctl git providers` to list configured Git providers with table/JSON/YAML output and quiet mode.

* **Documentation**
  * Updated command docs: quiet mode for `git providers` now outputs provider type names (e.g., azure_devops, gitlab).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->