### PR TITLE
chore(stack): polish logs --follow path

### DIFF
--- a/cli/cmd/stack.go
+++ b/cli/cmd/stack.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"sort"
@@ -18,18 +19,36 @@ import (
 
 // followLogs streams deployment logs via WebSocket until a terminal status is
 // received. Returns an error if the deployment ended in error status.
+//
+// Installs an os.Interrupt signal handler for Ctrl-C; writes log lines to
+// os.Stdout and warnings to os.Stderr. Test code should call followLogsCtx
+// directly to inject a context + writers.
 func followLogs(c *client.Client, instanceID string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
+	return followLogsCtx(ctx, c, instanceID, os.Stdout, os.Stderr)
+}
 
-	result, err := c.StreamDeploymentLogs(ctx, instanceID, os.Stdout, os.Stderr)
+// followLogsCtx is the testable core of followLogs. It does NOT install a
+// signal handler — the caller owns ctx and is responsible for cancelling
+// it on shutdown. Returns nil when:
+//   - the deployment reaches a terminal non-error status (running,
+//     stopped, draft, "unknown" on graceful server close);
+//   - ctx is cancelled before any other error surfaces (Ctrl-C path).
+//
+// Returns a wrapped error for terminal "error" status, or the underlying
+// network/parse error otherwise.
+func followLogsCtx(ctx context.Context, c *client.Client, instanceID string, out, warn io.Writer) error {
+	result, err := c.StreamDeploymentLogs(ctx, instanceID, out, warn)
 	if err != nil {
 		if ctx.Err() != nil {
+			// Ctrl-C / parent cancellation — surface as clean exit so
+			// the operator's intentional interrupt doesn't look like a
+			// command failure.
 			return nil
 		}
 		return err
 	}
-
 	if result.Status == "error" {
 		if result.ErrorMessage != "" {
 			return fmt.Errorf("deployment failed: %s", result.ErrorMessage)

--- a/cli/cmd/stack_test.go
+++ b/cli/cmd/stack_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -1209,6 +1210,134 @@ func TestStackLogsCmd_NotFound(t *testing.T) {
 	err := stackLogsCmd.RunE(stackLogsCmd, []string{"999"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no logs found")
+}
+
+// ---------- stack logs --follow ----------
+
+// startFollowLogsWS spins up a websocket server that emits a log line +
+// terminal-status event, then blocks on ReadMessage so the client's
+// CloseMessage handshake completes cleanly. Reused across the follow
+// tests.
+func startFollowLogsWS(t *testing.T, status string, logLines []string) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Read the subscribe message before sending anything (the client
+		// always subscribes immediately after the upgrade).
+		_, _, _ = conn.ReadMessage()
+		for _, line := range logLines {
+			payload, _ := json.Marshal(types.WSDeploymentLog{InstanceID: "42", Line: line})
+			msg, _ := json.Marshal(types.WSMessage{Type: "deployment.log", Data: payload})
+			_ = conn.WriteMessage(websocket.TextMessage, msg)
+		}
+		statusPayload, _ := json.Marshal(types.WSDeploymentStatus{InstanceID: "42", Status: status})
+		statusMsg, _ := json.Marshal(types.WSMessage{Type: "deployment.status", Data: statusPayload})
+		_ = conn.WriteMessage(websocket.TextMessage, statusMsg)
+		_, _, _ = conn.ReadMessage()
+	}))
+}
+
+// TestFollowLogsCtx_ExitsOnTerminalStatus locks acceptance criterion #1:
+// "Stream closes cleanly when deploy reaches terminal status." Driven
+// through the testable `followLogsCtx` so we can capture stdout.
+func TestFollowLogsCtx_ExitsOnTerminalStatus(t *testing.T) {
+	server := startFollowLogsWS(t, "running", []string{"hello", "world"})
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	c, err := newClient()
+	require.NoError(t, err)
+
+	var out, warn bytes.Buffer
+	require.NoError(t, followLogsCtx(context.Background(), c, "42", &out, &warn))
+	got := out.String()
+	assert.Contains(t, got, "hello")
+	assert.Contains(t, got, "world")
+}
+
+// TestFollowLogsCtx_ErrorStatusBubblesError verifies the documented
+// non-zero exit contract when the deployment ends with a terminal
+// "error" status — the wrapped error must mention "deployment failed".
+func TestFollowLogsCtx_ErrorStatusBubblesError(t *testing.T) {
+	server := startFollowLogsWS(t, "error", []string{"hint: image pull"})
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	c, err := newClient()
+	require.NoError(t, err)
+
+	var out, warn bytes.Buffer
+	err = followLogsCtx(context.Background(), c, "42", &out, &warn)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deployment failed")
+}
+
+// TestFollowLogsCtx_CtxCancelSurfacesAsCleanExit verifies the documented
+// Ctrl-C path: a cancelled context returns nil so the operator's
+// intentional interrupt doesn't look like a command failure. The
+// package-level goleak.VerifyTestMain check will catch any goroutine
+// leaked on this path.
+func TestFollowLogsCtx_CtxCancelSurfacesAsCleanExit(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Read subscribe, then block — only Ctrl-C terminates this.
+		_, _, _ = conn.ReadMessage()
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	_ = setupStackTestCmd(t, server.URL)
+	c, err := newClient()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the call starts so the read loop unwinds via
+	// the ctx-cancel path.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	var out, warn bytes.Buffer
+	err = followLogsCtx(ctx, c, "42", &out, &warn)
+	assert.NoError(t, err, "ctx cancellation must surface as clean exit")
+}
+
+// TestStackLogsCmd_NoFollowRegression locks the documented acceptance
+// "No behavioural regression for --follow=false path" — the default
+// REST-fetch path must keep returning the most recent deployment log
+// without touching the WebSocket.
+func TestStackLogsCmd_NoFollowRegression(t *testing.T) {
+	var wsHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ws" {
+			wsHits++
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		require.Equal(t, "/api/v1/stack-instances/42/deploy-log", r.URL.Path)
+		require.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.DeploymentLogResult{
+			Data:  []types.DeploymentLog{{ID: "1", InstanceID: "42", Action: "deploy", Status: "completed", Output: "ok"}},
+			Total: 1,
+		})
+	}))
+	defer server.Close()
+
+	buf := setupStackTestCmd(t, server.URL)
+	require.NoError(t, stackLogsCmd.RunE(stackLogsCmd, []string{"42"}))
+	assert.Contains(t, buf.String(), "ok")
+	assert.Equal(t, 0, wsHits, "--follow=false must NOT open a WebSocket")
 }
 
 // ---------- stack list: additional filter tests ----------

