### PR TITLE
fix(cluster): include registry_password in Create/UpdateClusterRequest

### DIFF
--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -4752,6 +4752,67 @@ func TestUpdateCluster_Error(t *testing.T) {
 	assert.Nil(t, cluster)
 }
 
+// Registry credentials (URL / username / password / pull-secret) must round-trip
+// intact through both CreateCluster and UpdateCluster — kvk-k8s-dev's ACR
+// bootstrap relies on stackctl carrying registry_password, which used to fall
+// out of the request body because the wire types omitted it.
+func TestCreateCluster_RegistryCredentialsRoundTrip(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "acr.example.io", body["registry_url"])
+		assert.Equal(t, "ci-token", body["registry_username"])
+		assert.Equal(t, "s3cret-pw", body["registry_password"])
+		assert.Equal(t, "registry-pull-secret", body["image_pull_secret_name"])
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(types.Cluster{Base: types.Base{ID: "7"}, Name: "acr-cluster", Status: "online"})
+	}))
+	defer server.Close()
+
+	c := New(server.URL)
+	_, err := c.CreateCluster(&types.CreateClusterRequest{
+		Name:                "acr-cluster",
+		RegistryURL:         "acr.example.io",
+		RegistryUsername:    "ci-token",
+		RegistryPassword:    "s3cret-pw",
+		ImagePullSecretName: "registry-pull-secret",
+	})
+	require.NoError(t, err)
+}
+
+func TestUpdateCluster_RegistryCredentialsRoundTrip(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "acr.example.io", body["registry_url"])
+		assert.Equal(t, "ci-token", body["registry_username"])
+		assert.Equal(t, "rotated-pw", body["registry_password"])
+		assert.Equal(t, "registry-pull-secret", body["image_pull_secret_name"])
+		// Untouched fields stay out of the request — verifies omitempty on pointers.
+		_, hasName := body["name"]
+		assert.False(t, hasName)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(types.Cluster{Base: types.Base{ID: "3"}, Name: "acr-cluster", Status: "online"})
+	}))
+	defer server.Close()
+
+	url := "acr.example.io"
+	user := "ci-token"
+	pw := "rotated-pw"
+	secret := "registry-pull-secret"
+
+	c := New(server.URL)
+	_, err := c.UpdateCluster("3", &types.UpdateClusterRequest{
+		RegistryURL:         &url,
+		RegistryUsername:    &user,
+		RegistryPassword:    &pw,
+		ImagePullSecretName: &secret,
+	})
+	require.NoError(t, err)
+}
+
 func TestDeleteCluster_Success(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -88,6 +88,7 @@ type CreateClusterRequest struct {
 	UseInCluster        bool   `json:"use_in_cluster,omitempty" yaml:"use_in_cluster,omitempty"`
 	RegistryURL         string `json:"registry_url,omitempty" yaml:"registry_url,omitempty"`
 	RegistryUsername    string `json:"registry_username,omitempty" yaml:"registry_username,omitempty"`
+	RegistryPassword    string `json:"registry_password,omitempty" yaml:"registry_password,omitempty"`
 	ImagePullSecretName string `json:"image_pull_secret_name,omitempty" yaml:"image_pull_secret_name,omitempty"`
 }
 
@@ -106,6 +107,7 @@ type UpdateClusterRequest struct {
 	UseInCluster        *bool   `json:"use_in_cluster,omitempty" yaml:"use_in_cluster,omitempty"`
 	RegistryURL         *string `json:"registry_url,omitempty" yaml:"registry_url,omitempty"`
 	RegistryUsername    *string `json:"registry_username,omitempty" yaml:"registry_username,omitempty"`
+	RegistryPassword    *string `json:"registry_password,omitempty" yaml:"registry_password,omitempty"`
 	ImagePullSecretName *string `json:"image_pull_secret_name,omitempty" yaml:"image_pull_secret_name,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
`CreateClusterRequest` / `UpdateClusterRequest` in [cli/pkg/types/types.go](cli/pkg/types/types.go) had `registry_url`, `registry_username`, and `image_pull_secret_name` but **not** `registry_password`. The backend has accepted it since the `registry_password` column was added in [migration 0042](../k8s-stack-manager/backend/internal/database/migrations.go#L818) — stackctl just silently dropped it from the JSON body.

Any caller that needed to set ACR / private-registry pull credentials had to drop down to `curl` because the password fell out. The kvk-k8s-dev bootstrap (`scripts/bootstrap-local.sh`) and ACR-token refresh (`scripts/refresh-acr-token.sh`) both hit this and can't fully migrate off direct API calls until this lands.

## Change
- Add `RegistryPassword` (string + `*string` in the update variant) to both request types, beside the existing url/username/pull-secret triple.
- Two new round-trip tests in `client_test.go`:
  - `TestCreateCluster_RegistryCredentialsRoundTrip` — asserts all 4 registry fields appear on `POST /api/v1/clusters` with snake_case keys.
  - `TestUpdateCluster_RegistryCredentialsRoundTrip` — same for `PUT /api/v1/clusters/:id`, plus a negative assertion that untouched pointer fields stay out of the body (verifies `omitempty` on pointers).

No CLI flag added — credentials should not be passed on the command line. Callers use `cluster create --from-file` / `cluster update --from-file`, matching the rest of the admin-payload pattern.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` full suite green
- [x] Both new round-trip tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying registry password during cluster creation
  * Registry password can now be configured and updated for existing clusters

* **Tests**
  * Added test cases verifying registry credentials are correctly serialized during cluster operations
  * Tests ensure unrelated fields are not sent when not provided

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->