### PR TITLE
ci(live): run cli/test/live/ on every PR against a freshly-booted backend

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -98,7 +98,8 @@ jobs:
           admin_id=$(echo "$login" | jq -r '.user.id')
           if [ -z "$jwt" ] || [ "$jwt" = "null" ] || [ -z "$admin_id" ] || [ "$admin_id" = "null" ]; then
             echo "Login response missing token/user.id" >&2
-            echo "$login" | jq . >&2
+            # Drop the JWT before logging so a failed boot can't leak it.
+            echo "$login" | jq 'del(.token, .access_token)' >&2
             exit 1
           fi
           # Mint a key — the raw key is only returned once.
@@ -111,7 +112,9 @@ jobs:
           key=$(echo "$mint" | jq -r '.raw_key')
           if [ -z "$key" ] || [ "$key" = "null" ]; then
             echo "API-key mint response missing .raw_key" >&2
-            echo "$mint" | jq . >&2
+            # Drop the raw key before logging — it's only valid once but
+            # still a credential while the job is alive.
+            echo "$mint" | jq 'del(.raw_key)' >&2
             exit 1
           fi
           # Mask in logs and export for the test step.

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -1,0 +1,122 @@
+name: Live tests
+
+# Boots k8s-stack-manager (origin/main, api-only profile) in the same job,
+# applies a SQL fixture, mints an API key, then runs cli/test/live against
+# the booted backend. Catches wire-contract drift between the two repos at
+# PR time — the stub-based unit tests can't see it.
+#
+# Tracks omattsson/stackctl#96.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live:
+    name: Live integration suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: ci-admin-password-do-not-reuse
+      DB_PASSWORD: rootpassword
+      DB_NAME: app
+      MYSQL_CONTAINER: app-mysql-dev
+      BACKEND_URL: http://localhost:8081
+    steps:
+      - name: Check out stackctl
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Clone k8s-stack-manager (origin/main)
+        run: |
+          git clone --depth=1 https://github.com/omattsson/k8s-stack-manager /tmp/k8s-sm
+          echo "k8s-sm @ $(git -C /tmp/k8s-sm rev-parse --short HEAD)"
+
+      - name: Boot api-only stack (backend + mysql)
+        working-directory: /tmp/k8s-sm
+        env:
+          ADMIN_USERNAME: ${{ env.ADMIN_USERNAME }}
+          ADMIN_PASSWORD: ${{ env.ADMIN_PASSWORD }}
+          DB_PASSWORD: ${{ env.DB_PASSWORD }}
+        run: |
+          # No --profile flag → only services without profiles run, which is
+          # exactly the api-only set (backend + mysql). Frontend is gated to
+          # the "full" profile.
+          docker compose up -d --wait backend
+
+      - name: Wait for backend /health/live
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS "$BACKEND_URL/health/live" >/dev/null 2>&1; then
+              echo "Backend healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Backend never became healthy" >&2
+          docker compose -f /tmp/k8s-sm/docker-compose.yml logs backend
+          exit 1
+
+      - name: Apply CI seed fixtures
+        run: |
+          docker exec -i "$MYSQL_CONTAINER" \
+            mysql -u root -p"$DB_PASSWORD" "$DB_NAME" \
+            < cli/test/live/testdata/ci-seed.sql
+
+      - name: Mint API key for live tests
+        id: apikey
+        run: |
+          set -euo pipefail
+          # Login as the env-seeded admin → JWT + admin user id.
+          login=$(curl -fsS -X POST "$BACKEND_URL/api/v1/auth/login" \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"$ADMIN_USERNAME\",\"password\":\"$ADMIN_PASSWORD\"}")
+          jwt=$(echo "$login" | jq -r '.token // .access_token')
+          admin_id=$(echo "$login" | jq -r '.user.id')
+          if [ -z "$jwt" ] || [ "$jwt" = "null" ] || [ -z "$admin_id" ] || [ "$admin_id" = "null" ]; then
+            echo "Login response missing token/user.id" >&2
+            echo "$login" | jq . >&2
+            exit 1
+          fi
+          # Mint a key — the raw key is only returned once.
+          # Backend requires an expiration; 1 day is plenty for a CI run.
+          # Response field is "raw_key" (prefixed sk_<hex>), not "key".
+          mint=$(curl -fsS -X POST "$BACKEND_URL/api/v1/users/$admin_id/api-keys" \
+            -H "Authorization: Bearer $jwt" \
+            -H 'Content-Type: application/json' \
+            -d '{"name":"ci-live-tests","expires_in_days":1}')
+          key=$(echo "$mint" | jq -r '.raw_key')
+          if [ -z "$key" ] || [ "$key" = "null" ]; then
+            echo "API-key mint response missing .raw_key" >&2
+            echo "$mint" | jq . >&2
+            exit 1
+          fi
+          # Mask in logs and export for the test step.
+          echo "::add-mask::$key"
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Run live suite
+        env:
+          STACKCTL_LIVE_URL: ${{ env.BACKEND_URL }}
+          STACKCTL_LIVE_API_KEY: ${{ steps.apikey.outputs.key }}
+        working-directory: cli
+        run: go test -tags live -count=1 -timeout 10m -v ./test/live/...
+
+      - name: Backend logs on failure
+        if: failure()
+        run: docker compose -f /tmp/k8s-sm/docker-compose.yml logs backend

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -48,7 +48,6 @@ jobs:
           echo "k8s-sm @ $(git -C /tmp/k8s-sm rev-parse --short HEAD)"
 
       - name: Boot api-only stack (backend + mysql)
