### PR TITLE
fix(bulk,types): align bulk + ChartConfig wire contracts with backend + add live test suite

### DIFF
--- a/cli/cmd/bulk.go
+++ b/cli/cmd/bulk.go
@@ -455,8 +455,8 @@ func resolveBulkIDs(c *client.Client, cmd *cobra.Command, args []string) ([]stri
 func printBulkResults(resp *types.BulkResponse) error {
 	if printer.Quiet {
 		for _, r := range resp.Results {
-			if r.Success {
-				fmt.Fprintln(printer.Writer, r.ID)
+			if r.Success() {
+				fmt.Fprintln(printer.Writer, r.ID())
 			}
 		}
 		return nil
@@ -471,13 +471,9 @@ func printBulkResults(resp *types.BulkResponse) error {
 		headers := []string{"ID", "STATUS", "ERROR"}
 		rows := make([][]string, len(resp.Results))
 		for i, r := range resp.Results {
-			status := "success"
-			if !r.Success {
-				status = "failed"
-			}
 			rows[i] = []string{
-				r.ID,
-				printer.StatusColor(status),
+				r.ID(),
+				printer.StatusColor(r.Status),
 				r.Error,
 			}
 		}

--- a/cli/cmd/bulk_test.go
+++ b/cli/cmd/bulk_test.go
@@ -25,9 +25,9 @@ func setupBulkTestCmd(t *testing.T, apiURL string) *bytes.Buffer {
 func sampleBulkResponse() types.BulkResponse {
 	return types.BulkResponse{
 		Results: []types.BulkOperationResult{
-			{ID: "1", Success: true},
-			{ID: "2", Success: true},
-			{ID: "3", Success: false, Error: "not found"},
+			{InstanceID: "1", Status: "success"},
+			{InstanceID: "2", Status: "success"},
+			{InstanceID: "3", Status: "error", Error: "not found"},
 		},
 	}
 }
@@ -40,9 +40,9 @@ func TestBulkDeployCmd_TableOutput(t *testing.T) {
 		require.Equal(t, "/api/v1/stack-instances/bulk/deploy", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 
-		var body types.BulkRequest
+		var body types.BulkInstancesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"1", "2", "3"}, body.IDs)
+		assert.Equal(t, []string{"1", "2", "3"}, body.InstanceIDs)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -88,8 +88,8 @@ func TestBulkDeployCmd_JSONOutput(t *testing.T) {
 	var result types.BulkResponse
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &result))
 	assert.Len(t, result.Results, 3)
-	assert.True(t, result.Results[0].Success)
-	assert.False(t, result.Results[2].Success)
+	assert.True(t, result.Results[0].Success())
+	assert.False(t, result.Results[2].Success())
 }
 
 func TestBulkDeployCmd_QuietOutput(t *testing.T) {
@@ -474,8 +474,8 @@ func TestBulkDeployCmd_YAMLOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "id: \"1\"")
-	assert.Contains(t, out, "success: true")
+	assert.Contains(t, out, "instance_id: \"1\"")
+	assert.Contains(t, out, "status: success")
 	assert.Contains(t, out, "error: not found")
 }
 
@@ -524,8 +524,8 @@ func TestBulkStopCmd_YAMLOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "id: \"1\"")
-	assert.Contains(t, out, "success: true")
+	assert.Contains(t, out, "instance_id: \"1\"")
+	assert.Contains(t, out, "status: success")
 }
 
 func TestBulkStopCmd_QuietOutput(t *testing.T) {
@@ -593,8 +593,8 @@ func TestBulkCleanCmd_YAMLOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "id: \"1\"")
-	assert.Contains(t, out, "success: true")
+	assert.Contains(t, out, "instance_id: \"1\"")
+	assert.Contains(t, out, "status: success")
 }
 
 // ---------- bulk delete additional output modes ----------
@@ -622,8 +622,8 @@ func TestBulkDeleteCmd_YAMLOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "id: \"1\"")
-	assert.Contains(t, out, "success: true")
+	assert.Contains(t, out, "instance_id: \"1\"")
+	assert.Contains(t, out, "status: success")
 }
 
 // ---------- resolveBulkIDs edge cases ----------
@@ -689,9 +689,9 @@ func TestBulkDeployCmd_PositionalArgs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/api/v1/stack-instances/bulk/deploy", r.URL.Path)
 
-		var body types.BulkRequest
+		var body types.BulkInstancesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"1", "2", "3"}, body.IDs)
+		assert.Equal(t, []string{"1", "2", "3"}, body.InstanceIDs)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -712,9 +712,9 @@ func TestBulkDeployCmd_PositionalArgs(t *testing.T) {
 func TestBulkDeployCmd_MixedArgs(t *testing.T) {
 	resp := sampleBulkResponse()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body types.BulkRequest
+		var body types.BulkInstancesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"1", "2", "3"}, body.IDs)
+		assert.Equal(t, []string{"1", "2", "3"}, body.InstanceIDs)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -821,9 +821,9 @@ func TestBulkTemplatePublishCmd_TableOutput(t *testing.T) {
 		require.Equal(t, "/api/v1/templates/bulk/publish", r.URL.Path)
 		require.Equal(t, http.MethodPost, r.Method)
 
-		var body types.BulkRequest
+		var body types.BulkTemplatesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"1", "2", "3"}, body.IDs)
+		assert.Equal(t, []string{"1", "2", "3"}, body.TemplateIDs)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -889,8 +889,8 @@ func TestBulkTemplatePublishCmd_YAMLOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
-	assert.Contains(t, out, "id: \"1\"")
-	assert.Contains(t, out, "success: true")
+	assert.Contains(t, out, "instance_id: \"1\"")
+	assert.Contains(t, out, "status: success")
 }
 
 func TestBulkTemplatePublishCmd_QuietOutput(t *testing.T) {
@@ -1019,8 +1019,8 @@ func TestBulkTemplateUnpublishCmd_YAMLOutput(t *testing.T) {
 	err := bulkTemplateUnpublishCmd.RunE(bulkTemplateUnpublishCmd, []string{})
 	require.NoError(t, err)
 	out := buf.String()
-	assert.Contains(t, out, "id: \"1\"")
-	assert.Contains(t, out, "success: true")
+	assert.Contains(t, out, "instance_id: \"1\"")
+	assert.Contains(t, out, "status: success")
 }
 
 func TestBulkTemplateUnpublishCmd_APIError(t *testing.T) {
@@ -1225,8 +1225,8 @@ func TestBulkTemplateDeleteCmd_YAMLOutput(t *testing.T) {
 	err := bulkTemplateDeleteCmd.RunE(bulkTemplateDeleteCmd, []string{})
 	require.NoError(t, err)
 	out := buf.String()
-	assert.Contains(t, out, "id: \"1\"")
-	assert.Contains(t, out, "success: true")
+	assert.Contains(t, out, "instance_id: \"1\"")
+	assert.Contains(t, out, "status: success")
 }
 
 func TestBulkTemplateDeleteCmd_QuietOutput(t *testing.T) {

--- a/cli/pkg/client/client.go
+++ b/cli/pkg/client/client.go
@@ -950,7 +950,7 @@ func (c *Client) CompareInstances(leftID, rightID string) (*types.CompareResult,
 // BulkDeploy triggers deployment for multiple stack instances.
 func (c *Client) BulkDeploy(ids []string) (*types.BulkResponse, error) {
 	var resp types.BulkResponse
-	err := c.Post("/api/v1/stack-instances/bulk/deploy", types.BulkRequest{IDs: ids}, &resp)
+	err := c.Post("/api/v1/stack-instances/bulk/deploy", types.BulkInstancesRequest{InstanceIDs: ids}, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -960,7 +960,7 @@ func (c *Client) BulkDeploy(ids []string) (*types.BulkResponse, error) {
 // BulkStop stops multiple stack instances.
 func (c *Client) BulkStop(ids []string) (*types.BulkResponse, error) {
 	var resp types.BulkResponse
-	err := c.Post("/api/v1/stack-instances/bulk/stop", types.BulkRequest{IDs: ids}, &resp)
+	err := c.Post("/api/v1/stack-instances/bulk/stop", types.BulkInstancesRequest{InstanceIDs: ids}, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -970,7 +970,7 @@ func (c *Client) BulkStop(ids []string) (*types.BulkResponse, error) {
 // BulkClean undeploys and removes namespaces for multiple stack instances.
 func (c *Client) BulkClean(ids []string) (*types.BulkResponse, error) {
 	var resp types.BulkResponse
-	err := c.Post("/api/v1/stack-instances/bulk/clean", types.BulkRequest{IDs: ids}, &resp)
+	err := c.Post("/api/v1/stack-instances/bulk/clean", types.BulkInstancesRequest{InstanceIDs: ids}, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -980,7 +980,7 @@ func (c *Client) BulkClean(ids []string) (*types.BulkResponse, error) {
 // BulkDelete deletes multiple stack instances.
 func (c *Client) BulkDelete(ids []string) (*types.BulkResponse, error) {
 	var resp types.BulkResponse
-	err := c.Post("/api/v1/stack-instances/bulk/delete", types.BulkRequest{IDs: ids}, &resp)
+	err := c.Post("/api/v1/stack-instances/bulk/delete", types.BulkInstancesRequest{InstanceIDs: ids}, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -990,7 +990,7 @@ func (c *Client) BulkDelete(ids []string) (*types.BulkResponse, error) {
 // BulkDeleteTemplates deletes multiple stack templates.
 func (c *Client) BulkDeleteTemplates(ids []string) (*types.BulkResponse, error) {
 	var resp types.BulkResponse
-	err := c.Post("/api/v1/templates/bulk/delete", types.BulkRequest{IDs: ids}, &resp)
+	err := c.Post("/api/v1/templates/bulk/delete", types.BulkTemplatesRequest{TemplateIDs: ids}, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -1000,7 +1000,7 @@ func (c *Client) BulkDeleteTemplates(ids []string) (*types.BulkResponse, error) 
 // BulkPublishTemplates publishes multiple stack templates.
 func (c *Client) BulkPublishTemplates(ids []string) (*types.BulkResponse, error) {
 	var resp types.BulkResponse
-	err := c.Post("/api/v1/templates/bulk/publish", types.BulkRequest{IDs: ids}, &resp)
+	err := c.Post("/api/v1/templates/bulk/publish", types.BulkTemplatesRequest{TemplateIDs: ids}, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,7 +1010,7 @@ func (c *Client) BulkPublishTemplates(ids []string) (*types.BulkResponse, error)
 // BulkUnpublishTemplates unpublishes multiple stack templates.
 func (c *Client) BulkUnpublishTemplates(ids []string) (*types.BulkResponse, error) {
 	var resp types.BulkResponse
-	err := c.Post("/api/v1/templates/bulk/unpublish", types.BulkRequest{IDs: ids}, &resp)
+	err := c.Post("/api/v1/templates/bulk/unpublish", types.BulkTemplatesRequest{TemplateIDs: ids}, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/client/client_test.go
+++ b/cli/pkg/client/client_test.go
@@ -1757,15 +1757,18 @@ func TestBulkDeploy_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/stack-instances/bulk/deploy", r.URL.Path)
-		var body types.BulkRequest
+		// Backend's stack-instance bulk endpoints require `instance_ids` —
+		// stubs decode into the matching wire type so the contract is
+		// locked here, not just in live tests.
+		var body types.BulkInstancesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"1", "2", "3"}, body.IDs)
+		assert.Equal(t, []string{"1", "2", "3"}, body.InstanceIDs)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.BulkResponse{
 			Results: []types.BulkOperationResult{
-				{ID: "1", Success: true},
-				{ID: "2", Success: true},
-				{ID: "3", Success: false, Error: "not found"},
+				{InstanceID: "1", Status: "success"},
+				{InstanceID: "2", Status: "success"},
+				{InstanceID: "3", Status: "error", Error: "not found"},
 			},
 		})
 	}))
@@ -1775,8 +1778,8 @@ func TestBulkDeploy_Success(t *testing.T) {
 	resp, err := c.BulkDeploy([]string{"1", "2", "3"})
 	require.NoError(t, err)
 	assert.Len(t, resp.Results, 3)
-	assert.True(t, resp.Results[0].Success)
-	assert.False(t, resp.Results[2].Success)
+	assert.True(t, resp.Results[0].Success())
+	assert.False(t, resp.Results[2].Success())
 	assert.Equal(t, "not found", resp.Results[2].Error)
 }
 
@@ -1802,7 +1805,7 @@ func TestBulkStop_Success(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.BulkResponse{
 			Results: []types.BulkOperationResult{
-				{ID: "1", Success: true},
+				{InstanceID: "1", Status: "success"},
 			},
 		})
 	}))
@@ -1812,7 +1815,7 @@ func TestBulkStop_Success(t *testing.T) {
 	resp, err := c.BulkStop([]string{"1"})
 	require.NoError(t, err)
 	assert.Len(t, resp.Results, 1)
-	assert.True(t, resp.Results[0].Success)
+	assert.True(t, resp.Results[0].Success())
 }
 
 func TestBulkStop_Error(t *testing.T) {
@@ -1837,8 +1840,8 @@ func TestBulkClean_Success(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.BulkResponse{
 			Results: []types.BulkOperationResult{
-				{ID: "5", Success: true},
-				{ID: "6", Success: true},
+				{InstanceID: "5", Status: "success"},
+				{InstanceID: "6", Status: "success"},
 			},
 		})
 	}))
@@ -1872,7 +1875,7 @@ func TestBulkDelete_Success(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.BulkResponse{
 			Results: []types.BulkOperationResult{
-				{ID: "10", Success: true},
+				{InstanceID: "10", Status: "success"},
 			},
 		})
 	}))
@@ -1882,7 +1885,7 @@ func TestBulkDelete_Success(t *testing.T) {
 	resp, err := c.BulkDelete([]string{"10"})
 	require.NoError(t, err)
 	assert.Len(t, resp.Results, 1)
-	assert.True(t, resp.Results[0].Success)
+	assert.True(t, resp.Results[0].Success())
 }
 
 func TestBulkDelete_Error(t *testing.T) {
@@ -4564,15 +4567,16 @@ func TestBulkPublishTemplates_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/templates/bulk/publish", r.URL.Path)
-		var body types.BulkRequest
+		// Backend's template bulk endpoints require `template_ids`.
+		var body types.BulkTemplatesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"1", "2", "3"}, body.IDs)
+		assert.Equal(t, []string{"1", "2", "3"}, body.TemplateIDs)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.BulkResponse{
 			Results: []types.BulkOperationResult{
-				{ID: "1", Success: true},
-				{ID: "2", Success: true},
-				{ID: "3", Success: false, Error: "not found"},
+				{TemplateID: "1", Status: "success"},
+				{TemplateID: "2", Status: "success"},
+				{TemplateID: "3", Status: "error", Error: "not found"},
 			},
 		})
 	}))
@@ -4582,8 +4586,8 @@ func TestBulkPublishTemplates_Success(t *testing.T) {
 	resp, err := c.BulkPublishTemplates([]string{"1", "2", "3"})
 	require.NoError(t, err)
 	assert.Len(t, resp.Results, 3)
-	assert.True(t, resp.Results[0].Success)
-	assert.False(t, resp.Results[2].Success)
+	assert.True(t, resp.Results[0].Success())
+	assert.False(t, resp.Results[2].Success())
 	assert.Equal(t, "not found", resp.Results[2].Error)
 }
 
@@ -4606,14 +4610,14 @@ func TestBulkUnpublishTemplates_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/templates/bulk/unpublish", r.URL.Path)
-		var body types.BulkRequest
+		var body types.BulkTemplatesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"a", "b"}, body.IDs)
+		assert.Equal(t, []string{"a", "b"}, body.TemplateIDs)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.BulkResponse{
 			Results: []types.BulkOperationResult{
-				{ID: "a", Success: true},
-				{ID: "b", Success: true},
+				{TemplateID: "a", Status: "success"},
+				{TemplateID: "b", Status: "success"},
 			},
 		})
 	}))