--- a/cli/pkg/client/websocket.go
+++ b/cli/pkg/client/websocket.go
@@ -45,13 +45,16 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 	go func() {
 		select {
 		case <-ctx.Done():
-			// Send a close frame AND tear down the TCP connection: the
-			// WriteMessage alone leaves ReadMessage blocked until the
-			// server echoes the close, which a hung server may never do.
-			// Closing the conn surfaces a read error immediately so the
-			// loop unwinds within ctx-cancel latency. Mirrors WatchEvents.
-			_ = conn.WriteMessage(websocket.CloseMessage,
-				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			// Send a close frame AND tear down the TCP connection. Use
+			// WriteControl with an explicit deadline rather than the
+			// blocking WriteMessage — a stalled connection could pin the
+			// goroutine on WriteMessage forever, preventing conn.Close
+			// from ever running. With WriteControl + 1s deadline + Close,
+			// ReadMessage in the read loop unwinds within ctx-cancel
+			// latency regardless of network state. Mirrors WatchEvents.
+			_ = conn.WriteControl(websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+				time.Now().Add(time.Second))
 			_ = conn.Close()
 		case <-done:
 		}
@@ -277,12 +280,15 @@ func (c *Client) WatchEvents(ctx context.Context, filter WatchFilter) (<-chan ty
 		// Watchdog: closes the connection when ctx is cancelled so the
 		// blocking ReadMessage below returns and the read loop exits;
 		// returns on its own when `done` closes so a server-initiated
-		// hang-up doesn't leak this goroutine.
+		// hang-up doesn't leak this goroutine. WriteControl with a write
+		// deadline is used instead of WriteMessage so a stalled TCP
+		// connection can't pin the goroutine forever and block conn.Close.
 		go func() {
 			select {
 			case <-ctx.Done():
-				_ = conn.WriteMessage(websocket.CloseMessage,
-					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				_ = conn.WriteControl(websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+					time.Now().Add(time.Second))
 				_ = conn.Close()
 			case <-done:
 			}

--- a/cli/pkg/client/websocket.go
+++ b/cli/pkg/client/websocket.go
@@ -25,32 +25,9 @@ var terminalStatuses = map[string]bool{
 // log lines for the given instance to w. It blocks until a terminal status is
 // received, the context is cancelled, or the connection drops.
 func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w io.Writer, warnWriter io.Writer) (*types.StreamResult, error) {
-	wsURL, err := c.websocketURL("/ws")
+	conn, err := c.dialWS(ctx, "/ws", warnWriter)
 	if err != nil {
 		return nil, err
-	}
-
-	header := http.Header{}
-	if c.APIKey != "" {
-		header.Set("X-API-Key", c.APIKey)
-	} else if c.Token != "" {
-		header.Set("Authorization", "Bearer "+c.Token)
-	}
-
-	dialer := websocket.DefaultDialer
-	if c.HTTPClient != nil && c.HTTPClient.Transport != nil {
-		if t, ok := c.HTTPClient.Transport.(*http.Transport); ok {
-			d := *websocket.DefaultDialer
-			d.TLSClientConfig = t.TLSClientConfig
-			dialer = &d
-		} else if warnWriter != nil {
-			fmt.Fprintln(warnWriter, "Warning: custom HTTP transport detected; WebSocket TLS config may not be applied")
-		}
-	}
-
-	conn, _, err := dialer.DialContext(ctx, wsURL, header)
-	if err != nil {
-		return nil, fmt.Errorf("connecting to WebSocket: %w", err)
 	}
 	defer conn.Close()
 
@@ -68,8 +45,14 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 	go func() {
 		select {
 		case <-ctx.Done():
-			conn.WriteMessage(websocket.CloseMessage,
+			// Send a close frame AND tear down the TCP connection: the
+			// WriteMessage alone leaves ReadMessage blocked until the
+			// server echoes the close, which a hung server may never do.
+			// Closing the conn surfaces a read error immediately so the
+			// loop unwinds within ctx-cancel latency. Mirrors WatchEvents.
+			_ = conn.WriteMessage(websocket.CloseMessage,
 				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			_ = conn.Close()
 		case <-done:
 		}
 	}()
@@ -128,6 +111,65 @@ func (c *Client) StreamDeploymentLogs(ctx context.Context, instanceID string, w 
 			}
 		}
 	}
+}
+
+// dialWS opens a WebSocket to the given path on the client's BaseURL with
+// the standard stackctl auth chain:
+//
+//   - X-API-Key when c.APIKey is set;
+//   - Authorization: Bearer when c.Token is set;
+//   - On HTTP 401 from the header path AND c.Token != "", a single retry
+//     with the JWT as a URL-escaped ?token= query param (the backend
+//     handler reads from either location — see handlers/websocket.go).
+//
+// Subprotocol auth is NOT attempted; the backend doesn't support it yet
+// (tracked as k8s-stack-manager K4).
+//
+// Custom HTTP transports have their TLS config copied to the dialer so
+// --insecure works for the WS upgrade. A non-*http.Transport custom
+// transport triggers a warning via warnWriter (when non-nil) because we
+// can't extract TLS settings safely.
+func (c *Client) dialWS(ctx context.Context, path string, warnWriter io.Writer) (*websocket.Conn, error) {
+	wsURL, err := c.websocketURL(path)
+	if err != nil {
+		return nil, err
+	}
+
+	header := http.Header{}
+	if c.APIKey != "" {
+		header.Set("X-API-Key", c.APIKey)
+	} else if c.Token != "" {
+		header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	dialer := websocket.DefaultDialer
+	if c.HTTPClient != nil && c.HTTPClient.Transport != nil {
+		if t, ok := c.HTTPClient.Transport.(*http.Transport); ok {
+			d := *websocket.DefaultDialer
+			d.TLSClientConfig = t.TLSClientConfig
+			dialer = &d
+		} else if warnWriter != nil {
+			fmt.Fprintln(warnWriter, "Warning: custom HTTP transport detected; WebSocket TLS config may not be applied")
+		}
+	}
+
+	conn, resp, err := dialer.DialContext(ctx, wsURL, header)
+	if err == nil {
+		return conn, nil
+	}
+	// 401 → fall back to ?token= query param when a JWT is configured.
+	// The retry is gated on c.Token because an API-key-only caller has no
+	// token to fall back to. When BOTH APIKey and Token are set, this
+	// transparently switches to the JWT path (documented precedence).
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized && c.Token != "" {
+		fallbackURL := appendQueryToken(wsURL, c.Token)
+		conn2, _, err2 := dialer.DialContext(ctx, fallbackURL, nil)
+		if err2 != nil {
+			return nil, fmt.Errorf("connecting to WebSocket (header auth failed with 401, query-param fallback also failed): %w", err2)
+		}
+		return conn2, nil
+	}
+	return nil, fmt.Errorf("connecting to WebSocket: %w", err)
 }
 
 func (c *Client) websocketURL(path string) (string, error) {
@@ -209,44 +251,9 @@ func (f WatchFilter) matches(s types.WSDeploymentStatus) bool {
 // be safely connected to the same /ws endpoint as StreamDeploymentLogs
 // without cross-talk.
 func (c *Client) WatchEvents(ctx context.Context, filter WatchFilter) (<-chan types.WatchEvent, error) {
-	wsURL, err := c.websocketURL("/ws")
+	conn, err := c.dialWS(ctx, "/ws", nil)
 	if err != nil {
 		return nil, err
-	}
-
-	header := http.Header{}
-	if c.APIKey != "" {
-		header.Set("X-API-Key", c.APIKey)
-	} else if c.Token != "" {
-		header.Set("Authorization", "Bearer "+c.Token)
-	}
-
-	dialer := websocket.DefaultDialer
-	if c.HTTPClient != nil && c.HTTPClient.Transport != nil {
-		if t, ok := c.HTTPClient.Transport.(*http.Transport); ok {
-			d := *websocket.DefaultDialer
-			d.TLSClientConfig = t.TLSClientConfig
-			dialer = &d
-		}
-	}
-
-	conn, resp, err := dialer.DialContext(ctx, wsURL, header)
-	if err != nil {
-		// 401 → fall back to ?token= query param. The backend WS handler
-		// (handlers/websocket.go) reads tokens from either location, so a
-		// 401 on the header path is the signal that the proxy stripped
-		// Authorization (a real-world failure mode for reverse proxies and
-		// browsers that we can recover from without operator intervention).
-		if resp != nil && resp.StatusCode == http.StatusUnauthorized && c.Token != "" {
-			fallbackURL := appendQueryToken(wsURL, c.Token)
-			conn2, _, err2 := dialer.DialContext(ctx, fallbackURL, nil)
-			if err2 != nil {
-				return nil, fmt.Errorf("connecting to WebSocket (header auth failed with 401, query-param fallback also failed): %w", err2)
-			}
-			conn = conn2
-		} else {
-			return nil, fmt.Errorf("connecting to WebSocket: %w", err)
-		}
 	}
 
 	// Buffer of 8 is roughly 2s of backpressure tolerance at the backend's

--- a/cli/pkg/client/websocket_test.go
+++ b/cli/pkg/client/websocket_test.go
@@ -274,6 +274,85 @@ func TestStreamDeploymentLogs_NonTerminalStatusIgnored(t *testing.T) {
 	assert.Contains(t, buf.String(), "Still going...")
 }
 
+// TestStreamDeploymentLogs_QueryParamFallbackOn401 locks in K4 auth-chain
+// parity with WatchEvents: when the backend rejects the Authorization
+// header with HTTP 401, the dialer transparently retries with the JWT as
+// a URL-escaped ?token= query param.
+func TestStreamDeploymentLogs_QueryParamFallbackOn401(t *testing.T) {
+	t.Parallel()
+	var gotToken string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// First attempt: header-only → reject.
+		if r.URL.Query().Get("token") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		gotToken = r.URL.Query().Get("token")
+		conn, err := upgrader.Upgrade(w, r, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+		readSubscribe(t, conn, "42")
+		writeWSMessage(t, conn, "deployment.status", types.WSDeploymentStatus{
+			InstanceID: "42", Status: "running", LogID: "log-1",
+		})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	c.Token = "tok-logs-fallback"
+	var buf bytes.Buffer
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "running", result.Status)
+	assert.Equal(t, "tok-logs-fallback", gotToken, "401 on header path must trigger ?token= retry")
+}
+
+// TestStreamDeploymentLogs_QueryParamFallbackDisabledForAPIKey asserts the
+// retry is gated on c.Token. API-key-only callers must see a clean error
+// rather than a misleading retry that would never carry their credential.
+func TestStreamDeploymentLogs_QueryParamFallbackDisabledForAPIKey(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	c.APIKey = "key-only"
+	var buf bytes.Buffer
+	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
+	require.Error(t, err)
+}
+
+// TestStreamDeploymentLogs_GoleakOnTerminalClose is a regression test for
+// the "logs --follow polish" acceptance: the stream must close cleanly
+// when the server reports a terminal status, with no leaked goroutines.
+// The package-level TestMain runs goleak.VerifyTestMain at exit and
+// would surface any leak from this test path; explicit parallel test is
+// here to exercise the path with no ctx cancellation from the caller.
+func TestStreamDeploymentLogs_GoleakOnTerminalClose(t *testing.T) {
+	t.Parallel()
+	server := wsServer(t, func(conn *websocket.Conn) {
+		readSubscribe(t, conn, "42")
+		writeWSMessage(t, conn, "deployment.log", types.WSDeploymentLog{
+			InstanceID: "42", LogID: "log-1", Line: "starting",
+		})
+		writeWSMessage(t, conn, "deployment.status", types.WSDeploymentStatus{
+			InstanceID: "42", Status: "running", LogID: "log-1",
+		})
+	})
+	defer server.Close()
+
+	c := New(server.URL)
+	var buf bytes.Buffer
+	// Use a never-cancelled context so the goroutine cleanup path under
+	// test is the terminal-status one (not the ctx-cancel one). Any leak
+	// here surfaces via TestMain's goleak.VerifyTestMain.
+	result, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "running", result.Status)
+}
+
 func TestStreamDeploymentLogs_ConnectionError(t *testing.T) {
 	t.Parallel()
 	c := New("http://localhost:1")

--- a/cli/pkg/client/websocket_test.go
+++ b/cli/pkg/client/websocket_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -307,12 +308,21 @@ func TestStreamDeploymentLogs_QueryParamFallbackOn401(t *testing.T) {
 	assert.Equal(t, "tok-logs-fallback", gotToken, "401 on header path must trigger ?token= retry")
 }
 
-// TestStreamDeploymentLogs_QueryParamFallbackDisabledForAPIKey asserts the
-// retry is gated on c.Token. API-key-only callers must see a clean error
-// rather than a misleading retry that would never carry their credential.
+// TestStreamDeploymentLogs_QueryParamFallbackDisabledForAPIKey asserts
+// the retry is gated on c.Token. API-key-only callers must see a clean
+// error rather than a misleading retry — both that the dial is NOT
+// repeated AND that the API key isn't accidentally surfaced as a query
+// param. `require.Error` alone is too weak: a buggy implementation that
+// retried with no token would still return an error from the second 401.
 func TestStreamDeploymentLogs_QueryParamFallbackDisabledForAPIKey(t *testing.T) {
 	t.Parallel()
+	var hits int32
+	var sawToken int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if r.URL.Query().Has("token") {
+			atomic.StoreInt32(&sawToken, 1)
+		}
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer server.Close()
@@ -322,6 +332,8 @@ func TestStreamDeploymentLogs_QueryParamFallbackDisabledForAPIKey(t *testing.T) 
 	var buf bytes.Buffer
 	_, err := c.StreamDeploymentLogs(context.Background(), "42", &buf, nil)
 	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "API-key-only auth must NOT retry with query token")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&sawToken), "no ?token= parameter should ever appear on an API-key request")
 }
 
 // TestStreamDeploymentLogs_GoleakOnTerminalClose is a regression test for

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -2615,6 +2615,55 @@ func TestE2EAnalyticsOverviewJSONParses(t *testing.T) {
 	assert.Equal(t, 7, got.TotalTemplates)
 }
 
+// startE2EStackLogsFollowWS serves a WebSocket upgrade at /ws that emits
+// a single log line and a terminal "running" status, then blocks on
+// ReadMessage so the client's close handshake completes cleanly. Used
+// by the `stack logs --follow` e2e test.
+func startE2EStackLogsFollowWS(t *testing.T) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ws" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Drain the subscribe message before emitting events.
+		_, _, _ = conn.ReadMessage()
+		logPayload, _ := json.Marshal(types.WSDeploymentLog{InstanceID: "42", Line: "installing chart"})
+		logMsg, _ := json.Marshal(types.WSMessage{Type: "deployment.log", Data: logPayload})
+		_ = conn.WriteMessage(websocket.TextMessage, logMsg)
+		statusPayload, _ := json.Marshal(types.WSDeploymentStatus{InstanceID: "42", Status: "running"})
+		statusMsg, _ := json.Marshal(types.WSMessage{Type: "deployment.status", Data: statusPayload})
+		_ = conn.WriteMessage(websocket.TextMessage, statusMsg)
+		_, _, _ = conn.ReadMessage()
+	}))
+}
+
+// TestE2EStackLogsFollow_CompletesOnTerminalStatus builds the binary and
+// exec's `stackctl stack logs 42 --follow` against a stub WS server.
+// Locks the issue acceptance: stream closes cleanly on terminal status
+// and the process exits 0 within the test timeout.
+func TestE2EStackLogsFollow_CompletesOnTerminalStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	server := startE2EStackLogsFollowWS(t)
+	defer server.Close()
+
+	dir := t.TempDir()
+	setupE2EStackContext(t, dir, server.URL)
+
+	stdout, _, err := runStackctl(t, dir, "stack", "logs", "42", "--follow")
+	require.NoError(t, err, "stack logs --follow must exit 0 on terminal status within timeout")
+	assert.Contains(t, stdout, "installing chart")
+}
+
 // startE2EStackWatchWS serves a WebSocket upgrade at /ws that emits the
 // supplied event sequence then holds the connection open until the
 // client closes. Used by the stack watch e2e tests.

--- a/cli/test/integration/stack_integration_test.go
+++ b/cli/test/integration/stack_integration_test.go
@@ -686,3 +686,57 @@ func TestStackWatchCobra_NonZeroOnFailed(t *testing.T) {
 	require.Error(t, err, "terminal error status must surface a non-zero exit")
 	assert.Contains(t, err.Error(), "failed")
 }
+
+// ---------- stack logs --follow ----------
+
+// startFollowLogsIntegrationWS is the integration-layer counterpart of
+// startFollowLogsWS from cmd tests: emits an optional log line + a
+// terminal-status event, then blocks on ReadMessage so the client's
+// close handshake completes cleanly.
+func startFollowLogsIntegrationWS(t *testing.T, status string, lines []string) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ws" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _, _ = conn.ReadMessage()
+		for _, l := range lines {
+			payload, _ := json.Marshal(types.WSDeploymentLog{InstanceID: "42", Line: l})
+			msg, _ := json.Marshal(types.WSMessage{Type: "deployment.log", Data: payload})
+			_ = conn.WriteMessage(websocket.TextMessage, msg)
+		}
+		statusPayload, _ := json.Marshal(types.WSDeploymentStatus{InstanceID: "42", Status: status})
+		statusMsg, _ := json.Marshal(types.WSMessage{Type: "deployment.status", Data: statusPayload})
+		_ = conn.WriteMessage(websocket.TextMessage, statusMsg)
+		_, _, _ = conn.ReadMessage()
+	}))
+}
+
+// TestStackLogsFollowCobra_CompletesOnTerminalStatus drives
+// `stack logs <id> --follow` through cobra.Execute() against a stub WS
+// server that sends a log line and a terminal "running" status. The
+// command must exit 0 within a few seconds.
+func TestStackLogsFollowCobra_CompletesOnTerminalStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	server := startFollowLogsIntegrationWS(t, "running", []string{"installing chart"})
+	defer server.Close()
+
+	t.Setenv("STACKCTL_CONFIG_DIR", t.TempDir())
+	t.Setenv("STACKCTL_API_URL", server.URL)
+
+	var buf bytes.Buffer
+	cmd.ResetFlagsForTest()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"stack", "logs", "42", "--follow"})
+	require.NoError(t, cmd.Execute())
+}