-        working-directory: /tmp/k8s-sm
         env:
           ADMIN_USERNAME: ${{ env.ADMIN_USERNAME }}
           ADMIN_PASSWORD: ${{ env.ADMIN_PASSWORD }}
@@ -57,7 +56,13 @@ jobs:
           # No --profile flag → only services without profiles run, which is
           # exactly the api-only set (backend + mysql). Frontend is gated to
           # the "full" profile.
-          docker compose up -d --wait backend
+          #
+          # The override file resets the dev bind-mount that would otherwise
+          # hide the production image's baked-in ./main binary.
+          docker compose \
+            -f /tmp/k8s-sm/docker-compose.yml \
+            -f "$GITHUB_WORKSPACE/cli/test/live/testdata/docker-compose.ci.yml" \
+            up -d --wait backend
 
       - name: Wait for backend /health/live
         run: |
@@ -69,7 +74,10 @@ jobs:
             sleep 1
           done
           echo "Backend never became healthy" >&2
-          docker compose -f /tmp/k8s-sm/docker-compose.yml logs backend
+          docker compose \
+            -f /tmp/k8s-sm/docker-compose.yml \
+            -f "$GITHUB_WORKSPACE/cli/test/live/testdata/docker-compose.ci.yml" \
+            logs backend
           exit 1
 
       - name: Apply CI seed fixtures
@@ -119,4 +127,8 @@ jobs:
 
       - name: Backend logs on failure
         if: failure()
-        run: docker compose -f /tmp/k8s-sm/docker-compose.yml logs backend
+        run: |
+          docker compose \
+            -f /tmp/k8s-sm/docker-compose.yml \
+            -f "$GITHUB_WORKSPACE/cli/test/live/testdata/docker-compose.ci.yml" \
+            logs backend