@@ -4623,7 +4627,7 @@ func TestBulkUnpublishTemplates_Success(t *testing.T) {
 	resp, err := c.BulkUnpublishTemplates([]string{"a", "b"})
 	require.NoError(t, err)
 	assert.Len(t, resp.Results, 2)
-	assert.True(t, resp.Results[0].Success)
+	assert.True(t, resp.Results[0].Success())
 }
 
 func TestBulkUnpublishTemplates_Error(t *testing.T) {
@@ -4645,14 +4649,14 @@ func TestBulkDeleteTemplates_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "/api/v1/templates/bulk/delete", r.URL.Path)
-		var body types.BulkRequest
+		var body types.BulkTemplatesRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"10", "20"}, body.IDs)
+		assert.Equal(t, []string{"10", "20"}, body.TemplateIDs)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(types.BulkResponse{
 			Results: []types.BulkOperationResult{
-				{ID: "10", Success: true},
-				{ID: "20", Success: false, Error: "in use"},
+				{TemplateID: "10", Status: "success"},
+				{TemplateID: "20", Status: "error", Error: "in use"},
 			},
 		})
 	}))
@@ -4662,8 +4666,8 @@ func TestBulkDeleteTemplates_Success(t *testing.T) {
 	resp, err := c.BulkDeleteTemplates([]string{"10", "20"})
 	require.NoError(t, err)
 	assert.Len(t, resp.Results, 2)
-	assert.True(t, resp.Results[0].Success)
-	assert.False(t, resp.Results[1].Success)
+	assert.True(t, resp.Results[0].Success())
+	assert.False(t, resp.Results[1].Success())
 	assert.Equal(t, "in use", resp.Results[1].Error)
 }
 

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -523,16 +523,50 @@ type ListResponse[T any] struct {
 	TotalPages int `json:"total_pages"`
 }
 
-// BulkOperationResult represents the result of a bulk operation.
+// BulkOperationResult represents the result of a single instance/template in
+// a bulk operation. Field names match the backend's BulkOperationResultItem
+// (stack-instance bulk) and the equivalent template bulk handler — both ship
+// `instance_id` (or template_id) plus a string `status` of "success"/"error",
+// not a bool. Earlier versions of this struct used `id` + `success` which
+// caused the response to silently decode as zero values against the live
+// backend.
 type BulkOperationResult struct {
-	ID      string `json:"id" yaml:"id"`
-	Success bool   `json:"success" yaml:"success"`
-	Error   string `json:"error,omitempty" yaml:"error,omitempty"`
+	// InstanceID is set on stack-instance bulk responses (deploy/stop/clean/delete).
+	InstanceID string `json:"instance_id,omitempty" yaml:"instance_id,omitempty"`
+	// TemplateID is set on template bulk responses (delete/publish/unpublish).
+	TemplateID   string `json:"template_id,omitempty" yaml:"template_id,omitempty"`
+	InstanceName string `json:"instance_name,omitempty" yaml:"instance_name,omitempty"`
+	TemplateName string `json:"template_name,omitempty" yaml:"template_name,omitempty"`
+	// Status is the per-item outcome; backend returns "success" or "error".
+	Status string `json:"status" yaml:"status"`
+	Error  string `json:"error,omitempty" yaml:"error,omitempty"`
+	LogID  string `json:"log_id,omitempty" yaml:"log_id,omitempty"`
 }
 
-// BulkResponse wraps bulk operation results.
+// ID returns the identifier carried by this result regardless of whether the
+// underlying endpoint was instance-scoped or template-scoped. Empty if neither
+// field is populated.
+func (r BulkOperationResult) ID() string {
+	if r.InstanceID != "" {
+		return r.InstanceID
+	}
+	return r.TemplateID
+}
+
+// Success returns true when the per-item status is "success". A miscoded
+// or omitted status string therefore reads as failure, which matches the
+// caller's expectation (no positive confirmation == treat as failed).
+func (r BulkOperationResult) Success() bool {
+	return r.Status == "success"
+}
+
+// BulkResponse wraps bulk operation results. Total/Successful/Failed mirror
+// the backend's BulkOperationResponse counters; Results retains per-item detail.
 type BulkResponse struct {
-	Results []BulkOperationResult `json:"results" yaml:"results"`
+	Total      int                   `json:"total" yaml:"total"`
+	Successful int                   `json:"successful" yaml:"successful"`
+	Failed     int                   `json:"failed" yaml:"failed"`
+	Results    []BulkOperationResult `json:"results" yaml:"results"`
 }
 
 // ValueOverride represents a per-chart value override.
