### PR TITLE
test(contract): refresh vendored swagger from k8s-stack-manager v0.3.1

### DIFF
--- a/cli/test/contract/testdata/swagger.json
+++ b/cli/test/contract/testdata/swagger.json
@@ -3559,7 +3559,8 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int64"
                             }
                         }
                     },
@@ -6530,7 +6531,7 @@
                 }
             },
             "post": {
-                "description": "Create a new stack template (devops/admin only)",
+                "description": "Create a new stack template (devops/admin only). May include a `charts` array to register the initial chart set in the same transaction.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6543,12 +6544,12 @@
                 "summary": "Create a stack template",
                 "parameters": [
                     {
-                        "description": "Template object",
+                        "description": "Template object (may include charts[])",
                         "name": "template",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.StackTemplate"
+                            "$ref": "#/definitions/handlers.createTemplateRequest"
                         }
                     }
                 ],
@@ -6556,7 +6557,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/models.StackTemplate"
+                            "$ref": "#/definitions/handlers.TemplateDetailResponse"
                         }
                     },
                     "400": {
@@ -8178,7 +8179,7 @@
         },
         "/ws": {
             "get": {
-                "description": "Upgrades the HTTP connection to a WebSocket for real-time events. Requires a valid JWT token via ?token= query parameter or Authorization: Bearer header.",
+                "description": "Upgrades the HTTP connection to a WebSocket for real-time events. Authenticate via one of: `Sec-WebSocket-Protocol: bearer, \u003cjwt\u003e` subprotocol header, `Authorization: Bearer \u003cjwt\u003e` header, or `?token=\u003cjwt\u003e` query parameter (the query token is redacted from access logs and traces by middleware before the handler runs).",
                 "tags": [
                     "websocket"
                 ],
@@ -8186,7 +8187,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "JWT authentication token",
+                        "description": "JWT authentication token (also accepted via Authorization header or Sec-WebSocket-Protocol subprotocol)",
                         "name": "token",
                         "in": "query"
                     }
@@ -9179,6 +9180,38 @@
                     "type": "string"
                 },
                 "webhook_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.createTemplateRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "charts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.TemplateChartConfig"
+                    }
+                },
+                "default_branch": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "is_published": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
Pins the contract tests to the [v0.3.1](https://github.com/omattsson/k8s-stack-manager/releases/tag/v0.3.1) schema before tagging stackctl v0.3.0. Diff is the new endpoints landed in v0.3.1: WebSocket subprotocol auth (#262), OIDC loopback (#249), inline-charts envelope on POST /templates (#264).

Local: `go test ./cli/test/contract/...` passes.