### PR DESCRIPTION
## Summary
- Extract `Client.dialWS` so `StreamDeploymentLogs` and `WatchEvents` share the auth chain (Bearer header → URL-escaped `?token=` fallback on 401). `logs --follow` now gets the same K4 resilience `stack watch` had.
- Harmonise the ctx-cancel watchdog: `StreamDeploymentLogs` now sends `CloseMessage` **and** tears down the TCP connection so a hung server can't pin `ReadMessage` open after Ctrl-C.
- Refactor `followLogs` into a thin signal-handler shim plus testable `followLogsCtx(ctx, client, instanceID, out, warn)`. Documents the Ctrl-C → exit-0 contract (cancellation must not look like a command failure).

## Acceptance criteria

- [x] Stream closes cleanly when deploy reaches terminal status — `TestStreamDeploymentLogs_GoleakOnTerminalClose` runs without a caller-side ctx cancel; the package-level `goleak.VerifyTestMain` (added in #75) verifies no leaked goroutines.
- [x] `goleak.VerifyNone(t)` passes for the follow command test — covered package-wide by `TestMain`.
- [x] No behavioural regression for `--follow=false` path — `TestStackLogsCmd_NoFollowRegression` asserts `wsHits == 0` on the default REST path.
- [x] Auth chain reused — `StreamDeploymentLogs` now routes through the same `dialWS` helper as `WatchEvents`; parity locked by `TestStreamDeploymentLogs_QueryParamFallbackOn401` and `TestStreamDeploymentLogs_QueryParamFallbackDisabledForAPIKey`.

## Test plan

- [x] `go test ./... -count=1` green (cmd 11.5s, client 5.2s, integration 13.7s, e2e 4.9s)
- [x] `go vet ./...` clean
- [x] Unit: 3 client tests + 4 cmd tests
- [x] Integration: `TestStackLogsFollowCobra_CompletesOnTerminalStatus`
- [x] E2E: `TestE2EStackLogsFollow_CompletesOnTerminalStatus` (builds binary, exec's against stub WS server)

This closes the final issue of epic #59.

Tracks #59
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error propagation when deployment log streaming reports terminal failures.

* **Improvements**
  * More reliable WebSocket authentication with automatic fallback for connection retries.
  * Cleaner cancellation and shutdown behavior so follow-mode exits without leaks.
  * Stronger connection cleanup to avoid blocked goroutines.

* **Tests**
  * Added unit, integration, and end-to-end tests covering follow-mode, auth fallback, and shutdown scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->