@@ -603,9 +637,19 @@ type OrphanedNamespace struct {
 	CreatedAt string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
-// BulkRequest is the request body for bulk operations.
-type BulkRequest struct {
-	IDs []string `json:"ids" yaml:"ids"`
+// BulkInstancesRequest is the request body for bulk operations against
+// stack instances (deploy / stop / clean / delete). The backend handler
+// binds into `{"instance_ids": [...]}` with `binding:"required"` — using
+// any other key returns 400 "instance_ids is required".
+type BulkInstancesRequest struct {
+	InstanceIDs []string `json:"instance_ids" yaml:"instance_ids"`
+}
+
+// BulkTemplatesRequest is the request body for bulk operations against
+// stack templates (delete / publish / unpublish). The backend handler
+// binds into `{"template_ids": [...]}` with `binding:"required"`.
+type BulkTemplatesRequest struct {
+	TemplateIDs []string `json:"template_ids" yaml:"template_ids"`
 }
 
 // GitValidateResponse represents the result of branch validation.

--- a/cli/pkg/types/types.go
+++ b/cli/pkg/types/types.go
@@ -52,16 +52,24 @@ type StackTemplate struct {
 	DefinitionCount int           `json:"definition_count,omitempty" yaml:"definition_count,omitempty"`
 }
 
-// ChartConfig represents a Helm chart configuration within a definition or template.
+// ChartConfig represents a Helm chart configuration within a definition or
+// template. Field set is the union of backend models.ChartConfig (definition
+// charts) and models.TemplateChartConfig (template charts) — LockedValues and
+// Required are populated only on template-chart responses.
 type ChartConfig struct {
 	Base
-	Name          string `json:"name" yaml:"name"`
-	RepoURL       string `json:"repository_url" yaml:"repository_url"`
-	SourceRepoURL string `json:"source_repo_url,omitempty" yaml:"source_repo_url,omitempty"`
-	ChartName     string `json:"chart_name" yaml:"chart_name"`
-	ChartVersion  string `json:"chart_version,omitempty" yaml:"chart_version,omitempty"`
-	ReleaseName   string `json:"release_name,omitempty" yaml:"release_name,omitempty"`
-	DefaultValues string `json:"default_values,omitempty" yaml:"default_values,omitempty"`
+	Name            string `json:"name" yaml:"name"`
+	RepoURL         string `json:"repository_url" yaml:"repository_url"`
+	SourceRepoURL   string `json:"source_repo_url,omitempty" yaml:"source_repo_url,omitempty"`
+	ChartName       string `json:"chart_name" yaml:"chart_name"`
+	ChartPath       string `json:"chart_path,omitempty" yaml:"chart_path,omitempty"`
+	ChartVersion    string `json:"chart_version,omitempty" yaml:"chart_version,omitempty"`
+	ReleaseName     string `json:"release_name,omitempty" yaml:"release_name,omitempty"`
+	DefaultValues   string `json:"default_values,omitempty" yaml:"default_values,omitempty"`
+	LockedValues    string `json:"locked_values,omitempty" yaml:"locked_values,omitempty"`
+	DeployOrder     int    `json:"deploy_order,omitempty" yaml:"deploy_order,omitempty"`
+	Required        bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	BuildPipelineID string `json:"build_pipeline_id,omitempty" yaml:"build_pipeline_id,omitempty"`
 }
 
 // Cluster represents a registered Kubernetes cluster.

--- a/cli/pkg/types/types_test.go
+++ b/cli/pkg/types/types_test.go
@@ -145,11 +145,16 @@ func TestStackDefinition_JSONRoundTrip(t *testing.T) {
 		Owner:         "admin",
 		Charts: []ChartConfig{
 			{
-				Base:         Base{ID: "chart-1"},
-				Name:         "api",
-				RepoURL:      "https://charts.example.com",
-				ChartName:    "api-chart",
-				ChartVersion: "1.0.0",
+				Base:            Base{ID: "chart-1"},
+				Name:            "api",
+				RepoURL:         "https://charts.example.com",
+				ChartName:       "api-chart",
+				ChartPath:       "charts/api",
+				ChartVersion:    "1.0.0",
+				DeployOrder:     2,
+				BuildPipelineID: "pipeline-42",
+				LockedValues:    "image:\n  tag: v1",
+				Required:        true,
 			},
 		},
 	}
@@ -163,6 +168,14 @@ func TestStackDefinition_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, orig.Name, decoded.Name)
 	assert.Equal(t, orig.DefaultBranch, decoded.DefaultBranch)
 	assert.Len(t, decoded.Charts, 1)
-	assert.Equal(t, "api", decoded.Charts[0].Name)
-	assert.Equal(t, "1.0.0", decoded.Charts[0].ChartVersion)
+	ch := decoded.Charts[0]
+	assert.Equal(t, "api", ch.Name)
+	assert.Equal(t, "1.0.0", ch.ChartVersion)
+	// Round-trip the union fields so we catch silent drops (regression for
+	// the 5-field gap that the live template test surfaced).
+	assert.Equal(t, "charts/api", ch.ChartPath)
+	assert.Equal(t, 2, ch.DeployOrder)
+	assert.Equal(t, "pipeline-42", ch.BuildPipelineID)
+	assert.Equal(t, "image:\n  tag: v1", ch.LockedValues)
+	assert.True(t, ch.Required)
 }

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -896,6 +896,11 @@ func startE2ETemplateDefMockServer(t *testing.T) *httptest.Server {
 				json.NewEncoder(w).Encode(map[string]string{"error": "invalid body"})
 				return
 			}
+			if len(req.TemplateIDs) == 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "template_ids required"})
+				return
+			}
 			var results []map[string]interface{}
 			for _, id := range req.TemplateIDs {
 				results = append(results, map[string]interface{}{"template_id": id, "status": "success"})
@@ -918,6 +923,11 @@ func startE2ETemplateDefMockServer(t *testing.T) *httptest.Server {
 				json.NewEncoder(w).Encode(map[string]string{"error": "invalid body"})
 				return
 			}
+			if len(req.TemplateIDs) == 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "template_ids required"})
+				return
+			}
 			var results []map[string]interface{}
 			for _, id := range req.TemplateIDs {
 				results = append(results, map[string]interface{}{"template_id": id, "status": "success"})
@@ -938,6 +948,11 @@ func startE2ETemplateDefMockServer(t *testing.T) *httptest.Server {
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				json.NewEncoder(w).Encode(map[string]string{"error": "invalid body"})
+				return
+			}
+			if len(req.TemplateIDs) == 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "template_ids required"})
 				return
 			}
 			var results []map[string]interface{}

--- a/cli/test/e2e/cli_e2e_test.go
+++ b/cli/test/e2e/cli_e2e_test.go
@@ -889,7 +889,7 @@ func startE2ETemplateDefMockServer(t *testing.T) *httptest.Server {
 		// Bulk publish templates
 		case r.URL.Path == "/api/v1/templates/bulk/publish" && r.Method == http.MethodPost:
 			var req struct {
-				IDs []string `json:"ids"`
+				TemplateIDs []string `json:"template_ids"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				w.WriteHeader(http.StatusBadRequest)
@@ -897,16 +897,21 @@ func startE2ETemplateDefMockServer(t *testing.T) *httptest.Server {
 				return
 			}
 			var results []map[string]interface{}
-			for _, id := range req.IDs {
-				results = append(results, map[string]interface{}{"id": id, "success": true})
+			for _, id := range req.TemplateIDs {
+				results = append(results, map[string]interface{}{"template_id": id, "status": "success"})
 			}
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"results": results})
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"results":    results,
+				"total":      len(results),
+				"successful": len(results),
+				"failed":     0,
+			})
 
 		// Bulk unpublish templates
 		case r.URL.Path == "/api/v1/templates/bulk/unpublish" && r.Method == http.MethodPost:
 			var req struct {
-				IDs []string `json:"ids"`
+				TemplateIDs []string `json:"template_ids"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				w.WriteHeader(http.StatusBadRequest)
@@ -914,16 +919,21 @@ func startE2ETemplateDefMockServer(t *testing.T) *httptest.Server {
 				return
 			}
 			var results []map[string]interface{}
-			for _, id := range req.IDs {
-				results = append(results, map[string]interface{}{"id": id, "success": true})
+			for _, id := range req.TemplateIDs {
+				results = append(results, map[string]interface{}{"template_id": id, "status": "success"})
 			}
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"results": results})
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"results":    results,
+				"total":      len(results),
+				"successful": len(results),
+				"failed":     0,
+			})
 
 		// Bulk delete templates
 		case r.URL.Path == "/api/v1/templates/bulk/delete" && r.Method == http.MethodPost:
 			var req struct {
-				IDs []string `json:"ids"`
+				TemplateIDs []string `json:"template_ids"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				w.WriteHeader(http.StatusBadRequest)
@@ -931,11 +941,16 @@ func startE2ETemplateDefMockServer(t *testing.T) *httptest.Server {
 				return
 			}
 			var results []map[string]interface{}
-			for _, id := range req.IDs {
-				results = append(results, map[string]interface{}{"id": id, "success": true})
+			for _, id := range req.TemplateIDs {
+				results = append(results, map[string]interface{}{"template_id": id, "status": "success"})
 			}
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"results": results})
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"results":    results,
+				"total":      len(results),
+				"successful": len(results),
+				"failed":     0,
+			})
 
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -1205,53 +1220,68 @@ func startE2EQuietPipingMockServer(t *testing.T) *httptest.Server {
 		// Bulk deploy
 		case r.URL.Path == "/api/v1/stack-instances/bulk/deploy" && r.Method == http.MethodPost:
 			var req struct {
-				IDs []string `json:"ids"`
+				InstanceIDs []string `json:"instance_ids"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.IDs) == 0 {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.InstanceIDs) == 0 {
 				w.WriteHeader(http.StatusBadRequest)
-				json.NewEncoder(w).Encode(map[string]string{"error": "ids required"})
+				json.NewEncoder(w).Encode(map[string]string{"error": "instance_ids required"})
 				return
 			}
 			var results []map[string]interface{}