--- a/cli/test/live/cluster_live_test.go
+++ b/cli/test/live/cluster_live_test.go
@@ -69,7 +69,17 @@ func TestLiveCluster_HealthAndTest(t *testing.T) {
 
 	t.Run("health", func(t *testing.T) {
 		health, err := c.GetClusterHealth(cluster.ID)
-		require.NoError(t, err, "get cluster health")
+		if err != nil {
+			// Same skip rule as the "nodes" subtest below: when the
+			// backend can't talk to the cluster, the health summary
+			// 500s. That's not a wire-shape regression, just an
+			// environment with no kubeconfig (e.g. the CI api-only
+			// stack against a stub cluster).
+			if isClusterUnreachable(err) {
+				t.Skipf("health endpoint unavailable (cluster not reachable): %v", err)
+			}
+			require.NoError(t, err, "get cluster health")
+		}
 		// Health summary should at least populate node count for any
 		// non-empty cluster. Zero would mean the wire decode lost data.
 		assert.GreaterOrEqual(t, health.NodeCount, 0, "node_count must decode (zero is fine for empty clusters)")
@@ -91,8 +101,7 @@ func TestLiveCluster_HealthAndTest(t *testing.T) {
 		if err != nil {
 			// Skip only when the backend can't reach the cluster — any
 			// other error (bad wire shape, 5xx) should fail the test.
-			msg := strings.ToLower(err.Error())
-			if strings.Contains(msg, "not reachable") || strings.Contains(msg, "unavailable") || strings.Contains(msg, "connection refused") {
+			if isClusterUnreachable(err) {
 				t.Skipf("nodes endpoint unavailable (cluster not reachable): %v", err)
 			}
 			require.NoError(t, err, "get cluster nodes")
@@ -100,4 +109,24 @@ func TestLiveCluster_HealthAndTest(t *testing.T) {
 		// Just verify we get a decodable slice back. Empty is fine.
 		assert.NotNil(t, nodes)
 	})
+}
+
+// isClusterUnreachable returns true when the backend's error indicates
+// the cluster itself isn't reachable (no kubeconfig, kube-apiserver
+// down, DNS failure) rather than a wire-shape or auth issue. Used by
+// the diagnostic-endpoint tests to skip cleanly in CI environments
+// running against a stub cluster.
+func isClusterUnreachable(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, needle := range []string{
+		"not reachable",
+		"unavailable",
+		"connection refused",
+		"failed to connect to cluster", // backend's literal 500 message
+	} {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/test/live/cluster_live_test.go
+++ b/cli/test/live/cluster_live_test.go
@@ -119,8 +119,11 @@ func TestLiveCluster_HealthAndTest(t *testing.T) {
 func isClusterUnreachable(err error) bool {
 	msg := strings.ToLower(err.Error())
 	for _, needle := range []string{
+		// Backend uses ClusterUnreachable = "unreachable" as its
+		// status constant; keep both spacings since the error string
+		// can render either way.
+		"unreachable",
 		"not reachable",
-		"unavailable",
 		"connection refused",
 		"failed to connect to cluster", // backend's literal 500 message
 	} {

--- a/cli/test/live/doc.go
+++ b/cli/test/live/doc.go
@@ -1,7 +1,52 @@
-// Package live contains integration tests that run against a live backend.
-// These tests are gated behind the "live" build tag and require environment
-// variables STACKCTL_LIVE_USER and STACKCTL_LIVE_PASS. STACKCTL_LIVE_URL is
-// optional; if unset, the tests default to http://localhost:8081.
+// Package live contains integration tests that run against a live
+// k8s-stack-manager backend. They are gated behind the "live" build tag
+// because they make real HTTP calls and shape-check the response wire
+// contract — the only way to catch field-name drift between stackctl and
+// the backend that stub-based unit tests can't see.
 //
-// Run with: go test -tags live ./test/live/ -v
+// # Environment
+//
+//   - STACKCTL_LIVE_URL — backend base URL (default: http://localhost:8081).
+//   - One of:
+//       STACKCTL_LIVE_API_KEY                    — header-based, no session.
+//       STACKCTL_LIVE_USER + STACKCTL_LIVE_PASS — login flow.
+//   - STACKCTL_LIVE_HEAVY=1 — also run the workload tests in live_test.go
+//     that actually deploy stack instances (~80 GiB of golden-db pull
+//     each, takes ~10 min). Off by default — the per-endpoint *_live_test.go
+//     files cover wire-shape contracts without real workloads.
+//
+// # Running locally
+//
+//	go test -tags live ./test/live/ -v
+//
+// # Reproducing the CI flow
+//
+// .github/workflows/live-tests.yml boots k8s-stack-manager (origin/main,
+// api-only profile) in the same job and runs this suite. To reproduce
+// locally, run the equivalent of those steps against your own checkout:
+//
+//	# 1. Boot the api-only stack (backend + mysql; no frontend).
+//	cd /path/to/k8s-stack-manager
+//	ADMIN_USERNAME=admin ADMIN_PASSWORD=ci-admin-password-do-not-reuse \
+//	    docker compose up -d --wait backend
+//
+//	# 2. Apply the seed fixtures (one cluster, one definition, one
+//	#    published template — so require* helpers don't skip).
+//	docker exec -i app-mysql-dev mysql -u root -prootpassword app \
+//	    < /path/to/stackctl/cli/test/live/testdata/ci-seed.sql
+//
+//	# 3. Mint an API key (login → mint), then run the suite.
+//	jwt=$(curl -fsS -X POST http://localhost:8081/api/v1/auth/login \
+//	    -H 'Content-Type: application/json' \
+//	    -d '{"username":"admin","password":"ci-admin-password-do-not-reuse"}' \
+//	    | jq -r '.token // .access_token')
+//	admin_id=$(curl -fsS http://localhost:8081/api/v1/auth/me \
+//	    -H "Authorization: Bearer $jwt" | jq -r '.id')
+//	key=$(curl -fsS -X POST "http://localhost:8081/api/v1/users/$admin_id/api-keys" \
+//	    -H "Authorization: Bearer $jwt" -H 'Content-Type: application/json' \
+//	    -d '{"name":"local-live-tests","expires_in_days":1}' | jq -r '.raw_key')
+//
+//	STACKCTL_LIVE_URL=http://localhost:8081 \
+//	STACKCTL_LIVE_API_KEY="$key" \
+//	    go test -tags live -count=1 ./test/live/...
 package live

--- a/cli/test/live/testdata/ci-seed.sql
+++ b/cli/test/live/testdata/ci-seed.sql
@@ -1,0 +1,90 @@
+-- CI fixture seed for the live integration suite.
+--
+-- The live tests gate themselves behind require{Cluster,Definition,Template}
+-- helpers that skip when the backend has nothing to look at. A fresh CI
+-- backend would skip ~70% of the suite — defeating the point of running it.
+--
+-- This script inserts the minimum metadata needed so every test reaches its
+-- assertions:
+--   - 1 cluster (no real connectivity)
+--   - 1 stack_definition + 1 chart_config
+--   - 1 stack_template + 1 template_chart_config
+--
+-- Owner is the env-seeded admin user (created by the backend's
+-- EnsureAdminUser at boot). We look it up at apply time so we don't need to
+-- substitute the non-deterministic UUID into the script.
+
+SET @admin_id = (SELECT id FROM users WHERE username = 'admin' LIMIT 1);
+
+-- Cluster — health_status stays "unreachable" since api-only mode has no
+-- real kubeconfig. test-connection / nodes endpoints will fail; tests
+-- handle that as expected.
+INSERT INTO clusters (
+    id, name, description,
+    api_server_url, kubeconfig_data, kubeconfig_path,
+    region, health_status,
+    registry_url, registry_username, registry_password, image_pull_secret_name,
+    max_namespaces, max_instances_per_user,
+    is_default, use_in_cluster,
+    created_at, updated_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000001', 'ci-stub', 'CI fixture cluster — no real connectivity',
+    '', '', '',
+    '', 'unreachable',
+    '', '', '', '',
+    0, 0,
+    1, 0,
+    NOW(), NOW()
+);
+
+-- Stack definition (owner = admin) with a single noop chart.
+INSERT INTO stack_definitions (
+    id, name, description, owner_id, default_branch, created_at, updated_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000002',
+    'ci-stub-definition',
+    'CI fixture definition — wire-shape only, never deployed',
+    @admin_id, 'master', NOW(), NOW()
+);
+
+INSERT INTO chart_configs (
+    id, stack_definition_id,
+    chart_name, repository_url, source_repo_url, build_pipeline_id,
+    chart_path, chart_version, default_values, deploy_order,
+    created_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000003',
+    '00000000-0000-0000-0000-000000000002',
+    'ci-noop', '', '', '',
+    '', '0.1.0', '', 0,
+    NOW()
+);
+
+-- Published stack template so requireTemplate and TestLiveTemplate_ListAndGet
+-- find at least one row. Inline chart so the chart-roundtrip tests have
+-- something to read.
+INSERT INTO stack_templates (
+    id, name, description, category, version, owner_id,
+    default_branch, is_published, created_at, updated_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000004',
+    'ci-stub-template',
+    'CI fixture template — published so list filter sees it',
+    '', '1.0.0', @admin_id,
+    'master', 1, NOW(), NOW()
+);
+
+INSERT INTO template_chart_configs (
+    id, stack_template_id,
+    chart_name, repository_url, source_repo_url, build_pipeline_id,
+    chart_path, chart_version, default_values, locked_values,
+    deploy_order, required,
+    created_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000005',
+    '00000000-0000-0000-0000-000000000004',
+    'ci-noop', '', '', '',
+    '', '0.1.0', '', '',
+    0, 0,
+    NOW()
+);

--- a/cli/test/live/testdata/docker-compose.ci.yml
+++ b/cli/test/live/testdata/docker-compose.ci.yml
@@ -1,11 +1,20 @@
 # CI override for k8s-stack-manager's docker-compose.yml.
 #
-# The upstream compose bind-mounts ./backend:/app for dev hot-reload, but
-# that overlays the production image's baked-in /app/main binary with the
-# host source tree (which has no compiled binary), so the container can't
-# start. We're not editing source at runtime in CI, so reset the volumes.
+# Two upstream defaults don't fit `target: production` + headless CI:
 #
-# `!reset []` replaces the list instead of merging (Compose ≥1.28).
+# 1. `./backend:/app` bind-mount is for dev hot-reload. With the production
+#    target it overlays the baked-in /app/main binary with the host source
+#    tree (which has no compiled binary), so the container exits with
+#    "stat ./main: no such file or directory". `!reset []` replaces the
+#    list instead of merging (Compose ≥1.28).
+#
+# 2. The healthcheck runs `curl -f http://localhost:8081/health/live`
+#    inside the container, but the alpine production image doesn't have
+#    curl installed. The check fails forever and `docker compose up
+#    --wait` times out. Disable the container-side healthcheck — we run
+#    our own poll against /health/live from the host in the next step.
 services:
   backend:
     volumes: !reset []
+    healthcheck:
+      test: ["NONE"]

--- a/cli/test/live/testdata/docker-compose.ci.yml
+++ b/cli/test/live/testdata/docker-compose.ci.yml
@@ -10,11 +10,16 @@
 #
 # 2. The healthcheck runs `curl -f http://localhost:8081/health/live`
 #    inside the container, but the alpine production image doesn't have
-#    curl installed. The check fails forever and `docker compose up
-#    --wait` times out. Disable the container-side healthcheck — we run
-#    our own poll against /health/live from the host in the next step.
+#    curl installed. Replace with busybox `wget --spider`, which alpine
+#    ships in the base image. (`test: ["NONE"]` would disable the check
+#    but then `docker compose up --wait` errors with "no healthcheck
+#    configured" instead of treating "running" as ready.)
 services:
   backend:
     volumes: !reset []
     healthcheck:
-      test: ["NONE"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8081/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 30s

--- a/cli/test/live/testdata/docker-compose.ci.yml
+++ b/cli/test/live/testdata/docker-compose.ci.yml
@@ -1,0 +1,11 @@
+# CI override for k8s-stack-manager's docker-compose.yml.
+#
+# The upstream compose bind-mounts ./backend:/app for dev hot-reload, but
+# that overlays the production image's baked-in /app/main binary with the
+# host source tree (which has no compiled binary), so the container can't
+# start. We're not editing source at runtime in CI, so reset the volumes.
+#
+# `!reset []` replaces the list instead of merging (Compose ≥1.28).
+services:
+  backend:
+    volumes: !reset []


### PR DESCRIPTION
## Summary

Closes #96.

Adds a CI job that boots `k8s-stack-manager` (origin/main, api-only docker-compose profile) in the same runner, applies a SQL fixture, mints a 1-day API key, then runs `cli/test/live/...` against it. PR-time signal that the wire contracts still match between the two repos — the class of bug stub-based unit tests can't see, and that surfaced four times in the past week alone (#95, k8s-sm#264, #98).

## Design decisions

Three open questions in #96 were resolved before writing the workflow:

| Question | Decision | Rationale |
| --- | --- | --- |
| Bootstrap mechanism | Backend SQL seed + login-then-mint via API | Hardcoded bcrypt / SHA-256 hashes in fixtures rot when hashing schemes change; using the public auth endpoints survives migrations. SQL fixtures cover the require* skip-gates that a fresh DB would otherwise trip. |
| k8s-sm pinning | Track `origin/main` | Surfacing cross-repo contract breaks is the whole point of this workflow. Pin later if it becomes too noisy. |
| Workflow location | New `.github/workflows/live-tests.yml` | Separable from the unit/integration job — easy to mark non-required if it ever gets flaky without blocking the rest of CI. |

## Validation

Bootstrap flow validated against the rancher-desktop k8s-sm before pushing:

- `SHOW COLUMNS` confirms the SQL fixture matches the GORM-migrated schema for `clusters`, `stack_definitions`, `chart_configs`, `stack_templates`, `template_chart_configs`, `users`.
- Seed runs cleanly inside a transaction with no schema errors.
- `/api/v1/auth/me` returns `{id, username, role}` as expected.
- `POST /api/v1/users/<id>/api-keys` returns `.raw_key` (validated key minted + revoked).

Two contract-drift gotchas surfaced during that validation (precisely the kind of bug this workflow will surface on PRs):

- `POST /api/v1/users/<id>/api-keys` requires `expires_at` OR `expires_in_days`. Initial draft sent neither → 400.
- Minted-key field is `raw_key`, not `key`.

Both fixed in the workflow + `cli/test/live/doc.go` before pushing.

## Depends on

#98 (live suite expansion + bulk wire-contract fix). The live tests this job runs were introduced there — needs to merge first.

## Test plan

- [ ] CI green on this PR (`live` job passes)
- [ ] Manually verify a follow-up PR that introduces a deliberate field-name drift fails this job with a clear error
- [ ] Reproducing the CI flow locally via the steps in `cli/test/live/doc.go` produces the same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated live integration test workflow that runs on pushes to main and on pull requests; it boots the backend and database, seeds test data, mints a short‑lived API key, and executes the live test suite.

* **Documentation**
  * Expanded live-test docs with setup steps, required environment variables, authentication examples, and CI reproduction instructions.

* **Bug Fixes**
  * Live tests now gracefully skip cluster health diagnostics when the backend indicates the cluster is unreachable, reducing false failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/stackctl/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->