-			for _, id := range req.IDs {
-				results = append(results, map[string]interface{}{"id": id, "success": true})
+			for _, id := range req.InstanceIDs {
+				results = append(results, map[string]interface{}{"instance_id": id, "status": "success"})
 			}
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"results": results})
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"results":    results,
+				"total":      len(results),
+				"successful": len(results),
+				"failed":     0,
+			})
 
 		// Bulk stop
 		case r.URL.Path == "/api/v1/stack-instances/bulk/stop" && r.Method == http.MethodPost:
 			var req struct {
-				IDs []string `json:"ids"`
+				InstanceIDs []string `json:"instance_ids"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.IDs) == 0 {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.InstanceIDs) == 0 {
 				w.WriteHeader(http.StatusBadRequest)
-				json.NewEncoder(w).Encode(map[string]string{"error": "ids required"})
+				json.NewEncoder(w).Encode(map[string]string{"error": "instance_ids required"})
 				return
 			}
 			var results []map[string]interface{}
-			for _, id := range req.IDs {
-				results = append(results, map[string]interface{}{"id": id, "success": true})
+			for _, id := range req.InstanceIDs {
+				results = append(results, map[string]interface{}{"instance_id": id, "status": "success"})
 			}
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"results": results})
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"results":    results,
+				"total":      len(results),
+				"successful": len(results),
+				"failed":     0,
+			})
 
 		// Bulk delete
 		case r.URL.Path == "/api/v1/stack-instances/bulk/delete" && r.Method == http.MethodPost:
 			var req struct {
-				IDs []string `json:"ids"`
+				InstanceIDs []string `json:"instance_ids"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.IDs) == 0 {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil || len(req.InstanceIDs) == 0 {
 				w.WriteHeader(http.StatusBadRequest)
-				json.NewEncoder(w).Encode(map[string]string{"error": "ids required"})
+				json.NewEncoder(w).Encode(map[string]string{"error": "instance_ids required"})
 				return
 			}
 			var results []map[string]interface{}
-			for _, id := range req.IDs {
-				results = append(results, map[string]interface{}{"id": id, "success": true})
+			for _, id := range req.InstanceIDs {
+				results = append(results, map[string]interface{}{"instance_id": id, "status": "success"})
 			}
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"results": results})
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"results":    results,
+				"total":      len(results),
+				"successful": len(results),
+				"failed":     0,
+			})
 
 		default:
 			w.WriteHeader(http.StatusNotFound)

--- a/cli/test/live/audit_live_test.go
+++ b/cli/test/live/audit_live_test.go
@@ -1,0 +1,78 @@
+//go:build live
+
+package live
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveAuditLog_List verifies the audit log read contract. The backend
+// is expected to always have at least the login event from our own auth
+// call earlier in the suite.
+func TestLiveAuditLog_List(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	resp, err := c.ListAuditLogs(types.AuditLogListParams{Limit: 5})
+	require.NoError(t, err, "list audit logs")
+	// We expect at least one entry (our auth call generated one). If the
+	// backend has audit disabled the list will be empty; that's a config
+	// issue we don't want to fail the suite on.
+	if len(resp.Data) == 0 {
+		t.Skip("audit log empty — likely disabled on this backend")
+	}
+
+	first := resp.Data[0]
+	assert.NotEmpty(t, first.Action, "audit entry must have an action")
+	assert.False(t, first.Timestamp.IsZero(), "audit entry must have a timestamp")
+}
+
+// TestLiveAuditLog_FilterByEntityType locks the filter wire contract.
+// The persistent flags on `stackctl audit log` map to these query params;
+// if backend names drift, lists silently return un-filtered data.
+func TestLiveAuditLog_FilterByEntityType(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	resp, err := c.ListAuditLogs(types.AuditLogListParams{
+		EntityType: "template",
+		Limit:      10,
+	})
+	require.NoError(t, err, "list audit logs filtered by entity_type")
+
+	// All returned entries must match the filter — verifies the backend
+	// actually applied it. Empty result is fine (no template ops yet).
+	for _, e := range resp.Data {
+		assert.Equal(t, "template", e.EntityType,
+			"filter must be applied server-side, got entry with entity_type=%q", e.EntityType)
+	}
+}
+
+// TestLiveAuditLog_ExportJSON locks the export format wire contract.
+// Backend serves the export as a streamed JSON body; client wraps it
+// into ExportAuditLogs which returns raw bytes.
+func TestLiveAuditLog_ExportJSON(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	out, err := c.ExportAuditLogs("json", types.AuditLogListParams{Limit: 5})
+	if err != nil {
+		// Export is admin-gated — skip if the API key doesn't have it.
+		if strings.Contains(err.Error(), "Permission denied") || strings.Contains(err.Error(), "forbidden") {
+			t.Skipf("audit log export is admin-gated: %v", err)
+		}
+		require.NoError(t, err, "export audit logs")
+	}
+	assert.NotEmpty(t, out, "export must return non-empty bytes")
+	// Should look like JSON — start with [ or { after optional whitespace.
+	trimmed := strings.TrimSpace(string(out))
+	require.NotEmpty(t, trimmed)
+	first := trimmed[0]
+	assert.True(t, first == '[' || first == '{',
+		"JSON export must begin with [ or {, got %q", first)
+}

--- a/cli/test/live/bulk_live_test.go
+++ b/cli/test/live/bulk_live_test.go
@@ -1,0 +1,117 @@
+//go:build live
+
+package live
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveBulk_TemplateRoundTrip exercises the template bulk wire contract
+// without creating real workloads — bulk publish/unpublish are pure
+// metadata operations on the template object.
+//
+// Note: this is the regression test for the `template_ids` field-name
+// drift fixed in fix/bulk-wire-contract. Stub-based unit tests didn't
+// catch it because they decoded against stackctl's own wrong type.
+func TestLiveBulk_TemplateRoundTrip(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	// Create 2 throwaway templates so we can publish + unpublish them in
+	// bulk without affecting the seeded Klaravik templates.
+	prefix := liveResourcePrefix()
+	ids := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		tmpl, err := c.CreateTemplate(&types.CreateTemplateRequest{
+			Name:        fmt.Sprintf("%s-bulk-%d", prefix, i),
+			Description: "live-test bulk fixture",
+		})
+		require.NoError(t, err, "create template %d", i)
+		ids = append(ids, tmpl.ID)
+		deleteTemplateIfExists(t, c, tmpl.ID)
+	}
+
+	// Publish
+	pubResp, err := c.BulkPublishTemplates(ids)
+	require.NoError(t, err, "bulk publish templates")
+	require.Len(t, pubResp.Results, 2)
+	for _, r := range pubResp.Results {
+		assert.True(t, r.Success(),
+			"bulk publish must succeed for template_id=%s status=%q error=%q",
+			r.ID(), r.Status, r.Error)
+	}
+
+	// Unpublish
+	unpubResp, err := c.BulkUnpublishTemplates(ids)
+	require.NoError(t, err, "bulk unpublish templates")
+	require.Len(t, unpubResp.Results, 2)
+	for _, r := range unpubResp.Results {
+		assert.True(t, r.Success(),
+			"bulk unpublish must succeed for template_id=%s status=%q error=%q",
+			r.ID(), r.Status, r.Error)
+	}
+
+	// Bulk delete — cleanup-via-bulk also exercises the delete endpoint.
+	// We still have deleteTemplateIfExists registered as a safety net.
+	delResp, err := c.BulkDeleteTemplates(ids)
+	require.NoError(t, err, "bulk delete templates")
+	require.Len(t, delResp.Results, 2)
+	for _, r := range delResp.Results {
+		assert.True(t, r.Success(),
+			"bulk delete must succeed for template_id=%s status=%q error=%q",
+			r.ID(), r.Status, r.Error)
+	}
+}
+
+// TestLiveBulk_StackInstanceWireShape exercises the stack-instance bulk
+// endpoints without actually deploying anything. Creates draft instances
+// (status=draft, no PV, no pods), runs bulk delete against them, and
+// verifies the response shape.
+//
+// This is the regression test for the `instance_ids` field-name drift.
+func TestLiveBulk_StackInstanceWireShape(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	def := requireDefinition(t, c)
+
+	// Create 2 draft instances. CreateStack returns immediately without
+	// triggering helm — instance sits in `draft` state until DeployStack
+	// is called, which we deliberately skip.
+	prefix := liveResourcePrefix()
+	ids := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		inst, err := c.CreateStack(&types.CreateStackRequest{
+			Name:              fmt.Sprintf("%s-bulk-inst-%d", prefix, i),
+			StackDefinitionID: def.ID,
+			Branch:            "master",
+		})
+		require.NoError(t, err, "create draft instance %d", i)
+		ids = append(ids, inst.ID)
+		// Safety-net cleanup in case bulk delete fails partway.
+		t.Cleanup(func(id string) func() {
+			return func() { _ = c.DeleteStack(id) }
+		}(inst.ID))
+	}
+
+	// Bulk delete — pure metadata op on draft instances, no helm hook fires.
+	resp, err := c.BulkDelete(ids)
+	require.NoError(t, err, "bulk delete draft instances")
+	require.Len(t, resp.Results, 2)
+	for _, r := range resp.Results {
+		assert.True(t, r.Success(),
+			"bulk delete must succeed for instance_id=%s status=%q error=%q",
+			r.ID(), r.Status, r.Error)
+	}
+
+	// Confirm gone.
+	for _, id := range ids {
+		_, err := c.GetStack(id)
+		assert.Error(t, err, "GetStack on deleted draft %s should fail", id)
+	}
+}

--- a/cli/test/live/cluster_live_test.go
+++ b/cli/test/live/cluster_live_test.go
@@ -3,6 +3,7 @@
 package live
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,9 +46,14 @@ func TestLiveCluster_QuotaRoundTrip(t *testing.T) {
 
 	q, err := c.GetClusterQuota(cluster.ID)
 	if err != nil {
-		// Quota is optional — some clusters run unbounded. Skip rather
-		// than fail so partial-config backends stay green.
-		t.Skipf("cluster %s has no quota configured: %v", cluster.ID, err)
+		// Quota is optional — some clusters run unbounded. Only skip on
+		// the documented not-configured / not-found paths so genuine
+		// contract regressions still surface as failures.
+		msg := strings.ToLower(err.Error())
+		if strings.Contains(msg, "not found") || strings.Contains(msg, "no quota") {
+			t.Skipf("cluster %s has no quota configured: %v", cluster.ID, err)
+		}
+		require.NoError(t, err, "get cluster quota")
 	}
 	assert.NotEmpty(t, q.CPURequest, "quota cpu_request should be set when quota exists")
 	assert.NotEmpty(t, q.MemoryRequest, "quota memory_request should be set when quota exists")
@@ -83,7 +89,13 @@ func TestLiveCluster_HealthAndTest(t *testing.T) {
 	t.Run("nodes", func(t *testing.T) {
 		nodes, err := c.GetClusterNodes(cluster.ID)
 		if err != nil {
-			t.Skipf("nodes endpoint unavailable (cluster not reachable): %v", err)
+			// Skip only when the backend can't reach the cluster — any
+			// other error (bad wire shape, 5xx) should fail the test.
+			msg := strings.ToLower(err.Error())
+			if strings.Contains(msg, "not reachable") || strings.Contains(msg, "unavailable") || strings.Contains(msg, "connection refused") {
+				t.Skipf("nodes endpoint unavailable (cluster not reachable): %v", err)
+			}
+			require.NoError(t, err, "get cluster nodes")
 		}
 		// Just verify we get a decodable slice back. Empty is fine.
 		assert.NotNil(t, nodes)

--- a/cli/test/live/cluster_live_test.go
+++ b/cli/test/live/cluster_live_test.go
@@ -1,0 +1,91 @@
+//go:build live
+
+package live
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveCluster_ListAndGet locks the read-side cluster wire contract.
+// All clusters in the live backend must decode without losing IDs.
+func TestLiveCluster_ListAndGet(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	clusters, err := c.ListClusters()
+	require.NoError(t, err, "list clusters")
+	require.NotEmpty(t, clusters, "backend must have at least one cluster registered")
+
+	target := clusters[0]
+	for _, cl := range clusters {
+		if cl.IsDefault {
+			target = cl
+			break
+		}
+	}
+
+	got, err := c.GetCluster(target.ID)
+	require.NoError(t, err, "get cluster by ID")
+	assert.Equal(t, target.ID, got.ID)
+	assert.Equal(t, target.Name, got.Name)
+}
+
+// TestLiveCluster_QuotaRoundTrip verifies the cluster quota wire contract.
+// Read-only — we don't mutate the quota because other tests + the live
+// site depend on it. Just confirms the response decodes with non-zero
+// fields populated.
+func TestLiveCluster_QuotaRoundTrip(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	cluster := requireCluster(t, c)
+
+	q, err := c.GetClusterQuota(cluster.ID)
+	if err != nil {
+		// Quota is optional — some clusters run unbounded. Skip rather
+		// than fail so partial-config backends stay green.
+		t.Skipf("cluster %s has no quota configured: %v", cluster.ID, err)
+	}
+	assert.NotEmpty(t, q.CPURequest, "quota cpu_request should be set when quota exists")
+	assert.NotEmpty(t, q.MemoryRequest, "quota memory_request should be set when quota exists")
+}
+
+// TestLiveCluster_HealthAndTest exercises the diagnostic endpoints.
+// These are pure reads — safe to call repeatedly.
+func TestLiveCluster_HealthAndTest(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	cluster := requireCluster(t, c)
+
+	t.Run("health", func(t *testing.T) {
+		health, err := c.GetClusterHealth(cluster.ID)
+		require.NoError(t, err, "get cluster health")
+		// Health summary should at least populate node count for any
+		// non-empty cluster. Zero would mean the wire decode lost data.
+		assert.GreaterOrEqual(t, health.NodeCount, 0, "node_count must decode (zero is fine for empty clusters)")
+	})
+
+	t.Run("test_connection", func(t *testing.T) {
+		_, err := c.TestClusterConnection(cluster.ID)
+		// TestClusterConnection is allowed to fail (the backend may not
+		// be able to reach the cluster from CI). What matters is the
+		// response shape — if it returns NoError, we don't assert
+		// further; if it errors, we don't fail the whole suite.
+		if err != nil {
+			t.Logf("cluster %s test-connection failed (expected when backend can't reach kube-apiserver): %v", cluster.ID, err)
+		}
+	})
+
+	t.Run("nodes", func(t *testing.T) {
+		nodes, err := c.GetClusterNodes(cluster.ID)
+		if err != nil {
+			t.Skipf("nodes endpoint unavailable (cluster not reachable): %v", err)
+		}
+		// Just verify we get a decodable slice back. Empty is fine.
+		assert.NotNil(t, nodes)
+	})
+}

--- a/cli/test/live/definition_live_test.go
+++ b/cli/test/live/definition_live_test.go
@@ -61,7 +61,7 @@ func TestLiveDefinition_ExportImportRoundTrip(t *testing.T) {
 	// Re-fetch to confirm charts came along with the import.
 	roundtrip, err := c.GetDefinition(imported.ID)
 	require.NoError(t, err)
-	if origCharts, ok := bundle["charts"].([]any); ok && len(origCharts) > 0 {
+	if origCharts, ok := innerDef["charts"].([]any); ok && len(origCharts) > 0 {
 		assert.NotEmpty(t, roundtrip.Charts, "imported definition must carry its charts")
 	}
 }

--- a/cli/test/live/definition_live_test.go
+++ b/cli/test/live/definition_live_test.go
@@ -1,0 +1,86 @@
+//go:build live
+
+package live
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveDefinition_ListAndGet locks the read-side definition contract.
+func TestLiveDefinition_ListAndGet(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	def := requireDefinition(t, c)
+
+	got, err := c.GetDefinition(def.ID)
+	require.NoError(t, err, "get definition by ID")
+	assert.Equal(t, def.ID, got.ID)
+	assert.NotEmpty(t, got.Name)
+}
+
+// TestLiveDefinition_ExportImportRoundTrip locks the import wire contract
+// — the seed-definitions.sh script in kvk-k8s-dev posts *.definition.json
+// files via this path and any field-name drift would silently drop charts.
+func TestLiveDefinition_ExportImportRoundTrip(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	def := requireDefinition(t, c)
+
+	exported, err := c.ExportDefinition(def.ID)
+	require.NoError(t, err, "export definition")
+	require.NotEmpty(t, exported, "export must return a payload")
+
+	// Verify the export looks like the import contract before sending it
+	// back — a typo on schema_version would 400 on re-import.
+	var bundle map[string]any
+	require.NoError(t, json.Unmarshal(exported, &bundle))
+	assert.Contains(t, bundle, "schema_version", "exported bundle must have schema_version")
+	assert.Contains(t, bundle, "definition", "exported bundle must have definition")
+
+	// Re-import with a renamed definition so we don't collide.
+	prefix := liveResourcePrefix()
+	innerDef, ok := bundle["definition"].(map[string]any)
+	require.True(t, ok, "definition field must be an object")
+	innerDef["name"] = prefix + "-reimport"
+
+	rewritten, err := json.Marshal(bundle)
+	require.NoError(t, err)
+
+	imported, err := c.ImportDefinition(rewritten)
+	require.NoError(t, err, "import renamed bundle")
+	require.NotEmpty(t, imported.ID)
+	deleteDefinitionIfExists(t, c, imported.ID)
+
+	// Re-fetch to confirm charts came along with the import.
+	roundtrip, err := c.GetDefinition(imported.ID)
+	require.NoError(t, err)
+	if origCharts, ok := bundle["charts"].([]any); ok && len(origCharts) > 0 {
+		assert.NotEmpty(t, roundtrip.Charts, "imported definition must carry its charts")
+	}
+}
+
+// TestLiveDefinition_CreateBare verifies the CreateDefinitionRequest wire
+// shape end-to-end. Bare (no charts) — the inline-charts case is exercised
+// via ImportDefinition above.
+func TestLiveDefinition_CreateBare(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	prefix := liveResourcePrefix()
+	created, err := c.CreateDefinition(&types.CreateDefinitionRequest{
+		Name:        prefix + "-def",
+		Description: "live-test bare definition",
+	})
+	require.NoError(t, err, "create definition")
+	require.NotEmpty(t, created.ID)
+	deleteDefinitionIfExists(t, c, created.ID)
+
+	assert.Equal(t, prefix+"-def", created.Name)
+}

--- a/cli/test/live/favorite_live_test.go
+++ b/cli/test/live/favorite_live_test.go
@@ -58,8 +58,7 @@ func TestLiveFavorite_AddListRemove(t *testing.T) {
 	list2, err := c.ListFavorites()
 	require.NoError(t, err)
 	for _, f := range list2 {
-		if f.EntityType == entityType && f.EntityID == def.ID {
-			t.Errorf("favorite must be gone after RemoveFavorite, still found %+v", f)
-		}
+		assert.False(t, f.EntityType == entityType && f.EntityID == def.ID,
+			"favorite must be gone after RemoveFavorite, still found %+v", f)
 	}
 }

--- a/cli/test/live/favorite_live_test.go
+++ b/cli/test/live/favorite_live_test.go
@@ -1,0 +1,65 @@
+//go:build live
+
+package live
+
+import (
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveFavorite_AddListRemove locks the full favorite wire contract.
+// Field-name drift here would break stackctl's `favorite add/remove`
+// commands silently.
+func TestLiveFavorite_AddListRemove(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	def := requireDefinition(t, c)
+	const entityType = "definition"
+
+	// Ensure clean state — backend treats add as idempotent, but Remove
+	// before is cheap and confirms the wire contract too.
+	_ = c.RemoveFavorite(entityType, def.ID)
+
+	// Add
+	fav, err := c.AddFavorite(types.AddFavoriteRequest{
+		EntityType: entityType,
+		EntityID:   def.ID,
+	})
+	require.NoError(t, err, "add favorite")
+	assert.Equal(t, def.ID, fav.EntityID, "response must echo entity_id")
+	assert.Equal(t, entityType, fav.EntityType, "response must echo entity_type")
+
+	// Always best-effort remove so the test leaves no trace.
+	t.Cleanup(func() {
+		_ = c.RemoveFavorite(entityType, def.ID)
+	})
+
+	// List — our new favorite must show up.
+	list, err := c.ListFavorites()
+	require.NoError(t, err, "list favorites")
+
+	var found bool
+	for _, f := range list {
+		if f.EntityType == entityType && f.EntityID == def.ID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "newly added favorite (%s/%s) must appear in list", entityType, def.ID)
+
+	// Remove — explicit call (cleanup is the safety net).
+	require.NoError(t, c.RemoveFavorite(entityType, def.ID), "remove favorite")
+
+	// Confirm gone.
+	list2, err := c.ListFavorites()
+	require.NoError(t, err)
+	for _, f := range list2 {
+		if f.EntityType == entityType && f.EntityID == def.ID {
+			t.Errorf("favorite must be gone after RemoveFavorite, still found %+v", f)
+		}
+	}
+}

--- a/cli/test/live/helpers_test.go
+++ b/cli/test/live/helpers_test.go
@@ -101,14 +101,19 @@ func requireCluster(t *testing.T, c *client.Client) types.Cluster {
 // disabled in this backend build).
 func skipUnlessHTTP200(t *testing.T, c *client.Client, path string) {
 	t.Helper()
-	resp, err := http.Get(strings.TrimSuffix(c.BaseURL, "/") + path)
+	httpC := &http.Client{Timeout: 5 * time.Second}
+	resp, err := httpC.Get(strings.TrimSuffix(c.BaseURL, "/") + path)
 	if err != nil {
 		t.Skipf("endpoint %s unreachable: %v", path, err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		t.Skipf("endpoint %s returned 404 — feature not enabled on this backend", path)
 	}
+	t.Skipf("endpoint %s returned HTTP %d", path, resp.StatusCode)
 }
 
 // ensure imports stay used — these helpers are pulled in via _test.go

--- a/cli/test/live/helpers_test.go
+++ b/cli/test/live/helpers_test.go
@@ -1,0 +1,117 @@
+//go:build live
+
+package live
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Live-test conventions for new files under this package:
+//
+//   1. Use newLiveClient(t) — handles connectivity + auth (API key or login)
+//      and skips the test if neither path is configured.
+//   2. Never create real workloads. The CI runner is shared dev infra; tests
+//      must be safe to interleave. Stick to wire-shape round-trips: read
+//      lists, create-then-delete bare resources, exercise filters. If a
+//      command needs a deployed instance, GetStackStatus or GetStackLogs is
+//      fine against an existing one; do NOT call DeployStack inside live
+//      tests.
+//   3. Register cleanup via t.Cleanup so a failed assertion never leaves a
+//      named resource behind.
+//   4. Skip — don't fail — when the backend doesn't have the precondition
+//      (e.g. "no templates available") so partial environments stay green.
+
+// liveResourcePrefix uniquely identifies resources created by this run.
+// Use it as a name prefix so leftovers from a crashed test are obvious
+// in `stackctl stack list` / `stackctl template list`.
+func liveResourcePrefix() string {
+	return fmt.Sprintf("live-%d", time.Now().UnixMilli())
+}
+
+// deleteTemplateIfExists registers a t.Cleanup that drops a template by ID
+// regardless of test outcome.
+func deleteTemplateIfExists(t *testing.T, c *client.Client, id string) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = c.DeleteTemplate(id)
+	})
+}
+
+// deleteDefinitionIfExists registers a t.Cleanup that drops a definition by ID.
+func deleteDefinitionIfExists(t *testing.T, c *client.Client, id string) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = c.DeleteDefinition(id)
+	})
+}
+
+// requireTemplate fetches the first template available and skips if none.
+// Used by tests that need a template to exist but don't care which one.
+func requireTemplate(t *testing.T, c *client.Client) types.StackTemplate {
+	t.Helper()
+	resp, err := c.ListTemplates(nil)
+	require.NoError(t, err, "list templates")
+	if len(resp.Data) == 0 {
+		t.Skip("backend has no templates — seed Klaravik Core/Full Stack to run this suite")
+	}
+	return resp.Data[0]
+}
+
+// requireDefinition fetches the first definition available and skips if none.
+func requireDefinition(t *testing.T, c *client.Client) types.StackDefinition {
+	t.Helper()
+	resp, err := c.ListDefinitions(nil)
+	require.NoError(t, err, "list definitions")
+	if len(resp.Data) == 0 {
+		t.Skip("backend has no definitions — seed Klaravik Full Stack SE/DK to run this suite")
+	}
+	return resp.Data[0]
+}
+
+// requireCluster fetches the default cluster (or the first if none default)
+// and skips if no clusters are registered. Tests that need a cluster ID for
+// a payload (cluster_id field) get one this way.
+func requireCluster(t *testing.T, c *client.Client) types.Cluster {
+	t.Helper()
+	clusters, err := c.ListClusters()
+	require.NoError(t, err, "list clusters")
+	if len(clusters) == 0 {
+		t.Skip("backend has no clusters — register one via stackctl cluster create to run this suite")
+	}
+	for _, cl := range clusters {
+		if cl.IsDefault {
+			return cl
+		}
+	}
+	return clusters[0]
+}
+
+// skipUnlessHTTP200 issues a GET against the live backend and skips the
+// test if the response status isn't 200. Used to gate tests that depend on
+// optional endpoints (e.g. /api/v1/notifications when notifications are
+// disabled in this backend build).
+func skipUnlessHTTP200(t *testing.T, c *client.Client, path string) {
+	t.Helper()
+	resp, err := http.Get(strings.TrimSuffix(c.BaseURL, "/") + path)
+	if err != nil {
+		t.Skipf("endpoint %s unreachable: %v", path, err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		t.Skipf("endpoint %s returned 404 — feature not enabled on this backend", path)
+	}
+}
+
+// ensure imports stay used — these helpers are pulled in via _test.go
+// files so the compiler keeps them; the OS import is here because
+// live_test.go used it.
+var _ = os.Getenv

--- a/cli/test/live/live_test.go
+++ b/cli/test/live/live_test.go
@@ -24,18 +24,25 @@ func baseURL() string {
 
 // newLiveClient creates a client pointing at the live backend and verifies
 // connectivity. If the backend is unreachable the test is skipped.
+//
+// Auth: prefers STACKCTL_LIVE_API_KEY (header-based, no session) and falls
+// back to STACKCTL_LIVE_USER + STACKCTL_LIVE_PASS via Login. If neither is
+// configured the suite is skipped.
 func newLiveClient(t *testing.T) *client.Client {
 	t.Helper()
 
-	if os.Getenv("STACKCTL_LIVE_USER") == "" || os.Getenv("STACKCTL_LIVE_PASS") == "" {
-		t.Skip("STACKCTL_LIVE_USER and STACKCTL_LIVE_PASS must be set for live tests")
+	apiKey := os.Getenv("STACKCTL_LIVE_API_KEY")
+	user, pass := os.Getenv("STACKCTL_LIVE_USER"), os.Getenv("STACKCTL_LIVE_PASS")
+	if apiKey == "" && (user == "" || pass == "") {
+		t.Skip("STACKCTL_LIVE_API_KEY or (STACKCTL_LIVE_USER + STACKCTL_LIVE_PASS) must be set for live tests")
 	}
 
 	c := client.New(baseURL())
 
 	// Quick connectivity check — skip (not fail) if backend is down.
+	// Backend exposes /health/live (Kubernetes liveness probe), not /api/v1/health.
 	httpC := &http.Client{Timeout: 5 * time.Second}
-	resp, err := httpC.Get(baseURL() + "/api/v1/health")
+	resp, err := httpC.Get(baseURL() + "/health/live")
 	if err != nil {
 		t.Skipf("Backend unreachable at %s: %v", baseURL(), err)
 	}
@@ -44,12 +51,23 @@ func newLiveClient(t *testing.T) *client.Client {
 		t.Skipf("Backend unhealthy at %s: HTTP %d", baseURL(), resp.StatusCode)
 	}
 
+	// API-key path: stamps the X-API-Key header on every subsequent request,
+	// no login needed. Password path is handled by the per-test login() helper.
+	if apiKey != "" {
+		c.APIKey = apiKey
+	}
+
 	return c
 }
 
-// login authenticates the client and returns the login response.
+// login authenticates the client when running in password mode and returns
+// the login response. When STACKCTL_LIVE_API_KEY is set this is a no-op —
+// the client is already authenticated via the header set in newLiveClient.
 func login(t *testing.T, c *client.Client) *types.LoginResponse {
 	t.Helper()
+	if os.Getenv("STACKCTL_LIVE_API_KEY") != "" {
+		return &types.LoginResponse{}
+	}
 	resp, err := c.Login(os.Getenv("STACKCTL_LIVE_USER"), os.Getenv("STACKCTL_LIVE_PASS"))
 	require.NoError(t, err, "login must succeed")
 	require.NotEmpty(t, resp.Token, "token must not be empty")
@@ -57,7 +75,7 @@ func login(t *testing.T, c *client.Client) *types.LoginResponse {
 }
 
 // cleanupInstance registers a t.Cleanup that best-effort deletes the instance.
-func cleanupInstance(t *testing.T, c *client.Client, id uint) {
+func cleanupInstance(t *testing.T, c *client.Client, id string) {
 	t.Helper()
 	t.Cleanup(func() {
 		// Best-effort: stop -> clean -> delete. Ignore errors because the
@@ -74,7 +92,9 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 	// Step 1: Login
 	t.Log("Step 1: Login")
 	loginResp := login(t, c)
-	assert.NotEmpty(t, loginResp.User.Username)
+	if loginResp.User.Username != "" {
+		t.Logf("Logged in as %s", loginResp.User.Username)
+	}
 
 	// Step 2: List templates — pick the first available
 	t.Log("Step 2: List templates")
@@ -84,7 +104,7 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 		t.Skip("No templates available on backend — cannot run full lifecycle test")
 	}
 	tmpl := templates.Data[0]
-	t.Logf("Using template %d (%s)", tmpl.ID, tmpl.Name)
+	t.Logf("Using template %s (%s)", tmpl.ID, tmpl.Name)
 
 	// Step 3: Instantiate template
 	t.Log("Step 3: Instantiate template")
@@ -93,8 +113,8 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 		Branch: "main",
 	})
 	require.NoError(t, err, "instantiate template")
-	require.NotZero(t, instance.ID, "instance ID must be set")
-	t.Logf("Created instance %d (%s)", instance.ID, instance.Name)
+	require.NotEmpty(t, instance.ID, "instance ID must be set")
+	t.Logf("Created instance %s (%s)", instance.ID, instance.Name)
 
 	// Register cleanup so resources are removed even on failure.
 	cleanupInstance(t, c, instance.ID)
@@ -103,7 +123,7 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 	t.Log("Step 4: Deploy")
 	deployLog, err := c.DeployStack(instance.ID)
 	require.NoError(t, err, "deploy stack")
-	assert.NotZero(t, deployLog.ID, "deploy log ID must be set")
+	assert.NotEmpty(t, deployLog.LogID, "deploy log ID must be set")
 
 	// Step 5: Check status
 	t.Log("Step 5: Check status")
@@ -112,9 +132,13 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 	assert.NotEmpty(t, status.Status, "status field must be present")
 	t.Logf("Status: %s, pods: %d", status.Status, len(status.Pods))
 
-	// Step 6–7: Set overrides and redeploy (only if template has charts)
+	// Step 6–7: Set overrides and redeploy (only if template has charts).
+	// Note: templates.Data[0] from ListTemplates doesn't carry charts unless
+	// the backend includes them in the list response, so this branch usually
+	// gets skipped against the live backend (charts are populated by a
+	// per-template GET, not on the list endpoint).
 	if len(tmpl.Charts) == 0 {
-		t.Log("Step 6–7: Skipped — template has no charts, cannot set overrides")
+		t.Log("Step 6–7: Skipped — template list response carries no charts")
 	} else {
 		chartID := tmpl.Charts[0].ID
 
@@ -149,7 +173,7 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 		t.Log("Step 7: Redeploy")
 		redeployLog, err := c.DeployStack(instance.ID)
 		require.NoError(t, err, "redeploy stack")
-		assert.NotZero(t, redeployLog.ID, "redeploy log ID must be set")
+		assert.NotEmpty(t, redeployLog.LogID, "redeploy log ID must be set")
 	}
 
 	// Step 8: View logs
@@ -162,13 +186,13 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 	t.Log("Step 9: Stop")
 	stopLog, err := c.StopStack(instance.ID)
 	require.NoError(t, err, "stop stack")
-	assert.NotZero(t, stopLog.ID, "stop log ID must be set")
+	assert.NotEmpty(t, stopLog.LogID, "stop log ID must be set")
 
 	// Step 10: Clean
 	t.Log("Step 10: Clean")
 	cleanLog, err := c.CleanStack(instance.ID)
 	require.NoError(t, err, "clean stack")
-	assert.NotZero(t, cleanLog.ID, "clean log ID must be set")
+	assert.NotEmpty(t, cleanLog.LogID, "clean log ID must be set")
 
 	// Step 11: Delete
 	t.Log("Step 11: Delete")
@@ -195,11 +219,11 @@ func TestLiveWorkflow_BulkOperations(t *testing.T) {
 		t.Skip("No definitions available on backend — cannot run bulk test")
 	}
 	defID := defs.Data[0].ID
-	t.Logf("Using definition %d (%s)", defID, defs.Data[0].Name)
+	t.Logf("Using definition %s (%s)", defID, defs.Data[0].Name)
 
 	// Step 2: Create 3 stack instances
 	t.Log("Step 2: Create 3 stack instances")
-	var ids []uint
+	var ids []string
 	for i := 0; i < 3; i++ {
 		inst, err := c.CreateStack(&types.CreateStackRequest{
 			Name:              fmt.Sprintf("live-bulk-%d-%d", time.Now().UnixMilli(), i),
@@ -207,9 +231,9 @@ func TestLiveWorkflow_BulkOperations(t *testing.T) {
 			Branch:            "main",
 		})
 		require.NoError(t, err, "create stack %d", i)
-		require.NotZero(t, inst.ID)
+		require.NotEmpty(t, inst.ID)
 		ids = append(ids, inst.ID)
-		t.Logf("Created instance %d", inst.ID)
+		t.Logf("Created instance %s", inst.ID)
 	}
 
 	// Register cleanup for all created instances.
@@ -223,7 +247,7 @@ func TestLiveWorkflow_BulkOperations(t *testing.T) {
 	require.NoError(t, err, "bulk deploy")
 	assert.Len(t, deployResp.Results, 3, "should have 3 results")
 	for _, r := range deployResp.Results {
-		assert.True(t, r.Success, "deploy should succeed for id %d: %s", r.ID, r.Error)
+		assert.True(t, r.Success(), "deploy should succeed for id %s: %s", r.ID(), r.Error)
 	}
 
 	// Step 4: Bulk stop
@@ -232,7 +256,7 @@ func TestLiveWorkflow_BulkOperations(t *testing.T) {
 	require.NoError(t, err, "bulk stop")
 	assert.Len(t, stopResp.Results, 3)
 	for _, r := range stopResp.Results {
-		assert.True(t, r.Success, "stop should succeed for id %d: %s", r.ID, r.Error)
+		assert.True(t, r.Success(), "stop should succeed for id %s: %s", r.ID(), r.Error)
 	}
 
 	// Step 5: Bulk clean
@@ -241,7 +265,7 @@ func TestLiveWorkflow_BulkOperations(t *testing.T) {
 	require.NoError(t, err, "bulk clean")
 	assert.Len(t, cleanResp.Results, 3)
 	for _, r := range cleanResp.Results {
-		assert.True(t, r.Success, "clean should succeed for id %d: %s", r.ID, r.Error)
+		assert.True(t, r.Success(), "clean should succeed for id %s: %s", r.ID(), r.Error)
 	}
 
 	// Step 6: Bulk delete
@@ -250,13 +274,13 @@ func TestLiveWorkflow_BulkOperations(t *testing.T) {
 	require.NoError(t, err, "bulk delete")
 	assert.Len(t, deleteResp.Results, 3)
 	for _, r := range deleteResp.Results {
-		assert.True(t, r.Success, "delete should succeed for id %d: %s", r.ID, r.Error)
+		assert.True(t, r.Success(), "delete should succeed for id %s: %s", r.ID(), r.Error)
 	}
 
 	// Step 7: Verify all deleted
 	t.Log("Step 7: Verify all deleted")
 	for _, id := range ids {
 		_, err := c.GetStack(id)
-		assert.Error(t, err, "GetStack on deleted instance %d should fail", id)
+		assert.Error(t, err, "GetStack on deleted instance %s should fail", id)
 	}
 }

--- a/cli/test/live/live_test.go
+++ b/cli/test/live/live_test.go
@@ -86,7 +86,16 @@ func cleanupInstance(t *testing.T, c *client.Client, id string) {
 	})
 }
 
+// TestLiveWorkflow_FullLifecycle exercises the complete deploy-stop-clean-
+// delete path against a real backend by actually rolling out a stack
+// instance. It pulls images, allocates PVs, and burns cluster quota — so
+// it's gated behind STACKCTL_LIVE_HEAVY=1 to keep it off the default
+// suite. CI smoke + per-endpoint wire-contract coverage lives in the
+// other *_live_test.go files in this package.
 func TestLiveWorkflow_FullLifecycle(t *testing.T) {
+	if os.Getenv("STACKCTL_LIVE_HEAVY") == "" {
+		t.Skip("set STACKCTL_LIVE_HEAVY=1 to run real-workload lifecycle tests (~5–10 min, requires cluster capacity)")
+	}
 	c := newLiveClient(t)
 
 	// Step 1: Login
@@ -205,7 +214,16 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 	assert.Error(t, err, "GetStack on deleted instance should fail")
 }
 
+// TestLiveWorkflow_BulkOperations deploys 3 real stack instances and bulk-
+// operates on them. Heavy: ~3 cluster-CPU and ~5 Gi memory per instance,
+// plus golden-db pulls. Wire-shape coverage for bulk lives in
+// TestLiveBulk_StackInstanceWireShape / TestLiveBulk_TemplateRoundTrip;
+// this test only adds the actual deploy/stop/clean assertions, so it's
+// gated behind STACKCTL_LIVE_HEAVY=1.
 func TestLiveWorkflow_BulkOperations(t *testing.T) {
+	if os.Getenv("STACKCTL_LIVE_HEAVY") == "" {
+		t.Skip("set STACKCTL_LIVE_HEAVY=1 to run real-workload bulk tests (creates 3 instances)")
+	}
 	c := newLiveClient(t)
 
 	// Step 1: Login

--- a/cli/test/live/live_test.go
+++ b/cli/test/live/live_test.go
@@ -93,7 +93,7 @@ func cleanupInstance(t *testing.T, c *client.Client, id string) {
 // suite. CI smoke + per-endpoint wire-contract coverage lives in the
 // other *_live_test.go files in this package.
 func TestLiveWorkflow_FullLifecycle(t *testing.T) {
-	if os.Getenv("STACKCTL_LIVE_HEAVY") == "" {
+	if os.Getenv("STACKCTL_LIVE_HEAVY") != "1" {
 		t.Skip("set STACKCTL_LIVE_HEAVY=1 to run real-workload lifecycle tests (~5–10 min, requires cluster capacity)")
 	}
 	c := newLiveClient(t)
@@ -221,7 +221,7 @@ func TestLiveWorkflow_FullLifecycle(t *testing.T) {
 // this test only adds the actual deploy/stop/clean assertions, so it's
 // gated behind STACKCTL_LIVE_HEAVY=1.
 func TestLiveWorkflow_BulkOperations(t *testing.T) {
-	if os.Getenv("STACKCTL_LIVE_HEAVY") == "" {
+	if os.Getenv("STACKCTL_LIVE_HEAVY") != "1" {
 		t.Skip("set STACKCTL_LIVE_HEAVY=1 to run real-workload bulk tests (creates 3 instances)")
 	}
 	c := newLiveClient(t)

--- a/cli/test/live/notification_live_test.go
+++ b/cli/test/live/notification_live_test.go
@@ -1,0 +1,67 @@
+//go:build live
+
+package live
+
+import (
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/pkg/client"
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveNotification_List ensures the list endpoint returns the
+// PaginatedNotifications envelope shape — `notifications`, `total`,
+// `unread_count`. A drift here would silently truncate the response.
+func TestLiveNotification_List(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	resp, err := c.ListNotifications(client.NotificationListParams{Limit: 5})
+	require.NoError(t, err, "list notifications")
+
+	// Counters must decode even when there are no notifications.
+	assert.GreaterOrEqual(t, resp.Total, int64(0))
+	assert.GreaterOrEqual(t, resp.UnreadCount, int64(0))
+	// Notifications slice may be empty but must not be nil.
+	assert.NotNil(t, resp.Notifications)
+}
+
+// TestLiveNotification_PreferencesRoundTrip locks the prefs update wire
+// contract. We read current prefs, write them back unchanged, and verify
+// the response matches input — any field-name drift would cause the
+// backend to ignore values.
+func TestLiveNotification_PreferencesRoundTrip(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	prefs, err := c.GetNotificationPreferences()
+	require.NoError(t, err, "get notification preferences")
+
+	// If empty, backend has no prefs configured yet — seed one entry to
+	// exercise the write path. We can't restore to empty afterwards
+	// because the backend rejects "at least one preference is required"
+	// (verified live 2026-05-28); leaving the seeded pref in place is
+	// safe — subsequent runs hit the round-trip branch below.
+	if len(prefs) == 0 {
+		seeded := []types.NotificationPreference{
+			{EventType: "stack.deployed", Enabled: true},
+		}
+		got, err := c.UpdateNotificationPreferences(seeded)
+		require.NoError(t, err, "seed notification preference")
+		require.Len(t, got, 1)
+		assert.Equal(t, "stack.deployed", got[0].EventType)
+		assert.True(t, got[0].Enabled)
+		return
+	}
+
+	// Otherwise echo current prefs back and verify response matches input.
+	got, err := c.UpdateNotificationPreferences(prefs)
+	require.NoError(t, err, "update notification preferences (echo)")
+	require.Len(t, got, len(prefs), "response length must match input")
+	for i := range prefs {
+		assert.Equal(t, prefs[i].EventType, got[i].EventType, "event_type[%d]", i)
+		assert.Equal(t, prefs[i].Enabled, got[i].Enabled, "enabled[%d]", i)
+	}
+}

--- a/cli/test/live/template_live_test.go
+++ b/cli/test/live/template_live_test.go
@@ -1,0 +1,106 @@
+//go:build live
+
+package live
+
+import (
+	"testing"
+
+	"github.com/omattsson/stackctl/cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLiveTemplate_ListAndGet verifies the read-side template wire
+// contract: list returns the paginated envelope and at least one item
+// has the documented fields populated.
+func TestLiveTemplate_ListAndGet(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	tmpl := requireTemplate(t, c)
+
+	// GetTemplate returns the new TemplateDetailResponse shape (template
+	// fields at top level + a charts array). Sanity-check we got back
+	// something the type can decode without losing the ID.
+	got, err := c.GetTemplate(tmpl.ID)
+	require.NoError(t, err, "get template by ID")
+	assert.Equal(t, tmpl.ID, got.ID)
+	assert.NotEmpty(t, got.Name)
+}
+
+// TestLiveTemplate_CreateWithInlineCharts exercises the path fixed in
+// k8s-stack-manager#264 — `POST /api/v1/templates` now accepts a `charts`
+// array inline and persists every entry transactionally. This test was
+// the missing safety net while that bug shipped.
+func TestLiveTemplate_CreateWithInlineCharts(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	prefix := liveResourcePrefix()
+	name := prefix + "-template"
+
+	created, err := c.CreateTemplate(&types.CreateTemplateRequest{
+		Name:        name,
+		Description: "live-test fixture — safe to delete",
+		Charts: []types.ChartConfig{
+			{ChartName: "noop-a", RepoURL: "", ChartVersion: "0.1.0"},
+			{ChartName: "noop-b", RepoURL: "", ChartVersion: "0.1.0"},
+		},
+	})
+	require.NoError(t, err, "create template with inline charts")
+	require.NotEmpty(t, created.ID, "created template must have an ID")
+	deleteTemplateIfExists(t, c, created.ID)
+
+	// Read the template back via GET — backend's TemplateDetailResponse
+	// includes the persisted charts. Before k8s-stack-manager#264 the
+	// inline charts array was silently dropped by gin's bind, so the
+	// re-read returned 0 charts.
+	//
+	// Note: stackctl's ChartConfig type intentionally omits backend-only
+	// fields like chart_path / locked_values / deploy_order / required —
+	// we only assert presence + the fields the client maps.
+	detail, err := c.GetTemplate(created.ID)
+	require.NoError(t, err, "get template by ID")
+	require.Len(t, detail.Charts, 2, "GET must return both inline-created charts")
+
+	// Publish to materialise a version snapshot — versions are only
+	// created at publish time, not at create time. Then read it back.
+	_, err = c.PublishTemplate(created.ID)
+	require.NoError(t, err, "publish template (to trigger version snapshot)")
+
+	versions, err := c.ListTemplateVersions(created.ID)
+	require.NoError(t, err, "list template versions")
+	require.NotEmpty(t, versions, "publish must produce a version snapshot")
+
+	snap, err := c.GetTemplateVersion(created.ID, versions[0].ID)
+	require.NoError(t, err, "get template version detail")
+	assert.Len(t, snap.Snapshot.Charts, 2, "snapshot must echo both inline charts after publish")
+}
+
+// TestLiveTemplate_PublishLifecycle round-trips publish/unpublish — both
+// are devops-gated; we assume the API key has at least devops role.
+func TestLiveTemplate_PublishLifecycle(t *testing.T) {
+	c := newLiveClient(t)
+	login(t, c)
+
+	prefix := liveResourcePrefix()
+	tmpl, err := c.CreateTemplate(&types.CreateTemplateRequest{
+		Name:        prefix + "-publish",
+		Description: "live-test publish fixture",
+	})
+	require.NoError(t, err)
+	deleteTemplateIfExists(t, c, tmpl.ID)
+	require.False(t, tmpl.Published, "fresh template must start unpublished")
+
+	_, err = c.PublishTemplate(tmpl.ID)
+	require.NoError(t, err, "publish template")
+	after, err := c.GetTemplate(tmpl.ID)
+	require.NoError(t, err)
+	assert.True(t, after.Published, "template must be published after PublishTemplate")
+
+	_, err = c.UnpublishTemplate(tmpl.ID)
+	require.NoError(t, err, "unpublish template")
+	again, err := c.GetTemplate(tmpl.ID)
+	require.NoError(t, err)
+	assert.False(t, again.Published, "template must be unpublished after UnpublishTemplate")
+}

--- a/cli/test/live/template_live_test.go
+++ b/cli/test/live/template_live_test.go
@@ -43,8 +43,17 @@ func TestLiveTemplate_CreateWithInlineCharts(t *testing.T) {
 		Name:        name,
 		Description: "live-test fixture — safe to delete",
 		Charts: []types.ChartConfig{
-			{ChartName: "noop-a", RepoURL: "", ChartVersion: "0.1.0"},
-			{ChartName: "noop-b", RepoURL: "", ChartVersion: "0.1.0"},
+			{
+				ChartName:       "noop-a",
+				RepoURL:         "",
+				ChartVersion:    "0.1.0",
+				ChartPath:       "charts/noop-a",
+				DeployOrder:     1,
+				Required:        true,
+				LockedValues:    "image:\n  tag: pinned",
+				BuildPipelineID: "live-test-pipeline",
+			},
+			{ChartName: "noop-b", RepoURL: "", ChartVersion: "0.1.0", DeployOrder: 2},
 		},
 	})
 	require.NoError(t, err, "create template with inline charts")
@@ -55,13 +64,28 @@ func TestLiveTemplate_CreateWithInlineCharts(t *testing.T) {
 	// includes the persisted charts. Before k8s-stack-manager#264 the
 	// inline charts array was silently dropped by gin's bind, so the
 	// re-read returned 0 charts.
-	//
-	// Note: stackctl's ChartConfig type intentionally omits backend-only
-	// fields like chart_path / locked_values / deploy_order / required —
-	// we only assert presence + the fields the client maps.
 	detail, err := c.GetTemplate(created.ID)
 	require.NoError(t, err, "get template by ID")
 	require.Len(t, detail.Charts, 2, "GET must return both inline-created charts")
+
+	// Regression for the 5-field ChartConfig gap: prior to this fix,
+	// stackctl's ChartConfig had no JSON tags for chart_path / deploy_order
+	// / required / locked_values / build_pipeline_id, so backend-set values
+	// were silently dropped on decode. Locate chart-A by name and assert
+	// every union field round-trips.
+	var noopA *types.ChartConfig
+	for i := range detail.Charts {
+		if detail.Charts[i].ChartName == "noop-a" {
+			noopA = &detail.Charts[i]
+			break
+		}
+	}
+	require.NotNil(t, noopA, "decoded charts must include noop-a")
+	assert.Equal(t, "charts/noop-a", noopA.ChartPath, "chart_path must round-trip")
+	assert.Equal(t, 1, noopA.DeployOrder, "deploy_order must round-trip")
+	assert.True(t, noopA.Required, "required must round-trip")
+	assert.Equal(t, "image:\n  tag: pinned", noopA.LockedValues, "locked_values must round-trip")
+	assert.Equal(t, "live-test-pipeline", noopA.BuildPipelineID, "build_pipeline_id must round-trip")
 
 	// Publish to materialise a version snapshot — versions are only
 	// created at publish time, not at create time. Then read it back.


### PR DESCRIPTION
## Summary

Three related fixes after running the live integration suite against rancher-desktop k8s-stack-manager.

### 1. Bulk wire contract (`65fc94c`)

stackctl's bulk endpoints sent `{"ids": [...]}` but the backend handler binds into `{"instance_ids": [...]}` (stack-instance bulk) or `{"template_ids": [...]}` (template bulk) with `binding:"required"` — every bulk call returned `400 instance_ids is required`. Response shape was also wrong: stackctl decoded `{id, success bool}` but the backend ships `{instance_id|template_id, status: "success"|"error", log_id}`.

Split into two named request types (`BulkInstancesRequest` / `BulkTemplatesRequest`); reshaped `BulkOperationResult` with `ID()` / `Success()` accessor methods so callers don't need to know which side they're on.

### 2. Live integration test suite (`144dd88`)

Stub-based unit tests can't catch contract drift between stackctl and the backend (they decode requests into stackctl's own types — the bug is invisible). Expanded `cli/test/live/` from 2 deploy-heavy lifecycle tests into 7 endpoint-group wire-contract smoke files (audit / bulk / cluster / definition / favorite / notification / template). Designed to be fast and not create real workloads on shared infra.

The existing `TestLiveWorkflow_FullLifecycle` + `_BulkOperations` actually roll out stack instances (~80 GiB of golden-db data each); both are now gated behind `STACKCTL_LIVE_HEAVY=1` so the default suite stays lightweight.

### 3. ChartConfig 5-field gap (`a072bdf`)

The new template test surfaced that stackctl's `ChartConfig` only carried 5 of the 10 fields the backend models ship — `chart_path` / `deploy_order` / `build_pipeline_id` / `locked_values` / `required` were silently dropped on read. Same stub-test blind spot as #1. Widened to the union of `models.ChartConfig` + `models.TemplateChartConfig`; all 5 new fields `omitempty`.

## Verification

Full suite against rancher-desktop k8s-stack-manager (origin/main):

```
16 passed, 2 skipped (heavy-gated), 0 failed in 1.5s
```

Unit + integration suites also pass; `go vet ./...` clean.

## Related follow-ups (tracked separately)

- omattsson/stackctl#96 — CI hook to run `cli/test/live/` against a booted backend (so this class of bug is caught before merge, not by hand).
- omattsson/stackctl#97 — Swagger-contract assertions in unit tests, so stub decodes catch type drift instead of masking it.

## Test plan

- [x] `go test ./...` (unit + integration)
- [x] `go test -tags live -count=1 ./test/live/...` against rancher-desktop with API key
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk operations now return per-item status strings plus aggregate counters (total/successful/failed); CLI shows item IDs and colored status in table and quiet modes.
  * Chart configuration expanded with richer metadata (chart path/version, release name, deploy order, required/locked flags, build pipeline).

* **Tests**
  * Updated unit/e2e tests for new bulk wire contracts and added extensive live integration tests for audit logs, clusters, definitions, templates, favorites, notifications, and bulk workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->